### PR TITLE
Add lightweight batching interface to AIOKafkaProducer

### DIFF
--- a/aiokafka/producer/message_accumulator.py
+++ b/aiokafka/producer/message_accumulator.py
@@ -55,7 +55,7 @@ class BatchBuilder:
         else:
             return self._builder.size()
 
-    def length(self):
+    def record_count(self):
         return self._relative_offset
 
 
@@ -271,7 +271,6 @@ class MessageAccumulator:
 
         Returns:
             MessageBatch: delivery wrapper around the BatchBuilder object.
-                to the broker.
 
         Raises:
             aiokafka.errors.ProducerClosed: the accumulator has already been
@@ -282,11 +281,11 @@ class MessageAccumulator:
         if self._closed:
             raise ProducerClosed()
 
+        start = self._loop.time()
         while timeout > 0:
-            start = self._loop.time()
             pending = self._batches.get(tp)
             if pending:
-                yield from pending[-1].wait_drain()
+                yield from pending[-1].wait_drain(timeout=timeout)
                 timeout -= self._loop.time() - start
             else:
                 return self._append_batch(builder, tp)

--- a/examples/batch_produce.py
+++ b/examples/batch_produce.py
@@ -15,17 +15,18 @@ async def send_many(num):
 
     i = 0
     while i < num:
-        payload = "Test message %d" % i
-        if not batch.append(key=None, value=payload.encode(), timestamp=None):
+        msg = ("Test message %d" % i).encode("utf-8")
+        size = batch.append(key=None, value=msg, timestamp=None)
+        if size == 0:
             partitions = await producer.partitions_for(topic)
             partition = random.choice(tuple(partitions))
-            await producer.send_batch(batch, topic, partition)
+            await producer.send_batch(batch, topic, partition=partition)
             batch = producer.create_batch()
             continue
         i += 1
     partitions = await producer.partitions_for(topic)
     partition = random.choice(tuple(partitions))
-    await producer.send_batch(batch, topic, partition)
+    await producer.send_batch(batch, topic, partition=partition)
     await producer.stop()
 
 

--- a/examples/batch_produce.py
+++ b/examples/batch_produce.py
@@ -1,0 +1,33 @@
+import asyncio
+import random
+
+from aiokafka.producer import AIOKafkaProducer
+
+loop = asyncio.get_event_loop()
+
+
+async def send_many(num):
+    topic  = "my_topic"
+    producer = AIOKafkaProducer(loop=loop)
+    await producer.start()
+
+    batch = producer.create_batch()
+
+    i = 0
+    while i < num:
+        payload = "Test message %d" % i
+        if not batch.append(key=None, value=payload.encode(), timestamp=None):
+            partitions = await producer.partitions_for(topic)
+            partition = random.choice(tuple(partitions))
+            await producer.send_batch(batch, topic, partition)
+            batch = producer.create_batch()
+            continue
+        i += 1
+    partitions = await producer.partitions_for(topic)
+    partition = random.choice(tuple(partitions))
+    await producer.send_batch(batch, topic, partition)
+    await producer.stop()
+
+
+loop.run_until_complete(send_many(100))
+loop.close()

--- a/tests/test_message_accumulator.py
+++ b/tests/test_message_accumulator.py
@@ -194,12 +194,11 @@ class TestMessageAccumulator(unittest.TestCase):
         key = b"test key"
         value = b"test value"
         builder = BatchBuilder(magic, batch_size, None)
-        self.assertEqual(builder._actual_size, 0)
         self.assertEqual(builder._relative_offset, 0)
         self.assertIsNone(builder._buffer)
         self.assertFalse(builder._closed)
         self.assertEqual(builder.size(), 0)
-        self.assertEqual(len(builder), 0)
+        self.assertEqual(builder.length(), 0)
 
         # adding messages returns size and increments appropriate values
         for num in range(1, msg_count + 1):
@@ -207,9 +206,9 @@ class TestMessageAccumulator(unittest.TestCase):
             msg_size = builder.append(key=key, value=value, timestamp=None)
             self.assertTrue(msg_size > 0)
             self.assertEqual(builder.size(), old_size + msg_size)
-            self.assertEqual(len(builder), num)
+            self.assertEqual(builder.length(), num)
         old_size = builder.size()
-        old_count = len(builder)
+        old_count = builder.length()
 
         # close the builder
         buf = builder._build()
@@ -218,7 +217,8 @@ class TestMessageAccumulator(unittest.TestCase):
         self.assertTrue(builder._closed)
 
         # nothing can be added after the builder has been closed
+        old_size = builder.size()
         size = builder.append(key=key, value=value, timestamp=None)
         self.assertEqual(size, 0)
         self.assertEqual(builder.size(), old_size)
-        self.assertEqual(len(builder), old_count)
+        self.assertEqual(builder.length(), old_count)

--- a/tests/test_producer.py
+++ b/tests/test_producer.py
@@ -262,7 +262,7 @@ class TestKafkaProducerIntegration(KafkaIntegrationTestCase):
 
         # only fills up to its limits, then returns None
         batch = producer.create_batch()
-        self.assertEqual(batch.length(), 0)
+        self.assertEqual(batch.record_count(), 0)
         num = 0
         while True:
             size = batch.append(key=key, value=value, timestamp=None)
@@ -270,7 +270,7 @@ class TestKafkaProducerIntegration(KafkaIntegrationTestCase):
                 break
             num += 1
         self.assertTrue(num > 0)
-        self.assertEqual(batch.length(), num)
+        self.assertEqual(batch.record_count(), num)
 
         # batch gets properly sent
         future = yield from producer.send_batch(


### PR DESCRIPTION
Lightweight batching interface (as opposed to heavier change in #215). Resolves issue https://github.com/aio-libs/aiokafka/issues/216.

This implementation offers callers a simple interface by which to create batches and submit them once they're populated:

```python
# examples/batch_produce.py
import asyncio
import random

from aiokafka.producer import AIOKafkaProducer

loop = asyncio.get_event_loop()


async def send_many(num):
    topic  = "my_topic"
    producer = AIOKafkaProducer(loop=loop)
    await producer.start()

    partitions = await producer.partitions_for(topic)
    part = random.choice(tuple(partitions))
    batch = producer.create_batch(topic, part)

    i = 0
    while i < num:
        payload = "Test message %d" % i
        fut = batch.append(None, payload.encode(), None)
        if fut is None:
            await producer.send_batch(batch)
            partitions = await producer.partitions_for(topic)
            part = random.choice(tuple(partitions))
            batch = producer.create_batch(topic, part)
            continue
        i += 1
    await producer.send_batch(batch)
    await producer.stop()


loop.run_until_complete(send_many(100))
loop.close()
```

Tests succeed (additional `make` arguments are only there to start docker properly on Mac OS):
```
(.venv) aiokafka (shargan/batch-producer)$ make test KAFKA_VERSION=0.10.1.1 FLAGS=--no-pull
extra=$(python -c "import sys;sys.stdout.write('--exclude tests/test_pep492.py') if sys.version_info[:3] < (3, 5, 0) else sys.stdout.write('')"); \
	flake8 aiokafka tests $extra
py.test -s --no-print-logs --docker-image aiolibs/kafka:2.11_0.10.1.1 --no-pull tests
========================================================= test session starts =========================================================
platform darwin -- Python 3.5.3, pytest-3.2.1, py-1.4.34, pluggy-0.4.0
benchmark: 3.1.1 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /Users/shargan/repos/aiokafka, inifile:
plugins: cov-2.5.1, catchlog-1.2.2, benchmark-3.1.1
collected 114 items

tests/test_client.py ................
tests/test_conn.py ..........
tests/test_consumer.py ..............................s.................x
tests/test_coordinator.py .............
tests/test_fetcher.py ......
tests/test_helpers.py s.
tests/test_message_accumulator.py ..
tests/test_pep492.py ....
tests/test_producer.py ............

========================================= 111 passed, 2 skipped, 1 xfailed in 112.68 seconds ==========================================
```