### PR TITLE
Allow on_partition_assigned and on_partition_revoked to be async functions

### DIFF
--- a/aiokafka/consumer.py
+++ b/aiokafka/consumer.py
@@ -472,7 +472,7 @@ class AIOKafkaConsumer(object):
             'Partition is not assigned'
         offset = self._subscription.assignment[partition].position
         if offset is None:
-            yield from self._update_fetch_positions([partition])
+            yield from self._update_fetch_positions(partition)
             offset = self._subscription.assignment[partition].position
         return offset
 

--- a/aiokafka/consumer.py
+++ b/aiokafka/consumer.py
@@ -469,7 +469,7 @@ class AIOKafkaConsumer(object):
             'Partition is not assigned'
         offset = self._subscription.assignment[partition].position
         if offset is None:
-            yield from self._update_fetch_positions(partition)
+            yield from self._update_fetch_positions([partition])
             offset = self._subscription.assignment[partition].position
         return offset
 

--- a/aiokafka/consumer.py
+++ b/aiokafka/consumer.py
@@ -376,7 +376,7 @@ class AIOKafkaConsumer(object):
             formatted_offsets = {}
             for tp, offset_and_metadata in offsets.items():
                 if not isinstance(tp, TopicPartition):
-                    raise ValueError(offsets)
+                    raise ValueError("Key should be TopicPartition instance")
 
                 if isinstance(offset_and_metadata, int):
                     offset, metadata = offset_and_metadata, ""
@@ -385,6 +385,9 @@ class AIOKafkaConsumer(object):
                         offset, metadata = offset_and_metadata
                     except Exception:
                         raise ValueError(offsets)
+
+                    if not isinstance(metadata, str):
+                        raise ValueError("Metadata should be a string")
 
                 formatted_offsets[tp] = OffsetAndMetadata(offset, metadata)
 

--- a/aiokafka/group_coordinator.py
+++ b/aiokafka/group_coordinator.py
@@ -2,7 +2,6 @@ import asyncio
 import collections
 import logging
 from copy import copy
-from typing import Awaitable
 
 from kafka.coordinator.assignors.roundrobin import RoundRobinPartitionAssignor
 from kafka.coordinator.protocol import ConsumerProtocol
@@ -305,7 +304,7 @@ class GroupCoordinator(BaseCoordinator):
                 revoked = set(self._subscription.assigned_partitions())
                 res = self._subscription.listener.on_partitions_revoked(
                     revoked)
-                if isinstance(res, Awaitable):
+                if asyncio.iscoroutine(res):
                     yield from res
             except Exception:
                 log.exception("User provided subscription listener %s"
@@ -382,7 +381,7 @@ class GroupCoordinator(BaseCoordinator):
             try:
                 res = self._subscription.listener.on_partitions_assigned(
                     assigned)
-                if isinstance(res, Awaitable):
+                if asyncio.iscoroutine(res):
                     yield from res
             except Exception:
                 log.exception("User provided listener %s for group %s"

--- a/aiokafka/group_coordinator.py
+++ b/aiokafka/group_coordinator.py
@@ -2,6 +2,7 @@ import asyncio
 import collections
 import logging
 from copy import copy
+from typing import Awaitable
 
 from kafka.coordinator.assignors.roundrobin import RoundRobinPartitionAssignor
 from kafka.coordinator.protocol import ConsumerProtocol
@@ -302,7 +303,10 @@ class GroupCoordinator(BaseCoordinator):
         if self._subscription.listener:
             try:
                 revoked = set(self._subscription.assigned_partitions())
-                self._subscription.listener.on_partitions_revoked(revoked)
+                res = self._subscription.listener.on_partitions_revoked(
+                    revoked)
+                if isinstance(res, Awaitable):
+                    yield from res
             except Exception:
                 log.exception("User provided subscription listener %s"
                               " for group %s failed on_partitions_revoked",
@@ -350,6 +354,7 @@ class GroupCoordinator(BaseCoordinator):
             group_assignment[member_id] = assignment
         return group_assignment
 
+    @asyncio.coroutine
     def _on_join_complete(self, generation, member_id, protocol,
                           member_assignment_bytes):
         assignor = self._lookup_assignor(protocol)
@@ -375,7 +380,10 @@ class GroupCoordinator(BaseCoordinator):
         # execute the user's callback after rebalance
         if self._subscription.listener:
             try:
-                self._subscription.listener.on_partitions_assigned(assigned)
+                res = self._subscription.listener.on_partitions_assigned(
+                    assigned)
+                if isinstance(res, Awaitable):
+                    yield from res
             except Exception:
                 log.exception("User provided listener %s for group %s"
                               " failed on partition assignment: %s",
@@ -713,7 +721,7 @@ class GroupCoordinator(BaseCoordinator):
                     continue
                 if assignment is not None:
                     protocol, member_assignment_bytes = assignment
-                    self._on_join_complete(
+                    yield from self._on_join_complete(
                         self.generation, self.member_id,
                         protocol, member_assignment_bytes)
                     self.needs_join_prepare = True

--- a/aiokafka/message_accumulator.py
+++ b/aiokafka/message_accumulator.py
@@ -142,15 +142,18 @@ class MessageBatch:
         memview[:4] = Int32.encode(self._buffer.tell() - 4)
         self._buffer.seek(0)
 
-    def data(self):
+    def get_data_buffer(self):
+        # ProduceRequest will read the buffer on encoding, leaving it in
+        # incorrect state, so to avoid that we reset it here.
+        self._buffer.seek(0)
         return self._buffer
 
 
 class MessageAccumulator:
-    """Accumulator of messages batches by topic-partition
+    """Accumulator of messages batched by topic-partition
 
-    Producer add messages to this accumulator and background send task
-    gets batches per nodes for process it.
+    Producer adds messages to this accumulator and a background send task
+    gets batches per nodes to process it.
     """
     def __init__(self, cluster, batch_size, compression_type, batch_ttl, loop):
         self._batches = {}

--- a/aiokafka/producer.py
+++ b/aiokafka/producer.py
@@ -343,7 +343,9 @@ class AIOKafkaProducer(object):
         while True:
             topics = collections.defaultdict(list)
             for tp, batch in batches.items():
-                topics[tp.topic].append((tp.partition, batch.data()))
+                topics[tp.topic].append(
+                    (tp.partition, batch.get_data_buffer())
+                )
 
             if self.client.api_version >= (0, 10):
                 version = 2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,5 +12,5 @@ sphinxcontrib-asyncio==0.2.0
 sphinxcontrib-spelling==2.3.0
 alabaster==0.7.10
 
-diff-cover==0.9.11
+diff-cover==0.9.12
 setuptools>=34.4.0

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -626,12 +626,15 @@ class TestConsumerIntegration(KafkaIntegrationTestCase):
             yield from consumer.commit({})
         with self.assertRaises(ValueError):
             yield from consumer.commit("something")
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegexp(
+                ValueError, "Key should be TopicPartition instance"):
             yield from consumer.commit({"my_topic": offset_and_metadata})
-        with self.assertRaises(ValueError):
-            yield from consumer.commit({tp: offset})
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegexp(
+                ValueError, "Metadata should be a string"):
             yield from consumer.commit({tp: (offset, 1000)})
+        with self.assertRaisesRegexp(
+                ValueError, "Metadata should be a string"):
+            yield from consumer.commit({tp: (offset, b"\x00\x02")})
 
     @run_until_complete
     def test_consumer_commit_no_group(self):

--- a/tests/test_message_accumulator.py
+++ b/tests/test_message_accumulator.py
@@ -149,7 +149,7 @@ class TestMessageAccumulator(unittest.TestCase):
         batches, _ = ma.drain_by_nodes(ignore_nodes=[])
         self.assertEqual(batches[0][tp0].expired(), False)
         self.assertEqual(batches[1][tp1].expired(), False)
-        batch_data = batches[0][tp0].data()
+        batch_data = batches[0][tp0].get_data_buffer()
         self.assertEqual(type(batch_data), io.BytesIO)
         batches[0][tp0].done(base_offset=10)
 


### PR DESCRIPTION
This is a backward compatible change, since it makes async optional.

We require these to be async functions since we need to call async code from within
the on_partitions_assigned and on_partitions_revoked handlers.