### PR TITLE
Send session_timeout_ms to GroupCoordinator constructor

### DIFF
--- a/aiokafka/consumer/consumer.py
+++ b/aiokafka/consumer/consumer.py
@@ -181,6 +181,7 @@ class AIOKafkaConsumer(object):
 
         self._group_id = group_id
         self._heartbeat_interval_ms = heartbeat_interval_ms
+        self._session_timeout_ms = session_timeout_ms
         self._retry_backoff_ms = retry_backoff_ms
         self._request_timeout_ms = request_timeout_ms
         self._enable_auto_commit = enable_auto_commit
@@ -244,6 +245,7 @@ class AIOKafkaConsumer(object):
                 self._client, self._subscription, loop=self._loop,
                 group_id=self._group_id,
                 heartbeat_interval_ms=self._heartbeat_interval_ms,
+                session_timeout_ms=self._session_timeout_ms,
                 retry_backoff_ms=self._retry_backoff_ms,
                 enable_auto_commit=self._enable_auto_commit,
                 auto_commit_interval_ms=self._auto_commit_interval_ms,

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -1375,3 +1375,38 @@ class TestConsumerIntegration(KafkaIntegrationTestCase):
             yield from consumer.beginning_offsets(tp)
         with self.assertRaises(UnsupportedVersionError):
             yield from consumer.end_offsets(tp)
+
+    @run_until_complete
+    def test_kafka_consumer_sets_coordinator_values(self):
+        group = "test-group-%s" % self.id()
+        session_timeout_ms = 12345
+        heartbeat_interval_ms = 3456
+        retry_backoff_ms = 567
+        auto_commit_interval_ms = 6789
+        exclude_internal_topics = False
+        enable_auto_commit = True
+
+        consumer = yield from self.consumer_factory(
+            group=group,
+            session_timeout_ms=session_timeout_ms,
+            heartbeat_interval_ms=heartbeat_interval_ms,
+            retry_backoff_ms=retry_backoff_ms,
+            auto_commit_interval_ms=auto_commit_interval_ms,
+            exclude_internal_topics=exclude_internal_topics,
+            enable_auto_commit=enable_auto_commit)
+        coordinator = consumer._coordinator
+
+        self.assertEqual(
+            coordinator.group_id, group)
+        self.assertEqual(
+            coordinator._session_timeout_ms, session_timeout_ms)
+        self.assertEqual(
+            coordinator._heartbeat_interval_ms, heartbeat_interval_ms)
+        self.assertEqual(
+            coordinator._retry_backoff_ms, retry_backoff_ms)
+        self.assertEqual(
+            coordinator._auto_commit_interval_ms, auto_commit_interval_ms)
+        self.assertEqual(
+            coordinator._exclude_internal_topics, exclude_internal_topics)
+        self.assertEqual(
+            coordinator._enable_auto_commit, enable_auto_commit)


### PR DESCRIPTION
Consumer is currently swallowing the `session_timeout_ms` kwarg. This diff sends it on to the GroupCoordinator as presumably intended.