### PR TITLE
Instantiate error for each future.set_exception

### DIFF
--- a/aiokafka/conn.py
+++ b/aiokafka/conn.py
@@ -174,11 +174,11 @@ class AIOKafkaConnection:
             self._writer = self._reader = None
             self._read_task.cancel()
             self._read_task = None
-            error = Errors.ConnectionError(
-                "Connection at {0}:{1} closed".format(
-                    self._host, self._port))
             for _, _, fut in self._requests:
                 if not fut.done():
+                    error = Errors.ConnectionError(
+                        "Connection at {0}:{1} closed".format(
+                            self._host, self._port))
                     fut.set_exception(error)
             self._requests = []
             if self._on_close_cb is not None:
@@ -229,11 +229,11 @@ class AIOKafkaConnection:
                 # Update idle timer.
                 self._last_action = self._loop.time()
         except (OSError, EOFError, ConnectionError) as exc:
-            conn_exc = Errors.ConnectionError(
-                "Connection at {0}:{1} broken".format(self._host, self._port))
-            conn_exc.__cause__ = exc
-            conn_exc.__context__ = exc
             for _, _, fut in self._requests:
+                conn_exc = Errors.ConnectionError(
+                    "Connection at {0}:{1} broken".format(self._host, self._port))
+                conn_exc.__cause__ = exc
+                conn_exc.__context__ = exc
                 fut.set_exception(conn_exc)
             self.close(reason=CloseReason.CONNECTION_BROKEN)
         except asyncio.CancelledError:

--- a/aiokafka/producer/message_accumulator.py
+++ b/aiokafka/producer/message_accumulator.py
@@ -1,6 +1,7 @@
 import asyncio
 import collections
 import io
+import copy
 
 from kafka.protocol.types import Int32
 
@@ -165,7 +166,9 @@ class MessageBatch:
         for future, _ in self._msg_futures:
             if future.done():
                 continue
-            future.set_exception(exception)
+            # we need to copy exception so traceback is not multiplied
+            # https://github.com/aio-libs/aiokafka/issues/246
+            future.set_exception(copy.copy(exception))
 
     def wait_deliver(self, timeout=None):
         """Wait until all message from this batch is processed"""


### PR DESCRIPTION
This fixes https://github.com/aio-libs/aiokafka/issues/246 . I've found that `set_exceptions` is used also in `MessageBatch.failure()` but it is settings an exception that is passed as argument. I would need to change it's interface to pass some function that returns the exception so it can be called for every future in `MessageBatch._msg_future`. Do you agree or do you have another idea?