### PR TITLE
Stop iterator and pending fetch calls on `consumer.stop()`

### DIFF
--- a/aiokafka/__init__.py
+++ b/aiokafka/__init__.py
@@ -1,16 +1,23 @@
+import sys
+
+from .errors import ConsumerStoppedError
 
 try:
     from asyncio import ensure_future
 except ImportError:
     from asyncio import async as ensure_future
-import sys  # noqa
-PY_35 = sys.version_info >= (3, 5)
 
 __version__ = '0.2.1.dev'
+PY_35 = sys.version_info >= (3, 5)
 
 from .client import AIOKafkaClient  # noqa
 from .producer import AIOKafkaProducer  # noqa
 from .consumer import AIOKafkaConsumer  # noqa
 
+__all__ = [
+    "AIOKafkaProducer",
+    "AIOKafkaConsumer",
+    "ConsumerStoppedError",
+]
 
-(AIOKafkaClient, AIOKafkaProducer, AIOKafkaConsumer, ensure_future)
+(AIOKafkaClient, ensure_future)

--- a/aiokafka/conn.py
+++ b/aiokafka/conn.py
@@ -38,7 +38,6 @@ class AIOKafkaProtocol(asyncio.StreamReaderProtocol):
 
     def connection_lost(self, exc):
         super().connection_lost(exc)
-        print("Connection lost", self, exc)
         if not self._closed_fut.cancelled():
             self._closed_fut.set_result(None)
 

--- a/aiokafka/conn.py
+++ b/aiokafka/conn.py
@@ -38,6 +38,7 @@ class AIOKafkaProtocol(asyncio.StreamReaderProtocol):
 
     def connection_lost(self, exc):
         super().connection_lost(exc)
+        print("Connection lost", self, exc)
         if not self._closed_fut.cancelled():
             self._closed_fut.set_result(None)
 

--- a/aiokafka/consumer.py
+++ b/aiokafka/consumer.py
@@ -701,6 +701,8 @@ class AIOKafkaConsumer(object):
             while True:
                 try:
                     return (yield from self.getone())
+                except ConsumerStoppedError:
+                    raise StopAsyncIteration
                 except (TopicAuthorizationFailedError,
                         OffsetOutOfRangeError) as err:
                     raise err

--- a/aiokafka/consumer.py
+++ b/aiokafka/consumer.py
@@ -11,6 +11,7 @@ from kafka.consumer.subscription_state import SubscriptionState
 
 from aiokafka.client import AIOKafkaClient
 from aiokafka.group_coordinator import GroupCoordinator
+from aiokafka.errors import ConsumerStoppedError
 from aiokafka.fetcher import Fetcher
 from aiokafka import __version__, ensure_future, PY_35
 
@@ -627,6 +628,8 @@ class AIOKafkaConsumer(object):
 
         """
         assert all(map(lambda k: isinstance(k, TopicPartition), partitions))
+        if self._closed:
+            raise ConsumerStoppedError()
 
         msg = yield from self._fetcher.next_record(partitions)
         return msg
@@ -666,6 +669,9 @@ class AIOKafkaConsumer(object):
 
         """
         assert all(map(lambda k: isinstance(k, TopicPartition), partitions))
+        if self._closed:
+            raise ConsumerStoppedError()
+
         if max_records is not None and (
                 not isinstance(max_records, int) or max_records < 1):
             raise ValueError("`max_records` must be a positive Integer")
@@ -679,6 +685,8 @@ class AIOKafkaConsumer(object):
     if PY_35:
         @asyncio.coroutine
         def __aiter__(self):
+            if self._closed:
+                raise ConsumerStoppedError()
             return self
 
         @asyncio.coroutine

--- a/aiokafka/consumer.py
+++ b/aiokafka/consumer.py
@@ -702,7 +702,7 @@ class AIOKafkaConsumer(object):
                 try:
                     return (yield from self.getone())
                 except ConsumerStoppedError:
-                    raise StopAsyncIteration
+                    raise StopAsyncIteration  # noqa: F821
                 except (TopicAuthorizationFailedError,
                         OffsetOutOfRangeError) as err:
                     raise err

--- a/aiokafka/errors.py
+++ b/aiokafka/errors.py
@@ -1,0 +1,5 @@
+
+class ConsumerStoppedError(Exception):
+    """ Raised on `get*` methods of Consumer if it's cancelled, even pending
+        ones.
+    """

--- a/tests/_testutil.py
+++ b/tests/_testutil.py
@@ -3,7 +3,6 @@ import string
 import random
 import time
 import unittest
-import uuid
 import pytest
 
 from functools import wraps
@@ -136,18 +135,6 @@ class KafkaIntegrationTestCase(unittest.TestCase):
 
         # Make sure there are no duplicates
         self.assertEquals(len(set(messages)), num_messages)
-
-    def msgs(self, iterable):
-        return [self.msg(x) for x in iterable]
-
-    def msg(self, s):
-        if s not in self._messages:
-            self._messages[s] = '%s-%s-%s' % (s, self.id(), str(uuid.uuid4()))
-
-        return self._messages[s].encode('utf-8')
-
-    def key(self, k):
-        return k.encode('utf-8')
 
     def create_ssl_context(self):
         return create_ssl_context(

--- a/tests/test_conn.py
+++ b/tests/test_conn.py
@@ -84,10 +84,6 @@ class ConnIntegrationTest(KafkaIntegrationTestCase):
         with self.assertRaises(ConnectionError):
             yield from conn.send(request)
 
-        @asyncio.coroutine
-        def invoke_osserror(*a, **kw):
-            yield from asyncio.sleep(0.1, loop=self.loop)
-            raise OSError('mocked writer is closed')
         conn._writer = mock.MagicMock()
         conn._writer.write.side_effect = OSError('mocked writer is closed')
 

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -231,10 +231,6 @@ class TestConsumerIntegration(KafkaIntegrationTestCase):
             if len(result) == len(available_msgs):
                 break
 
-        yield from consumer2.stop()
-        if consumer1._client.api_version < (0, 9):
-            # coordinator rebalance feature works with >=Kafka-0.9 only
-            return
         self.assertEqual(set(available_msgs), set(result))
         yield from consumer1.stop()
         yield from consumer2.stop()
@@ -541,6 +537,7 @@ class TestConsumerIntegration(KafkaIntegrationTestCase):
                 bootstrap_servers=self.hosts,
                 security_protocol="SSL", ssl_context=None)
 
+    @run_until_complete
     def test_consumer_group_without_subscription(self):
         consumer = AIOKafkaConsumer(
             loop=self.loop,
@@ -657,6 +654,7 @@ class TestConsumerIntegration(KafkaIntegrationTestCase):
         yield from consumer1.stop()
         yield from consumer2.stop()
 
+    @run_until_complete
     def test_consumer_stops_getone(self):
         # If we have a fetch in progress it should be cancelled if consumer is
         # stoped

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -199,14 +199,14 @@ class TestKafkaCoordinatorIntegration(KafkaIntegrationTestCase):
         mocked.send.side_effect = Errors.UnknownMemberIdError()
         with self.assertRaises(Errors.UnknownMemberIdError):
             yield from do_sync_group()
-            self.assertEqual(
-                coordinator.member_id, JoinGroupRequest.UNKNOWN_MEMBER_ID)
+        self.assertEqual(
+            coordinator.member_id, JoinGroupRequest.UNKNOWN_MEMBER_ID)
 
         mocked.send.side_effect = Errors.NotCoordinatorForGroupError()
         coordinator.coordinator_id = 'some_id'
         with self.assertRaises(Errors.NotCoordinatorForGroupError):
             yield from do_sync_group()
-            self.assertEqual(coordinator.coordinator_id, None)
+        self.assertEqual(coordinator.coordinator_id, None)
 
         mocked.send.side_effect = KafkaError()
         with self.assertRaises(KafkaError):

--- a/tests/test_pep492.py
+++ b/tests/test_pep492.py
@@ -1,3 +1,4 @@
+import asyncio
 from aiokafka.consumer import AIOKafkaConsumer
 from kafka.common import OffsetOutOfRangeError
 from ._testutil import (
@@ -73,3 +74,24 @@ class TestConsumerIteratorIntegration(KafkaIntegrationTestCase):
         with self.assertRaises(OffsetOutOfRangeError):
             async for m in consumer:
                 print(m)
+
+    @run_until_complete
+    async def test_consumer_stops_iter(self):
+        consumer = AIOKafkaConsumer(
+            self.topic, loop=self.loop,
+            bootstrap_servers=self.hosts,
+            auto_offset_reset=None)
+        await consumer.start()
+
+        async def iterator():
+            async for msg in consumer:
+                assert False, "No items should be here, got {}".format(msg)
+
+        task = self.loop.create_task(iterator())
+        await asyncio.sleep(0.1, loop=self.loop)
+        # As we didn't input any data into Kafka
+        self.assertFalse(task.done())
+
+        await consumer.stop()
+        # Should just stop iterator, no errors
+        await task

--- a/tests/test_pep492.py
+++ b/tests/test_pep492.py
@@ -74,7 +74,7 @@ class TestConsumerIteratorIntegration(KafkaIntegrationTestCase):
 
         with self.assertRaises(OffsetOutOfRangeError):
             async for m in consumer:
-                print(m)
+                print(m)  # pragma: no cover
 
     @run_until_complete
     async def test_consumer_stops_iter(self):
@@ -85,7 +85,7 @@ class TestConsumerIteratorIntegration(KafkaIntegrationTestCase):
         await consumer.start()
 
         async def iterator():
-            async for msg in consumer:
+            async for msg in consumer:  # pragma: no cover
                 assert False, "No items should be here, got {}".format(msg)
 
         task = self.loop.create_task(iterator())


### PR DESCRIPTION
fixes #80 