### PR TITLE
Fix race condition in record fetcher

### DIFF
--- a/aiokafka/consumer/fetcher.py
+++ b/aiokafka/consumer/fetcher.py
@@ -822,12 +822,15 @@ class Fetcher:
             if self._wait_empty_future is None \
                     or self._wait_empty_future.done():
                 self._wait_empty_future = create_future(loop=self._loop)
+
+            wait_empty_future = self._wait_empty_future
+
             done, _ = yield from asyncio.wait(
-                [self._wait_empty_future], timeout=timeout, loop=self._loop)
+                [wait_empty_future], timeout=timeout, loop=self._loop)
 
             # _wait_empty_future can be set an exception in `close()` call
             # to stop all long running tasks
-            if not done or self._wait_empty_future.exception() is not None:
+            if not done or wait_empty_future.exception() is not None:
                 return {}
 
             # Decrease timeout accordingly


### PR DESCRIPTION
Concurrent record consuming fails with `InvalidStateError('Exception is not set.')` in record fetcher. This fixes race condition.