### PR TITLE
Added waiting for all connection sockets to be properly closed.

### DIFF
--- a/aiokafka/client.py
+++ b/aiokafka/client.py
@@ -94,13 +94,11 @@ class AIOKafkaClient:
             except asyncio.CancelledError:
                 pass
             self._sync_task = None
-        futs = []
         # Be careful to wait for graceful closure of all connections, so we
         # process all pending buffers.
+        futs = []
         for conn in self._conns.values():
-            fut = conn.close()
-            if fut is not None:
-                futs.append(fut)
+            futs.append(conn.close())
         if futs:
             yield from asyncio.gather(*futs, loop=self._loop)
 


### PR DESCRIPTION
I've separated this part from SSL PR, as it's somehow harder, than I wanted it to be. The issue is, that to properly close SSL we must flush AND read all pending data for both ends. ``writer.close()`` will flush all data, but not read it from the other end. Proper closing would be after ``connection_lost`` is called, but StreamReaderProtocol did not a proper future for that, so I had to subclass it.