### PR TITLE
wait subscribed topic(s) creation in consumer on start

### DIFF
--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -547,6 +547,9 @@ class TestConsumerIntegration(KafkaIntegrationTestCase):
         consumer = AIOKafkaConsumer(
             topic, loop=self.loop, bootstrap_servers=self.hosts)
         yield from consumer.start()
+        consume_task = self.loop.create_task(consumer.getone())
+        # just to be sure getone does not fail (before produce)
+        yield from asyncio.sleep(0.5, loop=self.loop)
 
         producer = AIOKafkaProducer(
             loop=self.loop, bootstrap_servers=self.hosts)
@@ -554,6 +557,6 @@ class TestConsumerIntegration(KafkaIntegrationTestCase):
         yield from producer.send(topic, b'test msg')
         yield from producer.stop()
 
-        data = yield from consumer.getone()
+        data = yield from consume_task
         self.assertEqual(data.value, b'test msg')
         yield from consumer.stop()


### PR DESCRIPTION
If topic does not exists in Kafka, consumer is crashes on start.

> $ python examples/simple_consumer.py 
Traceback (most recent call last):
  File "examples/simple_consumer.py", line 17, in <module>
    loop.run_until_complete(consume())
  File "/usr/lib64/python3.5/asyncio/base_events.py", line 387, in run_until_complete
    return future.result()
  File "/usr/lib64/python3.5/asyncio/futures.py", line 274, in result
    raise self._exception
  File "/usr/lib64/python3.5/asyncio/tasks.py", line 239, in _step
    result = coro.send(None)
  File "examples/simple_consumer.py", line 10, in consume
    await consumer.start()
  File "/home/kst/.virtualenvs/aiokafka/lib/python3.5/site-packages/aiokafka/consumer.py", line 210, in start
    raise UnknownTopicOrPartitionError()

_wait_on_metadata() coroutine is moved to client and used both producer and consumer.