### PR TITLE
Update TP position when a fetch request returns OffsetOutOfRangeError

### DIFF
--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -181,7 +181,7 @@ class TestFetcher(unittest.TestCase):
         state.seek(4)
         client.send.side_effect = asyncio.coroutine(
             lambda n, r: FetchResponse(
-                [('test', [(0, 1, 9, [(4, 10, msg)])])]))
+                [('test', [(0, 1, 9, [(4, 10, raw_batch)])])]))
         fetcher._in_flight.add(0)
         fetcher._records.clear()
         with mock.patch.object(fetcher, "update_fetch_positions") as mocked:


### PR DESCRIPTION
If `_fetch_requests_routine()` receives `OffsetOutOfRangeError` in response to a request the offending TP is marked as requiring a reset. However, `update_fetch_positions()`, the method responsible for performing the reset, is only called if the subscription changes or a user calls one of the consumer's seek methods. As a result, the fetcher retains ownership of the TP but no longer consumes from it.

This is especially problematic when processing data with `auto_offset_reset='earliest'` against a broker with specific retention times. Data may be pruned by the time autocommit kicks in and the TP never recovers.

The patch included here works but changes test behavior significantly. If this approach works for you, I'll update the tests accordingly.