### PR TITLE
Performance improvements to _LegacyRecordBatchBuilderPy

### DIFF
--- a/aiokafka/record/_legacy_records.pyx
+++ b/aiokafka/record/_legacy_records.pyx
@@ -21,7 +21,7 @@ cdef extern from "Python.h":
     object PyMemoryView_FromMemory(char *mem, ssize_t size, int flags)
 
 
-# This should be before _cutil to generate include for `winsock2.h` before 
+# This should be before _cutil to generate include for `winsock2.h` before
 # `windows.h`
 from aiokafka.record cimport _hton as hton
 from aiokafka.record cimport _cutil as cutil
@@ -360,6 +360,8 @@ cdef class _LegacyRecordBatchBuilderCython:
         cdef:
             Py_ssize_t pos
             Py_ssize_t size
+            Py_ssize_t key_size
+            Py_ssize_t value_size
             char *buf
             int64_t ts
             LegacyRecordMetadata metadata
@@ -372,9 +374,12 @@ cdef class _LegacyRecordBatchBuilderCython:
         else:
             ts = timestamp
 
+        key_size = _size_of_bytearray(key)
+        value_size = _size_of_bytearray(value)
+
         # Check if we have room for another message
         pos = PyByteArray_GET_SIZE(self._buffer)
-        size = _size_in_bytes(self._magic, key, value)
+        size = _size_in_bytes(self._magic, key_size, value_size)
         # We always allow at least one record to be appended
         if offset != 0 and pos + size >= self._batch_size:
             return None
@@ -398,10 +403,10 @@ cdef class _LegacyRecordBatchBuilderCython:
 
     # Size calculations. Just copied Java's implementation
 
-    def size_in_bytes(self, offset, timestamp, key, value):
+    def size_in_bytes(self, offset, timestamp, key_size, value_size):
         """ Actual size of message to add
         """
-        return _size_in_bytes(self._magic, key, value)
+        return _size_in_bytes(self._magic, key_size, value_size)
 
     @staticmethod
     def record_overhead(char magic):
@@ -415,6 +420,7 @@ cdef class _LegacyRecordBatchBuilderCython:
             object compressed
             char *buf
             Py_ssize_t size
+            Py_ssize_t value_size
             uint32_t crc
 
         if self._compression_type != 0:
@@ -429,7 +435,9 @@ cdef class _LegacyRecordBatchBuilderCython:
                     compressed = lz4_encode(bytes(self._buffer))
             else:
                 return 0
-            size = _size_in_bytes(self._magic, key=None, value=compressed)
+            value_size = _size_of_bytearray(compressed)
+            size = _size_in_bytes(
+                self._magic, key_size=0, value_size=value_size)
             # We will just write the result into the same memory space.
             PyByteArray_Resize(self._buffer, size)
 
@@ -447,32 +455,28 @@ cdef class _LegacyRecordBatchBuilderCython:
         return self._buffer
 
 
-cdef Py_ssize_t _size_in_bytes(char magic, object key, object value) except -1:
+cdef Py_ssize_t _size_in_bytes(char magic, Py_ssize_t key_size, Py_ssize_t value_size) except -1:
     """ Actual size of message to add
+    """
+    if magic == 0:
+        return LOG_OVERHEAD + RECORD_OVERHEAD_V0_DEF + key_size + value_size
+    else:
+        return LOG_OVERHEAD + RECORD_OVERHEAD_V1_DEF + key_size + value_size
+
+
+cdef Py_ssize_t _size_of_bytearray(object obj) except -1:
+    """ Properly return size of bytearray object
     """
     cdef:
         Py_buffer buf
-        Py_ssize_t key_len
-        Py_ssize_t value_len
 
-    if key is None:
-        key_len = 0
+    if obj is None:
+        return 0
     else:
-        PyObject_GetBuffer(key, &buf, PyBUF_SIMPLE)
-        key_len = buf.len
+        PyObject_GetBuffer(obj, &buf, PyBUF_SIMPLE)
+        obj_size = buf.len
         PyBuffer_Release(&buf)
-
-    if value is None:
-        value_len = 0
-    else:
-        PyObject_GetBuffer(value, &buf, PyBUF_SIMPLE)
-        value_len = buf.len
-        PyBuffer_Release(&buf)
-
-    if magic == 0:
-        return LOG_OVERHEAD + RECORD_OVERHEAD_V0_DEF + key_len + value_len
-    else:
-        return LOG_OVERHEAD + RECORD_OVERHEAD_V1_DEF + key_len + value_len
+        return obj_size
 
 
 cdef int _encode_msg(

--- a/aiokafka/record/legacy_records.py
+++ b/aiokafka/record/legacy_records.py
@@ -412,7 +412,8 @@ class _LegacyRecordBatchBuilderPy(LegacyRecordBase):
     def build(self):
         """Compress batch to be ready for send"""
         self._maybe_compress()
-        return memoryview(self._buffer)[:self._pos]
+        del self._buffer[self._pos:]
+        return self._buffer
 
     def size(self):
         """ Return current size of data written to buffer

--- a/aiokafka/record/legacy_records.py
+++ b/aiokafka/record/legacy_records.py
@@ -361,7 +361,8 @@ class _LegacyRecordBatchBuilderPy(LegacyRecordBase):
                 "%ds"  # value => bytes
                 % (key_size, value_size),
                 buf, 0, offset, length, 0, magic, attributes,
-                key_size or -1, key or b"", value_size or -1, value or b"")
+                key_size if key is not None else -1, key or b"",
+                value_size if value is not None else -1, value or b"")
         else:
             length += self.KEY_OFFSET_V1
             struct.pack_into(
@@ -377,7 +378,8 @@ class _LegacyRecordBatchBuilderPy(LegacyRecordBase):
                 "%ds"  # value => bytes
                 % (key_size, value_size),
                 buf, 0, offset, length, 0, magic, attributes, timestamp,
-                key_size or -1, key or b"", value_size or -1, value or b"")
+                key_size if key is not None else -1, key or b"",
+                value_size if value is not None else -1, value or b"")
 
         crc = crc32(buf[self.MAGIC_OFFSET:size])
         struct.pack_into(">I", buf, self.CRC_OFFSET, crc)

--- a/aiokafka/record/legacy_records.py
+++ b/aiokafka/record/legacy_records.py
@@ -1,7 +1,7 @@
 import struct
 import time
 
-from .util import calc_crc32
+from binascii import crc32
 
 from aiokafka.errors import CorruptRecordException
 from aiokafka.util import NO_EXTENSIONS
@@ -9,6 +9,9 @@ from kafka.codec import (
     gzip_encode, snappy_encode, lz4_encode, lz4_encode_old_kafka,
     gzip_decode, snappy_decode, lz4_decode, lz4_decode_old_kafka
 )
+
+
+NoneType = type(None)
 
 
 class LegacyRecordBase:
@@ -52,6 +55,10 @@ class LegacyRecordBase:
         "i"   # Key length
         "i"   # Value length
     )
+    RECORD_OVERHEAD = {
+        0: RECORD_OVERHEAD_V0,
+        1: RECORD_OVERHEAD_V1,
+    }
 
     KEY_OFFSET_V0 = HEADER_STRUCT_V0.size
     KEY_OFFSET_V1 = HEADER_STRUCT_V1.size
@@ -102,7 +109,7 @@ class _LegacyRecordBatchPy(LegacyRecordBase):
         return self._attributes & self.CODEC_MASK
 
     def validate_crc(self):
-        crc = calc_crc32(self._buffer[self.MAGIC_OFFSET:])
+        crc = crc32(self._buffer[self.MAGIC_OFFSET:])
         return self._crc == crc
 
     def _decompress(self, key_offset):
@@ -278,155 +285,154 @@ class _LegacyRecordPy:
 class _LegacyRecordBatchBuilderPy(LegacyRecordBase):
 
     def __init__(self, magic, compression_type, batch_size):
+        assert magic in [0, 1]
         self._magic = magic
         self._compression_type = compression_type
         self._batch_size = batch_size
-        self._buffer = bytearray()
+        self._buffer = bytearray(batch_size)
+        self._pos = 0
 
     def append(self, offset, timestamp, key, value):
         """ Append message to batch.
         """
-        # Check types
-        if type(offset) != int:
-            raise TypeError(offset)
         if self._magic == 0:
             timestamp = -1
         elif timestamp is None:
             timestamp = int(time.time() * 1000)
-        elif type(timestamp) != int:
-            raise TypeError(timestamp)
-        if not (key is None or
-                isinstance(key, (bytes, bytearray, memoryview))):
-            raise TypeError(
-                "Not supported type for key: {}".format(type(key)))
-        if not (value is None or
-                isinstance(value, (bytes, bytearray, memoryview))):
-            raise TypeError(
-                "Not supported type for value: {}".format(type(value)))
 
-        # Check if we have room for another message
-        pos = len(self._buffer)
-        size = self.size_in_bytes(offset, timestamp, key, value)
-        # We always allow at least one record to be appended
+        # calculating length is not cheap; only do it once
+        key_size = len(key) if key is not None else 0
+        value_size = len(value) if value is not None else 0
+
+        pos = self._pos
+        size = self.size_in_bytes(offset, timestamp, key_size, value_size)
+        # always allow at least one record to be appended
         if offset != 0 and pos + size >= self._batch_size:
             return None
+        elif offset == 0 and size > self._batch_size:
+            # if adding the message fails for any reason, this buffer will
+            # remain in its expanded state. Since position is tracked
+            # independently and comparisons are made against self._batch_size,
+            # this will have no ill effects
+            self._buffer = bytearray(size)
 
-        # Allocate proper buffer length
-        self._buffer.extend(bytearray(size))
+        try:
+            crc = self._encode_msg(
+                pos, size, offset, timestamp, key_size, key, value_size, value)
+            self._pos += size
+            return LegacyRecordMetadata(offset, crc, size, timestamp)
 
-        # Encode message
-        crc = self._encode_msg(pos, offset, timestamp, key, value)
+        except struct.error:
+            # perform expensive type checking only to translate struct errors
+            # to human-readable messages
+            if type(offset) != int:
+                raise TypeError(offset)
+            if type(timestamp) != int:
+                raise TypeError(timestamp)
+            if not isinstance(key, (bytes, bytearray, memoryview, NoneType)):
+                raise TypeError("Unsupported type for key: %s" % type(key))
+            if not isinstance(value, (bytes, bytearray, memoryview, NoneType)):
+                raise TypeError("Unsupported type for value: %s" % type(value))
+            raise
 
-        return LegacyRecordMetadata(offset, crc, size, timestamp)
-
-    def _encode_msg(self, start_pos, offset, timestamp, key, value,
-                    attributes=0):
+    def _encode_msg(self, start_pos, size, offset, timestamp, key_size, key,
+                    value_size, value, attributes=0):
         """ Encode msg data into the `msg_buffer`, which should be allocated
             to at least the size of this message.
         """
         magic = self._magic
-        buf = self._buffer
-        pos = start_pos
+        buf = memoryview(self._buffer)[start_pos:]
 
-        # Write key and value
-        pos += self.KEY_OFFSET_V0 if magic == 0 else self.KEY_OFFSET_V1
+        length = (self.KEY_LENGTH + key_size
+                  + self.VALUE_LENGTH + value_size
+                  - self.LOG_OVERHEAD)
 
-        if key is None:
-            struct.pack_into(">i", buf, pos, -1)
-            pos += self.KEY_LENGTH
-        else:
-            key_size = len(key)
-            struct.pack_into(">i", buf, pos, key_size)
-            pos += self.KEY_LENGTH
-            buf[pos: pos + key_size] = key
-            pos += key_size
-
-        if value is None:
-            struct.pack_into(">i", buf, pos, -1)
-            pos += self.VALUE_LENGTH
-        else:
-            value_size = len(value)
-            struct.pack_into(">i", buf, pos, value_size)
-            pos += self.VALUE_LENGTH
-            buf[pos: pos + value_size] = value
-            pos += value_size
-        length = (pos - start_pos) - self.LOG_OVERHEAD
-
-        # Write msg header. Note, that Crc will be updated later
         if magic == 0:
-            self.HEADER_STRUCT_V0.pack_into(
-                buf, start_pos,
-                offset, length, 0, magic, attributes)
+            length += self.KEY_OFFSET_V0
+            struct.pack_into(
+                ">q"   # BaseOffset => Int64
+                "i"    # Length => Int32
+                "I"    # CRC => Int32
+                "b"    # Magic => Int8
+                "b"    # Attributes => Int8
+                "i"    # key length => Int32
+                "%ds"  # key => bytes
+                "i"    # value length => Int32
+                "%ds"  # value => bytes
+                % (key_size, value_size),
+                buf, 0, offset, length, 0, magic, attributes,
+                key_size or -1, key or b"", value_size or -1, value or b"")
         else:
-            self.HEADER_STRUCT_V1.pack_into(
-                buf, start_pos,
-                offset, length, 0, magic, attributes, timestamp)
+            length += self.KEY_OFFSET_V1
+            struct.pack_into(
+                ">q"   # BaseOffset => Int64
+                "i"    # Length => Int32
+                "I"    # CRC => Int32
+                "b"    # Magic => Int8
+                "b"    # Attributes => Int8
+                "q"    # timestamp => Int64
+                "i"    # key length => Int32
+                "%ds"  # key => bytes
+                "i"    # value length => Int32
+                "%ds"  # value => bytes
+                % (key_size, value_size),
+                buf, 0, offset, length, 0, magic, attributes, timestamp,
+                key_size or -1, key or b"", value_size or -1, value or b"")
 
-        # Calculate CRC for msg
-        crc_data = memoryview(buf)[start_pos + self.MAGIC_OFFSET:]
-        crc = calc_crc32(crc_data)
-        struct.pack_into(">I", buf, start_pos + self.CRC_OFFSET, crc)
+        crc = crc32(buf[self.MAGIC_OFFSET:size])
+        struct.pack_into(">I", buf, self.CRC_OFFSET, crc)
         return crc
 
     def _maybe_compress(self):
         if self._compression_type:
+            buf = memoryview(self._buffer)[:self._pos]
             if self._compression_type == self.CODEC_GZIP:
-                compressed = gzip_encode(self._buffer)
+                compressed = gzip_encode(buf)
             elif self._compression_type == self.CODEC_SNAPPY:
-                compressed = snappy_encode(self._buffer)
+                compressed = snappy_encode(buf)
             elif self._compression_type == self.CODEC_LZ4:
                 if self._magic == 0:
-                    compressed = lz4_encode_old_kafka(bytes(self._buffer))
+                    compressed = lz4_encode_old_kafka(bytes(buf))
                 else:
-                    compressed = lz4_encode(bytes(self._buffer))
+                    compressed = lz4_encode(bytes(buf))
+            compressed_size = len(compressed)
             size = self.size_in_bytes(
-                0, timestamp=0, key=None, value=compressed)
+                0, timestamp=0, key_size=0, value_size=compressed_size)
             if size > len(self._buffer):
                 self._buffer = bytearray(size)
-            else:
-                del self._buffer[size:]
             self._encode_msg(
-                start_pos=0,
-                offset=0, timestamp=0, key=None, value=compressed,
+                start_pos=0, size=size,
+                offset=0, timestamp=0, key_size=0, key=None,
+                value_size=compressed_size, value=compressed,
                 attributes=self._compression_type)
+            self._pos = size
             return True
         return False
 
     def build(self):
         """Compress batch to be ready for send"""
         self._maybe_compress()
-        return self._buffer
+        return memoryview(self._buffer)[:self._pos]
 
     def size(self):
         """ Return current size of data written to buffer
         """
-        return len(self._buffer)
+        return self._pos
 
-    # Size calculations. Just copied Java's implementation
-
-    def size_in_bytes(self, offset, timestamp, key, value, headers=None):
+    def size_in_bytes(self, offset, timestamp, key_size, value_size,
+                      headers=None):
         """ Actual size of message to add
         """
         assert not headers, "Headers not supported in v0/v1"
-        magic = self._magic
-        return self.LOG_OVERHEAD + self.record_size(magic, key, value)
-
-    @classmethod
-    def record_size(cls, magic, key, value):
-        message_size = cls.record_overhead(magic)
-        if key is not None:
-            message_size += len(key)
-        if value is not None:
-            message_size += len(value)
-        return message_size
+        return (self.LOG_OVERHEAD + self.RECORD_OVERHEAD[self._magic]
+                + key_size + value_size)
 
     @classmethod
     def record_overhead(cls, magic):
-        assert magic in [0, 1], "Not supported magic"
-        if magic == 0:
-            return cls.RECORD_OVERHEAD_V0
-        else:
-            return cls.RECORD_OVERHEAD_V1
+        try:
+            return cls.RECORD_OVERHEAD[magic]
+        except KeyError:
+            raise ValueError("Unsupported magic: %d" % magic)
 
 
 class _LegacyRecordMetadataPy:

--- a/aiokafka/record/util.py
+++ b/aiokafka/record/util.py
@@ -1,8 +1,0 @@
-import binascii
-
-
-def calc_crc32(memview):
-    """ Calculate simple CRC-32 checksum over a memoryview of data
-    """
-    crc = binascii.crc32(memview)
-    return crc

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@ from aiokafka.util import NO_EXTENSIONS
 if not NO_EXTENSIONS:
     assert LegacyRecordBatchBuilder is not _LegacyRecordBatchBuilderPy, \
         "Expected to run tests with C extension, but it was not imported. "\
-        "To run tests without a C extensions set NO_EXTENSIONS=1 env veriable"
+        "To run tests without a C extensions set env AIOKAFKA_NO_EXTENSIONS=1"
     print("Running tests with C extension")
 else:
     print("Running tests without C extension")

--- a/tests/record/test_legacy.py
+++ b/tests/record/test_legacy.py
@@ -193,7 +193,6 @@ def test_read_log_append_time_v1():
 @pytest.mark.parametrize("magic", [0, 1])
 def test_reader_corrupt_record_v0_v1(magic):
     buffer = _make_compressed_batch(magic)
-    buffer = bytearray(buffer)
     len_offset = 8
 
     # If the wrapper of compressed messages has a key it will just be ignored.

--- a/tests/record/test_legacy.py
+++ b/tests/record/test_legacy.py
@@ -11,12 +11,14 @@ from aiokafka.errors import CorruptRecordException
 @pytest.mark.parametrize("key,value,checksum", [
     (b"test", b"Super", [278251978, -2095076219]),
     (b"test", None, [580701536, 164492157]),
-    (None, b"Super", [2797021502, 3315209433])])
+    (None, b"Super", [2797021502, 3315209433]),
+    (b"", b"Super", [1446809667, 890351012]),
+    (b"test", b"", [4230475139, 3614888862]),
+])
 def test_read_write_serde_v0_v1_no_compression(magic, key, value, checksum):
     builder = LegacyRecordBatchBuilder(
         magic=magic, compression_type=0, batch_size=1024 * 1024)
-    builder.append(
-        0, timestamp=9999999, key=key, value=value)
+    builder.append(0, timestamp=9999999, key=key, value=value)
     buffer = builder.build()
 
     batch = LegacyRecordBatch(buffer, magic)

--- a/tests/record/test_legacy.py
+++ b/tests/record/test_legacy.py
@@ -67,7 +67,7 @@ def test_written_bytes_equals_size_in_bytes(magic):
         magic=magic, compression_type=0, batch_size=1024 * 1024)
 
     size_in_bytes = builder.size_in_bytes(
-        0, timestamp=9999999, key=key, value=value)
+        0, timestamp=9999999, key_size=len(key), value_size=len(value))
 
     pos = builder.size()
     builder.append(0, timestamp=9999999, key=key, value=value)
@@ -90,7 +90,7 @@ def test_legacy_batch_builder_validates_arguments(magic):
         builder.append(
             0, timestamp=9999999, key=None, value="some string")
 
-    # Timestamp should be of proper type
+    # Timestamp should be of proper type (timestamp is ignored for magic == 0)
     if magic != 0:
         with pytest.raises(TypeError):
             builder.append(
@@ -193,6 +193,7 @@ def test_read_log_append_time_v1():
 @pytest.mark.parametrize("magic", [0, 1])
 def test_reader_corrupt_record_v0_v1(magic):
     buffer = _make_compressed_batch(magic)
+    buffer = bytearray(buffer)
     len_offset = 8
 
     # If the wrapper of compressed messages has a key it will just be ignored.


### PR DESCRIPTION
Highlights include:
- Perform `append()` type checking only when necessary (upon error)
- Wrap all `_encode_msg()` logic into a single `struct.pack_into()` call to reduce overhead
- Flatten multi-method invocations wherever possible without losing clarity
- Preallocate buffer space rather than expanding on each individual message
- Calculate key and value length only once

The results:
```
(.venv) aiokafka (master)$ python benchmark/record_batch_compose.py
.....................
batch_append_v0: Mean +- std dev: 906 us +- 60 us
.....................
batch_append_v1: Mean +- std dev: 946 us +- 52 us
(.venv) aiokafka (master)$ python bench_records.py simple
1000000 messages in 7.83s (127758.34 msg/s)

(.venv) aiokafka (shargan/record-performance)$ python benchmark/record_batch_compose.py
.....................
batch_append_v0: Mean +- std dev: 598 us +- 29 us
.....................
batch_append_v1: Mean +- std dev: 647 us +- 35 us
(.venv) aiokafka (shargan/record-performance)$ python bench_records.py simple
1000000 messages in 5.50s (181839.19 msg/s)
```