### PR TITLE
Added simple local diff coverage check using `diff_cover` lib.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ htmlcov/
 .tox/
 .coverage
 .cache
+diff-cover.html
 nosetests.xml
 coverage.xml
 cover

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ FLAGS=
 SCALA_VERSION?=2.11
 KAFKA_VERSION?=0.10.1.0
 DOCKER_IMAGE=aiolibs/kafka:$(SCALA_VERSION)_$(KAFKA_VERSION)
+DIFF_BRANCH=origin/master
 
 setup:
 	pip install -r requirements-dev.txt
@@ -22,6 +23,13 @@ vtest: flake
 cov cover coverage: flake
 	py.test -s --no-print-logs --cov aiokafka --cov-report html --docker-image $(DOCKER_IMAGE) $(FLAGS) tests
 	@echo "open file://`pwd`/htmlcov/index.html"
+
+coverage.xml: .coverage
+	coverage xml
+
+diff-cov: coverage.xml
+	git fetch
+	diff-cover coverage.xml --html-report diff-cover.html --compare-branch=$(DIFF_BRANCH)
 
 clean:
 	rm -rf `find . -name __pycache__`

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,3 +10,5 @@ xxhash==0.6.1
 
 sphinxcontrib-asyncio>=0.2.0
 sphinx-rtd-theme==0.1.9
+diff-cover==0.9.9
+setuptools==18.5


### PR DESCRIPTION
Example output:
```
(.aiokafka) vagrant@my-dev:/workspace/aiokafka$ make diff-cov 
coverage xml
git fetch
diff-cover coverage.xml --html-report diff-cover.html --compare-branch=origin/master
-------------
Diff Coverage
Diff: origin/master...HEAD, staged, and unstaged changes
-------------
aiokafka/client.py (100%)
aiokafka/conn.py (100%)
-------------
Total:   18 lines
Missing: 0 lines
Coverage: 100%
-------------
```