### PR TITLE
Prevent committing offset when group coordinator is unavailable

### DIFF
--- a/aiokafka/group_coordinator.py
+++ b/aiokafka/group_coordinator.py
@@ -212,7 +212,8 @@ class GroupCoordinator(object):
         self._subscription.mark_for_reassignment()
 
         # commit offsets prior to rebalance if auto-commit enabled
-        yield from self._maybe_auto_commit_offsets_sync()
+        if not (yield from self.coordinator_unknown()):
+            yield from self._maybe_auto_commit_offsets_sync()
 
         # execute the user's callback before rebalance
         log.debug("Revoking previously assigned partitions %s",


### PR DESCRIPTION
Prevent committing offset when coordinator is not available

Fix #44 by not attempting to commit offsets when
we are not joined to a group.

This avoids looping forever and permits the group to be
joined again normally once it is available.