### PR TITLE
Change subscription called only if necessary

### DIFF
--- a/aiokafka/group_coordinator.py
+++ b/aiokafka/group_coordinator.py
@@ -49,7 +49,8 @@ class BaseCoordinator(object):
                 if self._subscription.subscribed_pattern.match(topic):
                     topics.append(topic)
 
-            self._subscription.change_subscription(topics)
+            if set(topics) != self._subscription.subscription:
+                self._subscription.change_subscription(topics)
 
         if self._subscription.partitions_auto_assigned():
             metadata_snapshot = self._get_metadata_snapshot()

--- a/aiokafka/message_accumulator.py
+++ b/aiokafka/message_accumulator.py
@@ -175,7 +175,7 @@ class MessageAccumulator:
     @asyncio.coroutine
     def add_message(self, tp, key, value, timeout):
         """ Add message to batch by topic-partition
-        If batch is already full this method waits (`ttl` seconds maximum)
+        If batch is already full this method waits (`timeout` seconds maximum)
         until batch is drained by send task
         """
         if self._closed:

--- a/aiokafka/producer.py
+++ b/aiokafka/producer.py
@@ -114,7 +114,7 @@ class AIOKafkaProducer(object):
         request_timeout_ms (int): Produce request timeout in milliseconds.
             As it's sent as part of ProduceRequest (it's a blocking call),
             maximum waiting time can be up to 2 * request_timeout_ms.
-            Default: 30000.
+            Default: 40000.
         retry_backoff_ms (int): Milliseconds to backoff when retrying on
             errors. Default: 100.
         api_version (str): specify which kafka API version to use.
@@ -201,7 +201,7 @@ class AIOKafkaProducer(object):
 
     @asyncio.coroutine
     def stop(self):
-        """Flush all pending data and close all connections to kafka cluser"""
+        """Flush all pending data and close all connections to kafka cluster"""
         if self._closed:
             return
 


### PR DESCRIPTION
This is subsequent PR to https://github.com/dpkp/kafka-python/pull/1132 . When we are subscribing by pattern mostly the set of topics is not changed but `change_subscription` is called anyway and then report warning that nothing happened. I don't thing this is message worthy of warning level. In `kafka-python` we agreed on that `change_subscription` should not be called if we can easily check that. 
Also I fixed a few typos I found in docstrings.