### PR TITLE
Add asyncio trove classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ classifiers = [
     'Operating System :: OS Independent',
     'Topic :: System :: Networking',
     'Topic :: System :: Distributed Computing',
+    'Framework :: AsyncIO',
     'Development Status :: 4 - Beta',
 ]
 


### PR DESCRIPTION
The `Framework :: AsyncIO` [trove classifier](https://pypi.python.org/pypi?%3Aaction=list_classifiers) has recently been added to PyPI. It can help people discover asyncio related packages.