### PR TITLE
Allow on_partition_assigned and on_partition_revoked to be async functions

### DIFF
--- a/aiokafka/consumer.py
+++ b/aiokafka/consumer.py
@@ -472,7 +472,7 @@ class AIOKafkaConsumer(object):
             'Partition is not assigned'
         offset = self._subscription.assignment[partition].position
         if offset is None:
-            yield from self._update_fetch_positions([partition])
+            yield from self._update_fetch_positions(partition)
             offset = self._subscription.assignment[partition].position
         return offset
 

--- a/aiokafka/consumer.py
+++ b/aiokafka/consumer.py
@@ -472,7 +472,7 @@ class AIOKafkaConsumer(object):
             'Partition is not assigned'
         offset = self._subscription.assignment[partition].position
         if offset is None:
-            yield from self._update_fetch_positions(partition)
+            yield from self._update_fetch_positions([partition])
             offset = self._subscription.assignment[partition].position
         return offset
 

--- a/aiokafka/group_coordinator.py
+++ b/aiokafka/group_coordinator.py
@@ -302,7 +302,10 @@ class GroupCoordinator(BaseCoordinator):
         if self._subscription.listener:
             try:
                 revoked = set(self._subscription.assigned_partitions())
-                self._subscription.listener.on_partitions_revoked(revoked)
+                res = self._subscription.listener.on_partitions_revoked(
+                    revoked)
+                if asyncio.iscoroutine(res):
+                    yield from res
             except Exception:
                 log.exception("User provided subscription listener %s"
                               " for group %s failed on_partitions_revoked",
@@ -350,6 +353,7 @@ class GroupCoordinator(BaseCoordinator):
             group_assignment[member_id] = assignment
         return group_assignment
 
+    @asyncio.coroutine
     def _on_join_complete(self, generation, member_id, protocol,
                           member_assignment_bytes):
         assignor = self._lookup_assignor(protocol)
@@ -375,7 +379,10 @@ class GroupCoordinator(BaseCoordinator):
         # execute the user's callback after rebalance
         if self._subscription.listener:
             try:
-                self._subscription.listener.on_partitions_assigned(assigned)
+                res = self._subscription.listener.on_partitions_assigned(
+                    assigned)
+                if asyncio.iscoroutine(res):
+                    yield from res
             except Exception:
                 log.exception("User provided listener %s for group %s"
                               " failed on partition assignment: %s",
@@ -713,7 +720,7 @@ class GroupCoordinator(BaseCoordinator):
                     continue
                 if assignment is not None:
                     protocol, member_assignment_bytes = assignment
-                    self._on_join_complete(
+                    yield from self._on_join_complete(
                         self.generation, self.member_id,
                         protocol, member_assignment_bytes)
                     self.needs_join_prepare = True


### PR DESCRIPTION
This is a backward compatible change, since it makes async optional.

We require these to be async functions since we need to call async code from within
the on_partitions_assigned and on_partitions_revoked handlers.

Note: Fixes #159 