### PR TITLE
Don't fail GroupCoordinator._on_join_prepare() if commit_offset() throws exception

### DIFF
--- a/aiokafka/consumer/group_coordinator.py
+++ b/aiokafka/consumer/group_coordinator.py
@@ -305,7 +305,10 @@ class GroupCoordinator(BaseCoordinator):
         self._assignment_snapshot = None
 
         # commit offsets prior to rebalance if auto-commit enabled
-        yield from self._maybe_auto_commit_offsets_sync()
+        try:
+            yield from self._maybe_auto_commit_offsets_sync()
+        except Errors.KafkaError as err:
+            log.error("OffsetCommit failed before join, ignoring: %s", err)
 
         # execute the user's callback before rebalance
         log.info("Revoking previously assigned partitions %s for group %s",

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -328,6 +328,12 @@ class TestKafkaCoordinatorIntegration(KafkaIntegrationTestCase):
             with self.assertRaises(Errors.RebalanceInProgressError):
                 yield from coordinator.commit_offsets(offsets)
             self.assertEqual(subscription.needs_partition_assignment, True)
+            subscription.needs_partition_assignment = False
+
+            mocked.return_value = Errors.UnknownMemberIdError
+            with self.assertRaises(Errors.UnknownMemberIdError):
+                yield from coordinator.commit_offsets(offsets)
+            self.assertEqual(subscription.needs_partition_assignment, True)
 
             mocked.return_value = KafkaError
             with self.assertRaises(KafkaError):
@@ -338,8 +344,7 @@ class TestKafkaCoordinatorIntegration(KafkaIntegrationTestCase):
                 yield from coordinator.commit_offsets(offsets)
             self.assertEqual(coordinator.coordinator_id, None)
 
-            with self.assertRaises(
-                    Errors.GroupCoordinatorNotAvailableError):
+            with self.assertRaises(Errors.GroupCoordinatorNotAvailableError):
                 yield from coordinator.commit_offsets(offsets)
 
         yield from coordinator.close()
@@ -544,6 +549,40 @@ class TestKafkaCoordinatorIntegration(KafkaIntegrationTestCase):
             yield from client.force_metadata_update()
             yield from coordinator.ensure_active_group()
             self.assertEqual(mocked.call_count, 1)
+
+        yield from coordinator.close()
+        yield from client.close()
+
+    @run_until_complete
+    def test_coordinator_ensure_active_group_on_expired_membership(self):
+        # Do not fail ensure_active_group() if group membership has expired
+        client = AIOKafkaClient(loop=self.loop, bootstrap_servers=self.hosts)
+        yield from client.bootstrap()
+        yield from self.wait_topic(client, 'topic1')
+        subscription = SubscriptionState('earliest')
+        subscription.subscribe(topics=('topic1',))
+        coordinator = GroupCoordinator(
+            client, subscription, loop=self.loop,
+            group_id='test-offsets-group')
+        yield from coordinator.ensure_active_group()
+
+        # during OffsetCommit, UnknownMemberIdError is raised
+        offsets = {TopicPartition('topic1', 0): OffsetAndMetadata(1, '')}
+        with mock.patch('aiokafka.errors.for_code') as mocked:
+            mocked.return_value = Errors.UnknownMemberIdError
+            with self.assertRaises(Errors.UnknownMemberIdError):
+                yield from coordinator.commit_offsets(offsets)
+            self.assertEqual(subscription.needs_partition_assignment, True)
+
+        # same exception is raised during ensure_active_group()'s call to
+        # commit_offsets() via _on_join_prepare() but doesn't break this method
+        with mock.patch.object(coordinator, "commit_offsets") as mocked:
+            @asyncio.coroutine
+            def mock_commit_offsets(*args, **kwargs):
+                raise Errors.UnknownMemberIdError()
+            mocked.side_effect = mock_commit_offsets
+
+            yield from coordinator.ensure_active_group()
 
         yield from coordinator.close()
         yield from client.close()


### PR DESCRIPTION
As it currently stands, a Consumer whose membership in a group expires (whether due to message processing that exceeds the `session_timeout_ms` or a brief network interruption) enters an unrecoverable state. Every cycle of the heartbeat routine calls `ensure_active_group()`, which attempts to commit outstanding offsets before taking any further action. If membership has expired, however, interacting with the coordinator will throw an `UnknownMemberIdError` exception and the process will begin again on the next heartbeat cycle.

To illustrate, start a Kafka broker with group.min.session.timeout.ms set to a very low value. Populate some data into the `test` topic and then run the following code (#229 is required to set the session timeout properly):

```python
import aiokafka
import asyncio
import logging
import sys
import time

logging.basicConfig(level=logging.INFO, stream=sys.stderr)


async def doit(loop):
    consumer = aiokafka.AIOKafkaConsumer(
        loop=loop,
        group_id="test",
        session_timeout_ms=100,
        heartbeat_interval_ms=33,
    )
    consumer.subscribe("test")
    await consumer.start()

    print("\n### Sleeping to induce error\n")
    time.sleep(1)

    await consumer.getmany()
    await asyncio.sleep(1)
    await consumer.stop()

loop = asyncio.get_event_loop()
loop.run_until_complete(doit(loop))
loop.close()
```

The result:
```
INFO:kafka.consumer.subscription_state:Updating subscribed topics to: ['test']
INFO:aiokafka.consumer.group_coordinator:Discovered coordinator 1001 for group test
INFO:aiokafka.consumer.group_coordinator:Revoking previously assigned partitions set() for group test
INFO:aiokafka.consumer.group_coordinator:(Re-)joining group test
INFO:aiokafka.consumer.group_coordinator:Joined group 'test' (generation 1) with member_id aiokafka-0.3.2.dev-4470f1dc-e352-4ce5-97eb-2abc16a99414
INFO:aiokafka.consumer.group_coordinator:Elected group leader -- performing partition assignments using roundrobin
INFO:aiokafka.consumer.group_coordinator:Successfully synced group test with generation 1
INFO:kafka.consumer.subscription_state:Updated partition assignment: [TopicPartition(topic='test', partition=0)]
INFO:aiokafka.consumer.group_coordinator:Setting newly assigned partitions {TopicPartition(topic='test', partition=0)} for group test

### Sleeping to induce error

WARNING:aiokafka.consumer.group_coordinator:Heartbeat failed: local member_id was not recognized; resetting and re-joining group
ERROR:aiokafka.consumer.group_coordinator:Heartbeat session expired - marking coordinator dead
WARNING:aiokafka.consumer.group_coordinator:Marking the coordinator dead (node 1001)for group test: None.
INFO:aiokafka.consumer.group_coordinator:Discovered coordinator 1001 for group test
ERROR:aiokafka.consumer.group_coordinator:OffsetCommit failed for group test due to group error ([Error 25] UnknownMemberIdError: test), will rejoin
ERROR:aiokafka.consumer.group_coordinator:Skipping heartbeat: no active group: UnknownMemberIdError('test',)
ERROR:aiokafka.consumer.group_coordinator:OffsetCommit failed for group test due to group error ([Error 25] UnknownMemberIdError: test), will rejoin
ERROR:aiokafka.consumer.group_coordinator:Skipping heartbeat: no active group: UnknownMemberIdError('test',)
ERROR:aiokafka.consumer.group_coordinator:OffsetCommit failed for group test due to group error ([Error 25] UnknownMemberIdError: test), will rejoin
ERROR:aiokafka.consumer.group_coordinator:Skipping heartbeat: no active group: UnknownMemberIdError('test',)
ERROR:aiokafka.consumer.group_coordinator:OffsetCommit failed for group test due to group error ([Error 25] UnknownMemberIdError: test), will rejoin
ERROR:aiokafka.consumer.group_coordinator:Skipping heartbeat: no active group: UnknownMemberIdError('test',)
ERROR:aiokafka.consumer.group_coordinator:OffsetCommit failed for group test due to group error ([Error 25] UnknownMemberIdError: test), will rejoin
ERROR:aiokafka.consumer.group_coordinator:Skipping heartbeat: no active group: UnknownMemberIdError('test',)
ERROR:aiokafka.consumer.group_coordinator:OffsetCommit failed for group test due to group error ([Error 25] UnknownMemberIdError: test), will rejoin
ERROR:aiokafka.consumer.group_coordinator:Skipping heartbeat: no active group: UnknownMemberIdError('test',)
ERROR:aiokafka.consumer.group_coordinator:OffsetCommit failed for group test due to group error ([Error 25] UnknownMemberIdError: test), will rejoin
ERROR:aiokafka.consumer.group_coordinator:Skipping heartbeat: no active group: UnknownMemberIdError('test',)
ERROR:aiokafka.consumer.group_coordinator:OffsetCommit failed for group test due to group error ([Error 25] UnknownMemberIdError: test), will rejoin
ERROR:aiokafka.consumer.group_coordinator:Skipping heartbeat: no active group: UnknownMemberIdError('test',)
ERROR:aiokafka.consumer.group_coordinator:OffsetCommit failed for group test due to group error ([Error 25] UnknownMemberIdError: test), will rejoin
ERROR:aiokafka.consumer.group_coordinator:Skipping heartbeat: no active group: UnknownMemberIdError('test',)
ERROR:aiokafka.consumer.group_coordinator:OffsetCommit failed for group test due to group error ([Error 25] UnknownMemberIdError: test), will rejoin
WARNING:aiokafka.consumer.group_coordinator:Auto offset commit failed: [Error 25] UnknownMemberIdError: test
ERROR:aiokafka.consumer.group_coordinator:LeaveGroup request failed: [Error 25] UnknownMemberIdError
```

This patch fixes the issue by ignoring exceptions from `_maybe_auto_commit_offsets_sync()` in `_on_join_prepare()`