### PR TITLE
Reconnect on TimeoutError

### DIFF
--- a/aiokafka/client.py
+++ b/aiokafka/client.py
@@ -376,6 +376,8 @@ class AIOKafkaClient:
         try:
             result = yield from future
         except asyncio.TimeoutError:
+            # delete connection so it is renewed in next request
+            del self._conns[node_id]
             raise KafkaTimeoutError()
         else:
             return result

--- a/aiokafka/client.py
+++ b/aiokafka/client.py
@@ -376,8 +376,8 @@ class AIOKafkaClient:
         try:
             result = yield from future
         except asyncio.TimeoutError:
-            # delete connection so it is renewed in next request
-            del self._conns[node_id]
+            # close connection so it is renewed in next request
+            self._conns[node_id].close()
             raise KafkaTimeoutError()
         else:
             return result

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -120,40 +120,54 @@ class TestAIOKafkaClient(unittest.TestCase):
         with self.assertRaises(NodeNotReadyError):
             self.loop.run_until_complete(client.send(0, None))
 
+    @run_until_complete
     def test_send_timeout_deletes_connection(self):
+        correct_response = MetadataResponse([], [])
+
         @asyncio.coroutine
-        def send_exception(request_id):
+        def send_exception(*args, **kwargs):
             raise asyncio.TimeoutError()
 
         @asyncio.coroutine
-        def send(request_id):
-            return 'result'
+        def send(*args, **kwargs):
+            return correct_response
 
         @asyncio.coroutine
         def get_conn(self, node_id):
+            if node_id in self._conns:
+                conn = self._conns[node_id]
+                if not conn.connected():
+                    del self._conns[node_id]
+                else:
+                    return conn
+
             conn = mock.MagicMock()
-            conn.send.side_effect = send_exception
+            conn.send.side_effect = send
             self._conns[node_id] = conn
             return conn
 
         node_id = 0
         conn = mock.MagicMock()
         conn.send.side_effect = send_exception
+        conn.connected.return_value = True
         mocked_conns = {node_id: conn}
         client = AIOKafkaClient(loop=self.loop,
                                 bootstrap_servers=['broker_1:4567'])
         client._conns = mocked_conns
-        client.get_conn = types.MethodType(get_conn, client)
+        client._get_conn = types.MethodType(get_conn, client)
 
         # first send timeouts
         with self.assertRaises(KafkaTimeoutError):
             yield from client.send(0, MetadataRequest([]))
-        assert 0 not in client._conns
 
-        # second get new connection and obtain result
+        conn.close.assert_called_once_with()
+        # this happens because conn was closed
+        conn.connected.return_value = False
+
+        # second send gets new connection and obtains result
         response = yield from client.send(0, MetadataRequest([]))
-        self.assertEqual(response, 'result')
-        assert 0 in client._conns
+        self.assertEqual(response, correct_response)
+        self.assertNotEqual(conn, client._conns[node_id])
 
 
 class TestKafkaClientIntegration(KafkaIntegrationTestCase):

--- a/tests/test_conn.py
+++ b/tests/test_conn.py
@@ -204,3 +204,12 @@ class ConnIntegrationTest(KafkaIntegrationTestCase):
         with self.assertRaises(ConnectionError):
             yield from conn.send(request)
         self.assertEqual(conn.connected(), False)
+
+    @run_until_complete
+    def test_close_disconnects_connection(self):
+        asyncio.set_event_loop(self.loop)
+        host, port = self.kafka_host, self.kafka_port
+        conn = yield from create_conn(host, port)
+        self.assertTrue(conn.connected())
+        conn.close()
+        self.assertFalse(conn.connected())


### PR DESCRIPTION
This should solve https://github.com/aio-libs/aiokafka/issues/144. When there is raised exception `asyncio.TimeoutError` from `AIOKafkaConnection` in `Client.send` it will delete connection from `Client._conns`. This means that next time we do some request to this node new connection is created and therefore we get rid of stale connection. There is still raised `KafkaTimeoutError` so you can retry your request if needed. I added a simple test for this. Please advise if there is something wrong with my code.