### PR TITLE
Moved all errors and structs to be accessible from aiokafka namespace…

### DIFF
--- a/aiokafka/client.py
+++ b/aiokafka/client.py
@@ -3,17 +3,18 @@ import logging
 import random
 
 from kafka.conn import collect_hosts
-from kafka.common import (KafkaError,
-                          ConnectionError,
-                          NodeNotReadyError,
-                          KafkaTimeoutError,
-                          UnknownTopicOrPartitionError,
-                          UnrecognizedBrokerVersion)
 from kafka.cluster import ClusterMetadata
 from kafka.protocol.metadata import MetadataRequest
 from kafka.protocol.produce import ProduceRequest
 
 from aiokafka.conn import create_conn
+from aiokafka.errors import (
+    KafkaError,
+    ConnectionError,
+    NodeNotReadyError,
+    KafkaTimeoutError,
+    UnknownTopicOrPartitionError,
+    UnrecognizedBrokerVersion)
 from aiokafka import ensure_future, __version__
 
 
@@ -354,7 +355,7 @@ class AIOKafkaClient:
         Raises:
             kafka.common.KafkaTimeoutError
             kafka.common.NodeNotReadyError
-            kafka.commom.ConnectionError
+            kafka.common.ConnectionError
             kafka.common.CorrelationIdError
 
         Returns:

--- a/aiokafka/conn.py
+++ b/aiokafka/conn.py
@@ -2,11 +2,11 @@ import asyncio
 import struct
 import logging
 
-import kafka.common as Errors
 from kafka.protocol.api import RequestHeader
 from kafka.protocol.commit import (
     GroupCoordinatorResponse_v0 as GroupCoordinatorResponse)
 
+import aiokafka.errors as Errors
 from aiokafka import ensure_future
 
 __all__ = ['AIOKafkaConnection', 'create_conn']

--- a/aiokafka/consumer.py
+++ b/aiokafka/consumer.py
@@ -2,13 +2,13 @@ import asyncio
 import logging
 import re
 
-from kafka.common import (OffsetAndMetadata, TopicPartition,
-                          KafkaError, UnknownTopicOrPartitionError,
-                          TopicAuthorizationFailedError, OffsetOutOfRangeError)
-
 from kafka.coordinator.assignors.roundrobin import RoundRobinPartitionAssignor
 from kafka.consumer.subscription_state import SubscriptionState
 
+from aiokafka.structs import TopicPartition, OffsetAndMetadata
+from aiokafka.errors import (
+    KafkaError, UnknownTopicOrPartitionError,
+    TopicAuthorizationFailedError, OffsetOutOfRangeError)
 from aiokafka.client import AIOKafkaClient
 from aiokafka.group_coordinator import GroupCoordinator, NoGroupCoordinator
 from aiokafka.errors import ConsumerStoppedError, IllegalOperation

--- a/aiokafka/errors.py
+++ b/aiokafka/errors.py
@@ -1,3 +1,23 @@
+from kafka.errors import *  # noqa
+from kafka.errors import KafkaError
+
+__all__ = [
+    # kafka-python errors
+    "KafkaError", "ConnectionError", "NodeNotReadyError",
+    "KafkaTimeoutError", "UnknownTopicOrPartitionError",
+    "UnrecognizedBrokerVersion", "NotLeaderForPartitionError",
+    "LeaderNotAvailableError", "TopicAuthorizationFailedError",
+    "OffsetOutOfRangeError", "MessageSizeTooLargeError", "for_code", "NoError",
+    "StaleMetadata", "CorrelationIdError", "NoBrokersAvailable",
+    "RebalanceInProgressError", "IllegalGenerationError",
+    "UnknownMemberIdError", "GroupLoadInProgressError",
+    "GroupCoordinatorNotAvailableError", "NotCoordinatorForGroupError",
+    "GroupAuthorizationFailedError",
+    # aiokafka custom errors
+    "ConsumerStoppedError", "NoOffsetForPartitionError", "RecordTooLargeError",
+    "ProducerClosed"
+]
+
 
 class ConsumerStoppedError(Exception):
     """ Raised on `get*` methods of Consumer if it's cancelled, even pending
@@ -10,3 +30,15 @@ class IllegalOperation(Exception):
         current configuration. For example trying to commit if no group_id was
         given.
     """
+
+
+class NoOffsetForPartitionError(KafkaError):
+    pass
+
+
+class RecordTooLargeError(KafkaError):
+    pass
+
+
+class ProducerClosed(KafkaError):
+    pass

--- a/aiokafka/fetcher.py
+++ b/aiokafka/fetcher.py
@@ -12,23 +12,11 @@ from kafka.protocol.offset import (
     OffsetRequest_v0 as OffsetRequest, OffsetResetStrategy)
 
 from aiokafka import ensure_future
-from aiokafka.errors import ConsumerStoppedError
+from aiokafka.errors import (
+    ConsumerStoppedError, RecordTooLargeError)
+from aiokafka.structs import ConsumerRecord
 
 log = logging.getLogger(__name__)
-
-
-ConsumerRecord = collections.namedtuple(
-    "ConsumerRecord", ["topic", "partition", "offset", "timestamp",
-                       "timestamp_type", "key", "value", "checksum",
-                       "serialized_key_size", "serialized_value_size"])
-
-
-class NoOffsetForPartitionError(Errors.KafkaError):
-    pass
-
-
-class RecordTooLargeError(Errors.KafkaError):
-    pass
 
 
 class FetchResult:

--- a/aiokafka/group_coordinator.py
+++ b/aiokafka/group_coordinator.py
@@ -3,10 +3,8 @@ import collections
 import logging
 from copy import copy
 
-import kafka.common as Errors
 from kafka.coordinator.assignors.roundrobin import RoundRobinPartitionAssignor
 from kafka.coordinator.protocol import ConsumerProtocol
-from kafka.common import OffsetAndMetadata, TopicPartition
 from kafka.protocol.commit import (
     GroupCoordinatorRequest_v0 as GroupCoordinatorRequest,
     OffsetCommitRequest_v2 as OffsetCommitRequest,
@@ -17,7 +15,9 @@ from kafka.protocol.group import (
     LeaveGroupRequest_v0 as LeaveGroupRequest,
     SyncGroupRequest_v0 as SyncGroupRequest)
 
+import aiokafka.errors as Errors
 from aiokafka import ensure_future
+from aiokafka.structs import OffsetAndMetadata, TopicPartition
 
 log = logging.getLogger(__name__)
 

--- a/aiokafka/message_accumulator.py
+++ b/aiokafka/message_accumulator.py
@@ -2,23 +2,18 @@ import io
 import asyncio
 import collections
 
-from kafka.common import (KafkaError,
-                          KafkaTimeoutError,
-                          NotLeaderForPartitionError,
-                          LeaderNotAvailableError)
 from kafka.protocol.message import Message, MessageSet
 from kafka.protocol.types import Int32, Int64
 from kafka.codec import (has_gzip, has_snappy, has_lz4,
                          gzip_encode, snappy_encode,
                          lz4_encode, lz4_encode_old_kafka)
 
+from aiokafka.errors import (KafkaTimeoutError,
+                             NotLeaderForPartitionError,
+                             LeaderNotAvailableError,
+                             ProducerClosed)
 
-RecordMetadata = collections.namedtuple(
-    'RecordMetadata', ['topic', 'partition', 'topic_partition', 'offset'])
-
-
-class ProducerClosed(KafkaError):
-    pass
+from aiokafka.structs import RecordMetadata
 
 
 class MessageBatch:

--- a/aiokafka/producer.py
+++ b/aiokafka/producer.py
@@ -2,17 +2,16 @@ import asyncio
 import logging
 import collections
 
-from kafka.common import (TopicPartition,
-                          MessageSizeTooLargeError,
-                          KafkaError)
 from kafka.partitioner.default import DefaultPartitioner
 from kafka.protocol.message import Message, MessageSet
 from kafka.protocol.produce import ProduceRequest
-import kafka.common as Errors
 
+import aiokafka.errors as Errors
 from aiokafka import ensure_future
 from aiokafka.client import AIOKafkaClient
+from aiokafka.errors import MessageSizeTooLargeError, KafkaError
 from aiokafka.message_accumulator import MessageAccumulator
+from aiokafka.structs import TopicPartition
 
 log = logging.getLogger(__name__)
 

--- a/aiokafka/structs.py
+++ b/aiokafka/structs.py
@@ -1,0 +1,14 @@
+import collections
+from kafka.common import OffsetAndMetadata, TopicPartition
+
+__all__ = [
+    "OffsetAndMetadata", "TopicPartition", "RecordMetadata", "ConsumerRecord"
+]
+
+RecordMetadata = collections.namedtuple(
+    'RecordMetadata', ['topic', 'partition', 'topic_partition', 'offset'])
+
+ConsumerRecord = collections.namedtuple(
+    "ConsumerRecord", ["topic", "partition", "offset", "timestamp",
+                       "timestamp_type", "key", "value", "checksum",
+                       "serialized_key_size", "serialized_value_size"])

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -309,7 +309,7 @@ class TestKafkaCoordinatorIntegration(KafkaIntegrationTestCase):
 
         offsets = {TopicPartition('topic1', 0): OffsetAndMetadata(1, '')}
         yield from coordinator.commit_offsets(offsets)
-        with mock.patch('kafka.common.for_code') as mocked:
+        with mock.patch('aiokafka.errors.for_code') as mocked:
             mocked.return_value = Errors.GroupAuthorizationFailedError
             with self.assertRaises(Errors.GroupAuthorizationFailedError):
                 yield from coordinator.commit_offsets(offsets)
@@ -361,7 +361,7 @@ class TestKafkaCoordinatorIntegration(KafkaIntegrationTestCase):
         yield from coordinator.ensure_active_group()
 
         offsets = {TopicPartition('topic1', 0): OffsetAndMetadata(1, '')}
-        with mock.patch('kafka.common.for_code') as mocked:
+        with mock.patch('aiokafka.errors.for_code') as mocked:
             mocked.side_effect = MockedKafkaErrCode(
                 Errors.GroupLoadInProgressError, Errors.NoError)
             yield from coordinator.fetch_committed_offsets(offsets)


### PR DESCRIPTION
…, without importing from kafka namespace.