### PR TITLE
Made commit usage easier

### DIFF
--- a/aiokafka/__init__.py
+++ b/aiokafka/__init__.py
@@ -1,6 +1,6 @@
 import sys
 
-from .errors import ConsumerStoppedError
+from .errors import ConsumerStoppedError, IllegalOperation
 
 try:
     from asyncio import ensure_future
@@ -13,11 +13,16 @@ PY_35 = sys.version_info >= (3, 5)
 from .client import AIOKafkaClient  # noqa
 from .producer import AIOKafkaProducer  # noqa
 from .consumer import AIOKafkaConsumer  # noqa
+from aiokafka.fetcher import ConsumerRecord  # noqa
 
 __all__ = [
+    # Clients API
     "AIOKafkaProducer",
     "AIOKafkaConsumer",
-    "ConsumerStoppedError",
+    # Errors
+    "ConsumerStoppedError", "IllegalOperation",
+    # Structs
+    "ConsumerRecord"
 ]
 
 (AIOKafkaClient, ensure_future)

--- a/aiokafka/errors.py
+++ b/aiokafka/errors.py
@@ -3,3 +3,9 @@ class ConsumerStoppedError(Exception):
     """ Raised on `get*` methods of Consumer if it's cancelled, even pending
         ones.
     """
+
+
+class IllegalOperation(Exception):
+    """ Raised if you try to execute an operation, that is not available with
+        current configuration
+    """

--- a/aiokafka/errors.py
+++ b/aiokafka/errors.py
@@ -7,5 +7,6 @@ class ConsumerStoppedError(Exception):
 
 class IllegalOperation(Exception):
     """ Raised if you try to execute an operation, that is not available with
-        current configuration
+        current configuration. For example trying to commit if no group_id was
+        given.
     """

--- a/docs/consumer.rst
+++ b/docs/consumer.rst
@@ -132,18 +132,19 @@ bulk. The algorithm can be enhanced by taking advantage of:
     unconsumed messages or this one is the last one in partition.
 
 If you want to have more controll over which partition and message is
-committed, you can specify offset manualy::
+committed, you can specify them manualy::
 
     while True:
         result = await consumer.getmany(timeout_ms=10 * 1000)
         for tp, messages in result.items():
             if messages:
                 await process_msg_batch(messages)
-                await consumer.commit({tp: messages[-1].offset + 1})
+                # Commit progress only for this partition
+                await consumer.commit({tp: (messages[-1], "")})
 
 .. note:: The committed offset should always be the offset of the next message
-  that your application will read. Thus, when calling ``commit(offsets)`` you 
-  should add one to the offset of the last message processed.
+  that your application will read. So in this example Consumer will actually
+  commit ``message.offset + 1``.
 
 Here we process a batch of messages per partition and commit not all consumed
 *offsets*, but only for the partition we processed.

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -6,7 +6,7 @@ from aiokafka.consumer import AIOKafkaConsumer
 from aiokafka.fetcher import RecordTooLargeError
 from aiokafka.producer import AIOKafkaProducer
 from aiokafka.client import AIOKafkaClient
-from aiokafka import ConsumerStoppedError
+from aiokafka import ConsumerStoppedError, IllegalOperation
 
 from kafka.common import (
     TopicPartition, OffsetAndMetadata, IllegalStateError,
@@ -127,7 +127,7 @@ class TestConsumerIntegration(KafkaIntegrationTestCase):
             message = yield from consumer1.getone()
             messages.append(message)
         self.assert_message_count(messages, 200)
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(IllegalOperation):
             # commit does not supported for None group
             yield from consumer1.commit()
 
@@ -613,6 +613,55 @@ class TestConsumerIntegration(KafkaIntegrationTestCase):
                 self.topic, loop=self.loop,
                 bootstrap_servers=self.hosts,
                 security_protocol="SSL", ssl_context=None)
+
+    @run_until_complete
+    def test_consumer_commit_validation(self):
+        consumer = yield from self.consumer_factory()
+
+        tp = TopicPartition(self.topic, 0)
+        offset = yield from consumer.position(tp)
+        offset_and_metadata = OffsetAndMetadata(offset, "")
+
+        with self.assertRaises(ValueError):
+            yield from consumer.commit({})
+        with self.assertRaises(ValueError):
+            yield from consumer.commit("something")
+        with self.assertRaises(ValueError):
+            yield from consumer.commit({"my_topic": offset_and_metadata})
+        with self.assertRaises(ValueError):
+            yield from consumer.commit({tp: offset})
+        with self.assertRaises(ValueError):
+            yield from consumer.commit({tp: (offset, 1000)})
+
+        consumer_no_group = yield from self.consumer_factory(group=None)
+
+        with self.assertRaises(IllegalOperation):
+            yield from consumer_no_group.commit({tp: offset_and_metadata})
+        with self.assertRaises(IllegalOperation):
+            yield from consumer_no_group.committed(tp)
+
+    @run_until_complete
+    def test_consumer_commit(self):
+        yield from self.send_messages(0, [1, 2, 3])
+
+        consumer = yield from self.consumer_factory()
+        tp = TopicPartition(self.topic, 0)
+
+        msg = yield from consumer.getone()
+        # Commit by message instance
+        yield from consumer.commit({
+            tp: (msg, "My metadata")
+        })
+        committed = yield from consumer.committed(tp)
+        self.assertEqual(committed, msg.offset + 1)
+
+        msg = yield from consumer.getone()
+        # Commit by offset
+        yield from consumer.commit({
+            tp: (msg.offset + 2, "My metadata 2")
+        })
+        committed = yield from consumer.committed(tp)
+        self.assertEqual(committed, msg.offset + 2)
 
     @run_until_complete
     def test_consumer_group_without_subscription(self):


### PR DESCRIPTION
Added ability to pass `offset` and `(offset, metadata)` as simple types instead of OffsetAndMetadata class.