### PR TITLE
uvloop OverflowError in fetcher has been fixed

### DIFF
--- a/aiokafka/fetcher.py
+++ b/aiokafka/fetcher.py
@@ -561,7 +561,7 @@ class Fetcher:
             self._subscriptions.seek(partition, offset)
 
     @asyncio.coroutine
-    def _retrieve_offsets(self, timestamps, timeout_ms=float("inf")):
+    def _retrieve_offsets(self, timestamps, timeout_ms=None):
         """ Fetch offset for each partition passed in ``timestamps`` map.
 
         Blocks until offsets are obtained, a non-retriable exception is raised

--- a/aiokafka/fetcher.py
+++ b/aiokafka/fetcher.py
@@ -561,7 +561,7 @@ class Fetcher:
             self._subscriptions.seek(partition, offset)
 
     @asyncio.coroutine
-    def _retrieve_offsets(self, timestamps, timeout_ms=None):
+    def _retrieve_offsets(self, timestamps, timeout_ms=float("inf")):
         """ Fetch offset for each partition passed in ``timestamps`` map.
 
         Blocks until offsets are obtained, a non-retriable exception is raised
@@ -588,7 +588,8 @@ class Fetcher:
             try:
                 offsets = yield from asyncio.wait_for(
                     self._proc_offset_requests(timestamps),
-                    timeout=remaining, loop=self._loop
+                    timeout=None if remaining == float("inf") else remaining,
+                    loop=self._loop
                 )
             except asyncio.TimeoutError:
                 break


### PR DESCRIPTION
AioKafka 0.3.0 fails with uvloop due to _float("inf")_ timeout for _asyncio.wait_for_.

```
Traceback (most recent call last):
  File "/home/dmitriy/.virtualenvs/wgcgre-qa/lib/python3.5/site-packages/aiokafka/consumer.py", line 897, in on_done
    fut.result()
  File "uvloop/future.pyx", line 146, in uvloop.loop.BaseFuture.result (uvloop/loop.c:109361)
  File "uvloop/future.pyx", line 101, in uvloop.loop.BaseFuture._result_impl (uvloop/loop.c:108900)
  File "uvloop/future.pyx", line 374, in uvloop.loop.BaseTask._fast_step (uvloop/loop.c:112704)
  File "/home/dmitriy/.virtualenvs/wgcgre-qa/lib/python3.5/site-packages/aiokafka/consumer.py", line 876, in _update_fetch_positions
    yield from self._fetcher.update_fetch_positions(partitions)
  File "/home/dmitriy/.virtualenvs/wgcgre-qa/lib/python3.5/site-packages/aiokafka/fetcher.py", line 501, in update_fetch_positions
    yield from asyncio.gather(*futures, loop=self._loop)
  File "/usr/lib/python3.5/asyncio/futures.py", line 361, in __iter__
    yield self  # This tells Task to wait for completion.
  File "uvloop/future.pyx", line 434, in uvloop.loop.BaseTask._fast_wakeup (uvloop/loop.c:114015)
  File "/usr/lib/python3.5/asyncio/futures.py", line 274, in result
    raise self._exception
  File "uvloop/future.pyx", line 372, in uvloop.loop.BaseTask._fast_step (uvloop/loop.c:112669)
  File "/home/dmitriy/.virtualenvs/wgcgre-qa/lib/python3.5/site-packages/aiokafka/fetcher.py", line 553, in _reset_offset
    offsets = yield from self._retrieve_offsets({partition: timestamp})
  File "/home/dmitriy/.virtualenvs/wgcgre-qa/lib/python3.5/site-packages/aiokafka/fetcher.py", line 591, in _retrieve_offsets
    timeout=remaining, loop=self._loop
  File "/usr/lib/python3.5/asyncio/tasks.py", line 376, in wait_for
    timeout_handle = loop.call_later(timeout, _release_waiter, waiter)
  File "uvloop/loop.pyx", line 1048, in uvloop.loop.Loop.call_later (uvloop/loop.c:23438)
OverflowError: cannot convert float infinity to integer
```