### PR TITLE
Refactoring to allow fetcher to always reset offsets properly.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -98,5 +98,7 @@ To run tests with a specific version of Kafka (default one is 0.10.1.0) use KAFK
 Test running cheatsheat:
 
  * ``make test FLAGS="-l -x --ff"`` - run until 1 failure, rerun failed tests fitst. Great for cleaning up a lot of errors, say after a big refactor.
- * ``make test FLAGS="-k consumer --no-pull"`` - run only the consumer tests.
+ * ``make test FLAGS="-k consumer"`` - run only the consumer tests.
+ * ``make test FLAGS="-m 'not ssl'"`` - run tests excluding ssl.
+ * ``make test FLAGS="--no-pull"`` - do not try to pull new docker image before test run.
 

--- a/README.rst
+++ b/README.rst
@@ -94,3 +94,9 @@ Running tests::
 To run tests with a specific version of Kafka (default one is 0.10.1.0) use KAFKA_VERSION variable::
 
     make cov KAFKA_VERSION=0.10.0.0
+
+Test running cheatsheat:
+
+ * ``make test FLAGS="-l -x --ff"`` - run until 1 failure, rerun failed tests fitst. Great for cleaning up a lot of errors, say after a big refactor.
+ * ``make test FLAGS="-k consumer --no-pull"`` - run only the consumer tests.
+

--- a/aiokafka/client.py
+++ b/aiokafka/client.py
@@ -421,7 +421,7 @@ class AIOKafkaClient:
         """Attempt to guess the broker version"""
         if node_id is None:
             default_group_conns = [
-                node_id for (node_id, group) in self._conns.keys()
+                n_id for (n_id, group) in self._conns.keys()
                 if group == ConnectionGroup.DEFAULT
             ]
             if default_group_conns:

--- a/aiokafka/consumer/consumer.py
+++ b/aiokafka/consumer/consumer.py
@@ -374,10 +374,22 @@ class AIOKafkaConsumer(object):
                 to commit with the configured ``group_id``. Defaults to current
                 consumed offsets for all subscribed partitions.
         Raises:
-            IllegalOperation: If used with ``group_id == None``
-            ValueError: If offsets is of wrong format
+            IllegalOperation: If used with ``group_id == None``.
+            IllegalStateError: If partitions not assigned.
+            ValueError: If offsets is of wrong format.
+            CommitFailedError: If membership already changed on broker.
             KafkaError: If commit failed on broker side. This could be due to
                 invalid offset, too long metadata, authorization failure, etc.
+
+        .. versionchanged:: 0.4.0
+
+            Changed ``AssertionError`` to ``IllegalStateError`` in case of
+            unassigned partition.
+
+        .. versionchanged:: 0.4.0
+
+            Will now raise ``CommitFailedError`` in case membership changed,
+            as (posibly) this partition is handled by another consumer.
         """
         if self._group_id is None:
             raise IllegalOperation("Requires group_id")
@@ -501,6 +513,11 @@ class AIOKafkaConsumer(object):
 
         Raises:
             IllegalStateError: partition is not assigned
+
+        .. versionchanged:: 0.4.0
+
+            Changed ``AssertionError`` to ``IllegalStateError`` in case of
+            unassigned partition
         """
         while True:
             if not self._subscription.is_assigned(partition):

--- a/aiokafka/consumer/consumer.py
+++ b/aiokafka/consumer/consumer.py
@@ -515,6 +515,11 @@ class AIOKafkaConsumer(object):
                     return_when=asyncio.FIRST_COMPLETED, loop=self._loop,
                 )
                 if not tp_state.has_valid_position:
+                    if self._subscription.subscription is None:
+                        raise IllegalStateError(
+                            'Partition {} is not assigned'.format(partition))
+                    if self._subscription.subscription.assignment is None:
+                        yield from self._subscription.wait_for_assignment()
                     continue
             return tp_state.position
 

--- a/aiokafka/consumer/consumer.py
+++ b/aiokafka/consumer/consumer.py
@@ -199,9 +199,6 @@ class AIOKafkaConsumer(object):
         self._fetch_max_wait_ms = fetch_max_wait_ms
         self._max_partition_fetch_bytes = max_partition_fetch_bytes
         self._exclude_internal_topics = exclude_internal_topics
-        if max_poll_records is not None and (
-                not isinstance(max_poll_records, int) or max_poll_records < 1):
-            raise ValueError("`max_poll_records` should be positive Integer")
         self._max_poll_records = max_poll_records
         self._consumer_timeout = consumer_timeout_ms / 1000
         self._check_crcs = check_crcs

--- a/aiokafka/consumer/consumer.py
+++ b/aiokafka/consumer/consumer.py
@@ -883,6 +883,8 @@ class AIOKafkaConsumer(object):
     def unsubscribe(self):
         """ Unsubscribe from all topics and clear all assigned partitions. """
         self._subscription.unsubscribe()
+        if self._group_id is not None:
+            self._coordinator.maybe_leave_group()
         self._client.set_topics([])
         log.info(
             "Unsubscribed all topics or patterns and assigned partitions")

--- a/aiokafka/consumer/consumer.py
+++ b/aiokafka/consumer/consumer.py
@@ -3,9 +3,8 @@ import logging
 import re
 
 from kafka.coordinator.assignors.roundrobin import RoundRobinPartitionAssignor
-from kafka.consumer.subscription_state import SubscriptionState
-from kafka.protocol.offset import OffsetResetStrategy
 
+from aiokafka.abc import ConsumerRebalanceListener
 from aiokafka.client import AIOKafkaClient
 from aiokafka.errors import (
     KafkaError, TopicAuthorizationFailedError, OffsetOutOfRangeError,
@@ -13,11 +12,12 @@ from aiokafka.errors import (
     IllegalStateError
 )
 from aiokafka.structs import TopicPartition, OffsetAndMetadata
-from aiokafka.util import ensure_future, PY_35
+from aiokafka.util import PY_35
 from aiokafka import __version__
 
-from .fetcher import Fetcher
+from .fetcher import Fetcher, OffsetResetStrategy
 from .group_coordinator import GroupCoordinator, NoGroupCoordinator
+from .subscription_state import SubscriptionState
 
 log = logging.getLogger(__name__)
 
@@ -179,10 +179,15 @@ class AIOKafkaConsumer(object):
             security_protocol=security_protocol,
             connections_max_idle_ms=connections_max_idle_ms)
 
+        if max_poll_records is not None and (
+                not isinstance(max_poll_records, int) or max_poll_records < 1):
+            raise ValueError("`max_poll_records` should be positive Integer")
+
         self._group_id = group_id
         self._heartbeat_interval_ms = heartbeat_interval_ms
         self._session_timeout_ms = session_timeout_ms
         self._retry_backoff_ms = retry_backoff_ms
+        self._auto_offset_reset = auto_offset_reset
         self._request_timeout_ms = request_timeout_ms
         self._enable_auto_commit = enable_auto_commit
         self._auto_commit_interval_ms = auto_commit_interval_ms
@@ -199,17 +204,14 @@ class AIOKafkaConsumer(object):
         self._max_poll_records = max_poll_records
         self._consumer_timeout = consumer_timeout_ms / 1000
         self._check_crcs = check_crcs
-        self._subscription = SubscriptionState(auto_offset_reset)
+        self._subscription = SubscriptionState(loop=loop)
         self._fetcher = None
         self._coordinator = None
         self._closed = False
         self._loop = loop
 
-        # Set for background updates, so we'll finalize them properly. Only
-        # active tasks are in this set, as done ones are discarded by callback.
-        self._pending_position_fetches = set([])
-
         if topics:
+            topics = self._validate_topics(topics)
             self._client.set_topics(topics)
             self._subscription.subscribe(topics=topics)
 
@@ -237,7 +239,8 @@ class AIOKafkaConsumer(object):
             max_partition_fetch_bytes=self._max_partition_fetch_bytes,
             check_crcs=self._check_crcs,
             fetcher_timeout=self._consumer_timeout,
-            retry_backoff_ms=self._retry_backoff_ms)
+            retry_backoff_ms=self._retry_backoff_ms,
+            auto_offset_reset=self._auto_offset_reset)
 
         if self._group_id is not None:
             # using group coordinator for automatic partitions assignment
@@ -250,29 +253,33 @@ class AIOKafkaConsumer(object):
                 enable_auto_commit=self._enable_auto_commit,
                 auto_commit_interval_ms=self._auto_commit_interval_ms,
                 assignors=self._partition_assignment_strategy,
-                exclude_internal_topics=self._exclude_internal_topics,
-                assignment_changed_cb=self._on_change_subscription)
-
-            yield from self._coordinator.ensure_active_group()
+                exclude_internal_topics=self._exclude_internal_topics)
+            # In case we provided topics to constructor we better wait for
+            # initial group join
+            if self._subscription.subscription is not None:
+                yield from self._subscription.wait_for_assignment()
         else:
             # Using a simple assignment coordinator for reassignment on
             # metadata changes
             self._coordinator = NoGroupCoordinator(
                 self._client, self._subscription, loop=self._loop,
-                exclude_internal_topics=self._exclude_internal_topics,
-                assignment_changed_cb=self._on_change_subscription)
+                exclude_internal_topics=self._exclude_internal_topics)
 
             # If we passed `topics` to constructor.
-            if self._subscription.needs_partition_assignment:
+            if self._subscription.subscription is not None:
                 yield from self._client.force_metadata_update()
                 self._coordinator.assign_all_partitions(check_unknown=True)
 
     @asyncio.coroutine
     def _wait_topics(self):
-        if not self._subscription.subscription:
-            return
-        for topic in self._subscription.subscription:
-            yield from self._client._wait_on_metadata(topic)
+        if self._subscription.subscription is not None:
+            for topic in self._subscription.subscription.topics:
+                yield from self._client._wait_on_metadata(topic)
+
+    def _validate_topics(self, topics):
+        if not isinstance(topics, (tuple, set, list)):
+            raise ValueError("Topics should be list of strings")
+        return set(topics)
 
     def assign(self, partitions):
         """ Manually assign a list of TopicPartitions to this consumer.
@@ -298,7 +305,9 @@ class AIOKafkaConsumer(object):
         """
         self._subscription.assign_from_user(partitions)
         self._client.set_topics([tp.topic for tp in partitions])
-        self._on_change_subscription()
+        if self._group_id is not None:
+            # refresh commit positions for all assigned partitions
+            yield from self._coordinator.refresh_committed_offsets()
 
     def assignment(self):
         """ Get the set of partitions currently assigned to this consumer.
@@ -327,12 +336,6 @@ class AIOKafkaConsumer(object):
             return
         log.debug("Closing the KafkaConsumer.")
         self._closed = True
-        for task in list(self._pending_position_fetches):
-            task.cancel()
-            try:
-                yield from task
-            except asyncio.CancelledError:
-                pass
         if self._coordinator:
             yield from self._coordinator.close()
         if self._fetcher:
@@ -380,8 +383,15 @@ class AIOKafkaConsumer(object):
         if self._group_id is None:
             raise IllegalOperation("Requires group_id")
 
+        subscription = self._subscription.subscription
+        if subscription is None:
+            raise IllegalStateError("Not subscribed to any topics")
+        assignment = subscription.assignment
+        if assignment is None:
+            raise IllegalStateError("No partitions assigned")
+
         if offsets is None:
-            offsets = self._subscription.all_consumed_offsets()
+            offsets = assignment.all_consumed_offsets()
         else:
             # validate `offsets` structure
             if not offsets or not isinstance(offsets, dict):
@@ -391,6 +401,10 @@ class AIOKafkaConsumer(object):
             for tp, offset_and_metadata in offsets.items():
                 if not isinstance(tp, TopicPartition):
                     raise ValueError("Key should be TopicPartition instance")
+
+                if tp not in assignment.tps:
+                    raise IllegalStateError(
+                        "Partition {} is not assigned".format(tp))
 
                 if isinstance(offset_and_metadata, int):
                     offset, metadata = offset_and_metadata, ""
@@ -407,7 +421,7 @@ class AIOKafkaConsumer(object):
 
             offsets = formatted_offsets
 
-        yield from self._coordinator.commit_offsets(offsets)
+        yield from self._coordinator.commit_offsets(assignment, offsets)
 
     @asyncio.coroutine
     def committed(self, partition):
@@ -434,10 +448,12 @@ class AIOKafkaConsumer(object):
             raise IllegalOperation("Requires group_id")
 
         if self._subscription.is_assigned(partition):
-            committed = self._subscription.assignment[partition].committed
-            if committed is None:
-                yield from self._coordinator.refresh_committed_offsets()
-                committed = self._subscription.assignment[partition].committed
+            assignment = self._subscription.subscription.assignment
+            tp_state = assignment.state_value(partition)
+            if tp_state.committed is None:
+                yield from tp_state.wait_for_committed()
+            committed = tp_state.committed.offset
+
         else:
             commit_map = yield from self._coordinator.fetch_committed_offsets(
                 [partition])
@@ -445,6 +461,8 @@ class AIOKafkaConsumer(object):
                 committed = commit_map[partition].offset
             else:
                 committed = None
+        if committed == -1:
+            return None
         return committed
 
     @asyncio.coroutine
@@ -481,14 +499,25 @@ class AIOKafkaConsumer(object):
 
         Returns:
             int: offset
+
+        Raises:
+            IllegalStateError: partition is not assigned
         """
-        assert self._subscription.is_assigned(partition), \
-            'Partition is not assigned'
-        offset = self._subscription.assignment[partition].position
-        if offset is None:
-            yield from self._update_fetch_positions([partition])
-            offset = self._subscription.assignment[partition].position
-        return offset
+        while True:
+            if not self._subscription.is_assigned(partition):
+                raise IllegalStateError(
+                    'Partition {} is not assigned'.format(partition))
+            assignment = self._subscription.subscription.assignment
+            tp_state = assignment.state_value(partition)
+            if not tp_state.has_valid_position:
+                yield from asyncio.wait(
+                    [tp_state.wait_for_position(),
+                     assignment.unassign_future],
+                    return_when=asyncio.FIRST_COMPLETED, loop=self._loop,
+                )
+                if not tp_state.has_valid_position:
+                    continue
+            return tp_state.position
 
     def highwater(self, partition):
         """ Last known highwater offset for a partition.
@@ -510,7 +539,8 @@ class AIOKafkaConsumer(object):
         """
         assert self._subscription.is_assigned(partition), \
             'Partition is not assigned'
-        return self._subscription.assignment[partition].highwater
+        assignment = self._subscription.subscription.assignment
+        return assignment.state_value(partition).highwater
 
     def seek(self, partition, offset):
         """ Manually specify the fetch offset for a TopicPartition.
@@ -530,14 +560,18 @@ class AIOKafkaConsumer(object):
             offset (int): message offset in partition
 
         Raises:
-            AssertionError: if offset is not an int >= 0;
-                            or if partition is not currently assigned.
+            ValueError: if offset is not a positive integer
+            IllegalStateError: partition is not currently assigned
+
+        .. versionchanged:: 0.4.0
+
+            Changed ``AssertionError`` to ``IllegalStateError`` and
+            ``ValueError`` in respective cases.
         """
-        assert isinstance(offset, int) and offset >= 0, 'Offset must be >= 0'
-        assert partition in self._subscription.assigned_partitions(), \
-            'Unassigned partition'
+        if not isinstance(offset, int):
+            raise ValueError("Offset must be a positive integer")
         log.debug("Seeking to offset %s for partition %s", offset, partition)
-        self._subscription.assignment[partition].seek(offset)
+        self._subscription.seek(partition, offset)
 
     @asyncio.coroutine
     def seek_to_beginning(self, *partitions):
@@ -557,8 +591,6 @@ class AIOKafkaConsumer(object):
         if not all([isinstance(p, TopicPartition) for p in partitions]):
             raise TypeError('partitions must be TopicPartition instances')
 
-        yield from self._coordinator.ensure_partitions_assigned()
-
         if not partitions:
             partitions = self._subscription.assigned_partitions()
             assert partitions, 'No partitions are currently assigned'
@@ -572,9 +604,8 @@ class AIOKafkaConsumer(object):
 
         for tp in partitions:
             log.debug("Seeking to beginning of partition %s", tp)
-            self._subscription.need_offset_reset(
-                tp, OffsetResetStrategy.EARLIEST)
-        yield from self._fetcher.update_fetch_positions(partitions)
+        yield from self._fetcher.request_offset_reset(
+            partitions, OffsetResetStrategy.EARLIEST)
 
     @asyncio.coroutine
     def seek_to_end(self, *partitions):
@@ -594,8 +625,6 @@ class AIOKafkaConsumer(object):
         if not all([isinstance(p, TopicPartition) for p in partitions]):
             raise TypeError('partitions must be TopicPartition instances')
 
-        yield from self._coordinator.ensure_partitions_assigned()
-
         if not partitions:
             partitions = self._subscription.assigned_partitions()
             assert partitions, 'No partitions are currently assigned'
@@ -609,9 +638,8 @@ class AIOKafkaConsumer(object):
 
         for tp in partitions:
             log.debug("Seeking to end of partition %s", tp)
-            self._subscription.need_offset_reset(
-                tp, OffsetResetStrategy.LATEST)
-        yield from self._fetcher.update_fetch_positions(partitions)
+        yield from self._fetcher.request_offset_reset(
+            partitions, OffsetResetStrategy.LATEST)
 
     @asyncio.coroutine
     def seek_to_committed(self, *partitions):
@@ -633,8 +661,6 @@ class AIOKafkaConsumer(object):
         if not all([isinstance(p, TopicPartition) for p in partitions]):
             raise TypeError('partitions must be TopicPartition instances')
 
-        yield from self._coordinator.ensure_partitions_assigned()
-
         if not partitions:
             partitions = self._subscription.assigned_partitions()
             assert partitions, 'No partitions are currently assigned'
@@ -647,8 +673,8 @@ class AIOKafkaConsumer(object):
                     "Partitions {} are not assigned".format(not_assigned))
 
         for tp in partitions:
-            log.debug("Seeking to committed of partition %s", tp)
             offset = yield from self.committed(tp)
+            log.debug("Seeking to committed of partition %s %s", tp, offset)
             if offset and offset > 0:
                 self.seek(tp, offset)
 
@@ -818,89 +844,41 @@ class AIOKafkaConsumer(object):
         if topics and pattern:
             raise ValueError(
                 "You can't provide both `topics` and `pattern`")
-        if pattern:
+        if listener is not None and \
+                not isinstance(listener, ConsumerRebalanceListener):
+            raise TypeError(
+                "listener should be an instance of ConsumerRebalanceListener")
+        if pattern is not None:
             try:
-                re.compile(pattern)
+                pattern = re.compile(pattern)
             except re.error as err:
                 raise ValueError(
                     "{!r} is not a valid pattern: {}".format(pattern, err))
-
-        # SubscriptionState handles error checking
-        self._subscription.subscribe(topics=topics,
-                                     pattern=pattern,
-                                     listener=listener)
-        # There's a bug in subscription, that pattern is not unset if we change
-        # from pattern to simple topic subscription
-        if not pattern:
-            self._subscription.subscribed_pattern = None
-
-        # regex will need all topic metadata
-        if pattern is not None:
+            self._subscription.subscribe_pattern(
+                pattern=pattern, listener=listener)
             self._client.set_topics([])
-            log.debug("Subscribed to topic pattern: %s", pattern)
-        else:
-            self._client.set_topics(self._subscription.group_subscription())
-            log.debug("Subscribed to topic(s): %s", topics)
+            log.info("Subscribed to topic pattern: %s", pattern)
+        elif topics:
+            topics = self._validate_topics(topics)
+            self._subscription.subscribe(
+                topics=topics, listener=listener)
+            self._client.set_topics(self._subscription.subscription.topics)
+            log.info("Subscribed to topic(s): %s", topics)
 
     def subscription(self):
         """ Get the current topic subscription.
 
         Returns:
-            set: {topic, ...}
+            frozenset: {topic, ...}
         """
-        return frozenset(self._subscription.subscription or [])
+        return self._subscription.subscription.topics
 
     def unsubscribe(self):
         """ Unsubscribe from all topics and clear all assigned partitions. """
         self._subscription.unsubscribe()
         self._client.set_topics([])
-        log.debug(
+        log.info(
             "Unsubscribed all topics or patterns and assigned partitions")
-
-    @asyncio.coroutine
-    def _update_fetch_positions(self, partitions):
-        """
-        Set the fetch position to the committed position (if there is one)
-        or reset it using the offset reset policy the user has configured.
-
-        Arguments:
-            partitions (List[TopicPartition]): The partitions that need
-                updating fetch positions
-
-        Raises:
-            NoOffsetForPartitionError: If no offset is stored for a given
-                partition and no offset reset policy is defined
-        """
-        if self._group_id is not None:
-            # refresh commits for all assigned partitions
-            yield from self._coordinator.refresh_committed_offsets()
-
-        # then do any offset lookups in case some positions are not known
-        yield from self._fetcher.update_fetch_positions(partitions)
-
-    def _on_change_subscription(self):
-        """ This is `group rebalanced` signal handler used to update fetch
-            positions of assigned partitions
-        """
-        if self._closed:  # pragma: no cover
-            return
-        # fetch positions if we have partitions we're subscribed
-        # to that we don't know the offset for
-        if not self._subscription.has_all_fetch_positions():
-            task = ensure_future(
-                self._update_fetch_positions(
-                    self._subscription.missing_fetch_positions()),
-                loop=self._loop
-            )
-            self._pending_position_fetches.add(task)
-
-            def on_done(fut, tasks=self._pending_position_fetches):
-                tasks.discard(fut)
-                try:
-                    fut.result()
-                except Exception as err:  # pragma: no cover
-                    log.error("Failed to update fetch positions: %r", err)
-            task.add_done_callback(on_done)
 
     @asyncio.coroutine
     def getone(self, *partitions):

--- a/aiokafka/consumer/consumer.py
+++ b/aiokafka/consumer/consumer.py
@@ -572,7 +572,7 @@ class AIOKafkaConsumer(object):
             Changed ``AssertionError`` to ``IllegalStateError`` and
             ``ValueError`` in respective cases.
         """
-        if not isinstance(offset, int):
+        if not isinstance(offset, int) or offset < 0:
             raise ValueError("Offset must be a positive integer")
         log.debug("Seeking to offset %s for partition %s", offset, partition)
         self._fetcher.seek_to(partition, offset)

--- a/aiokafka/consumer/fetcher.py
+++ b/aiokafka/consumer/fetcher.py
@@ -317,6 +317,7 @@ class Fetcher:
                             task.cancel()
                         yield from task
                     self._pending_tasks.clear()
+                    self._records.clear()
 
                     subscription = self._subscriptions.subscription
                     if subscription is None or \
@@ -545,6 +546,7 @@ class Fetcher:
         partition. It may be right after assignment, on seek_to_* calls of
         Consumer or if current position went out of range.
         """
+        log.debug("Updating fetch positions for partitions %s", tps)
         needs_wakeup = False
         # The list of partitions provided can consist of paritions that are
         # awaiting reset already and freshly assigned partitions. The second

--- a/aiokafka/consumer/fetcher.py
+++ b/aiokafka/consumer/fetcher.py
@@ -455,7 +455,11 @@ class Fetcher:
             # is no longer of interest.
             return False
 
-        assert assignment.active
+        if not assignment.active:
+            log.debug(
+                "Discarding fetch response since the assignment changed during"
+                " fetch")
+            return False
 
         fetch_offsets = {}
         for topic, partitions in request.topics:

--- a/aiokafka/consumer/fetcher.py
+++ b/aiokafka/consumer/fetcher.py
@@ -4,7 +4,7 @@ import logging
 import random
 from itertools import chain
 
-from kafka.protocol.offset import OffsetRequest, OffsetResetStrategy
+from kafka.protocol.offset import OffsetRequest
 
 from aiokafka.consumer.fetch import FetchRequest
 import aiokafka.errors as Errors
@@ -19,16 +19,54 @@ log = logging.getLogger(__name__)
 UNKNOWN_OFFSET = -1
 
 
+class OffsetResetStrategy:
+    LATEST = -1
+    EARLIEST = -2
+    NONE = 0
+
+    @classmethod
+    def from_str(cls, name):
+        name = name.lower()
+        if name == "latest":
+            return cls.LATEST
+        if name == "earliest":
+            return cls.EARLIEST
+        if name == "none":
+            return cls.NONE
+        else:
+            log.warning(
+                'Unrecognized ``auto_offset_reset`` config, using NONE')
+            return cls.NONE
+
+    @classmethod
+    def to_str(cls, value):
+        if value == cls.LATEST:
+            return "latest"
+        if value == cls.EARLIEST:
+            return "earliest"
+        if value == cls.NONE:
+            return "none"
+        else:
+            return "timestamp({})".format(value)
+
+
 class FetchResult:
     def __init__(
-            self, tp, *, subscriptions, loop, records, backoff):
+            self, tp, *, assignment, loop, message_iterator, backoff,
+            fetch_offset):
         self._topic_partition = tp
-        self._subscriptions = subscriptions
-        self._message_iter = records
+        self._message_iter = message_iterator
 
         self._created = loop.time()
         self._backoff = backoff
         self._loop = loop
+
+        self._assignment = assignment
+        # There are cases where the returned offset from broker differs from
+        # what was requested. This would not be much of an issue if the user
+        # could not seek to a different position between yielding results,
+        # so we can't reliably say witch case it is without a new veriable.
+        self._expected_position = fetch_offset
 
     def calculate_backoff(self):
         lifetime = self._loop.time() - self._created
@@ -37,8 +75,17 @@ class FetchResult:
         return 0
 
     def check_assignment(self, tp):
-        if self._subscriptions.needs_partition_assignment or \
-                not self._subscriptions.is_fetchable(tp):
+        assignment = self._assignment
+        return_result = True
+        if assignment.active:
+            tp = self._topic_partition
+            position = assignment.state_value(tp).position
+            if position != self._expected_position:
+                return_result = False
+        else:
+            return_result = False
+
+        if not return_result:
             # this can happen when a rebalance happened before
             # fetched records are returned
             log.debug("Not returning fetched records for partition %s"
@@ -47,12 +94,16 @@ class FetchResult:
             return False
         return True
 
+    def _consume_offset(self, offset):
+        position = self._expected_position = offset + 1
+        state = self._assignment.state_value(self._topic_partition)
+        state.consumed_to(position)
+
     def getone(self):
         tp = self._topic_partition
         if not self.check_assignment(tp) or not self.has_more():
             return
 
-        tp_assignment = self._subscriptions.assignment[tp]
         next_batch_iter = self._message_iter
         while True:
             try:
@@ -61,17 +112,15 @@ class FetchResult:
                 self._message_iter = None
                 return
 
-            if msg.offset < tp_assignment.position:
+            if msg.offset < self._expected_position:
                 # Probably just a compressed messageset, it's ok to skip.
                 continue
-            elif (msg.offset > tp_assignment.position and
-                    tp_assignment.drop_pending_message_set):
-                # We seeked to a different position between `get*` calls,
-                # so we can't verify if the message is correct.
-                self._message_iter = None
-                return
 
-            tp_assignment.position = msg.offset + 1
+            # It's not a problem if the offset is larger than expected
+            # position. It may happen in compacted topics, some messages were
+            # just removed.
+
+            self._consume_offset(msg.offset)
             return msg
 
     def getall(self, max_records=None):
@@ -79,32 +128,23 @@ class FetchResult:
         if not self.check_assignment(tp) or not self.has_more():
             return []
 
-        tp_assignment = self._subscriptions.assignment[tp]
         next_batch_iter = self._message_iter
-        try:
-            first_msg = next(next_batch_iter)
-        except StopIteration:
-            self._message_iter = None
-            return []
-
-        # In getall() we do this check only for the first message, other ones
-        # were fetched in the same call, so should be valid as well.
-        if first_msg.offset > tp_assignment.position:
-            if tp_assignment.drop_pending_message_set:
-                # We seeked to a different position between `get*` calls,
-                # so we can't verify if the message is correct.
-                self._message_iter = None
-                return []
-
         ret_list = []
-        for msg in chain([first_msg], next_batch_iter):
-            if msg.offset < tp_assignment.position:
+        for msg in next_batch_iter:
+            if msg.offset < self._expected_position:
                 # Probably just a compressed messageset, it's ok.
                 continue
+            # As in the `getone` case it's ok if offset is larger than expected
+
             ret_list.append(msg)
             if max_records is not None and len(ret_list) >= max_records:
                 break
-        tp_assignment.position = ret_list[-1].offset + 1
+        else:
+            self._message_iter = None
+
+        if ret_list:
+            self._consume_offset(ret_list[-1].offset)
+
         return ret_list
 
     def has_more(self):
@@ -139,7 +179,8 @@ class Fetcher:
                  check_crcs=True,
                  fetcher_timeout=0.2,
                  prefetch_backoff=0.1,
-                 retry_backoff_ms=100):
+                 retry_backoff_ms=100,
+                 auto_offset_reset='latest'):
         """Initialize a Kafka Message Fetcher.
 
         Parameters:
@@ -175,6 +216,10 @@ class Fetcher:
                 consumption of partition is paused. Paused partitions will not
                 request new data from Kafka server (will not be included in
                 next poll request).
+            auto_offset_reset (str): A policy for resetting offsets on
+                OffsetOutOfRange errors: 'earliest' will move to the oldest
+                available message, 'latest' will move to the most recent. Any
+                ofther value will raise the exception. Default: 'latest'.
         """
         self._client = client
         self._loop = loop
@@ -188,10 +233,12 @@ class Fetcher:
         self._prefetch_backoff = prefetch_backoff
         self._retry_backoff = retry_backoff_ms / 1000
         self._subscriptions = subscriptions
+        self._default_reset_strategy = OffsetResetStrategy.from_str(
+            auto_offset_reset)
 
         self._records = collections.OrderedDict()
         self._in_flight = set()
-        self._fetch_tasks = set()
+        self._pending_tasks = set()
 
         self._wait_consume_future = None
         self._wait_empty_future = None
@@ -215,167 +262,192 @@ class Fetcher:
                 not self._wait_empty_future.done():
             self._wait_empty_future.set_exception(ConsumerStoppedError())
 
-        for x in self._fetch_tasks:
+        for x in self._pending_tasks:
             x.cancel()
-            try:
-                yield from x
-            except asyncio.CancelledError:
-                pass
-
-    @asyncio.coroutine
-    def _fetch_requests_routine(self):
-        """ Background task, that always prefetches next result page.
-
-        The algorithm:
-        * Group partitions per node, which is the leader for it.
-        * If all partitions for this node need prefetch - do it right away
-        * If any partition has some data (in `self._records`) wait up till
-          `prefetch_backoff` so application can consume data from it.
-        * If data in `self._records` is not consumed up to
-          `prefetch_backoff` just request data for other partitions from this
-          node.
-
-        We request data in such manner cause Kafka blocks the connection if
-        we perform a FetchRequest and we don't have enough data. This means
-        we must perform a FetchRequest to as many partitions as we can in a
-        node.
-
-        Original Java Kafka client processes data differently, as it only
-        prefetches data if all messages were given to application (i.e. if
-        `self._records` are empty). We don't use this method, cause we allow
-        to process partitions separately (by passing `partitions` list to
-        `getall()` call of the consumer), which can end up in a long wait
-        if some partitions (or topics) are processed slower, than others.
-
-        """
-        try:
-            while True:
-                # Reset consuming signal future.
-                self._wait_consume_future = create_future(loop=self._loop)
-                # Create and send fetch requests
-                requests, timeout = self._create_fetch_requests()
-                for node_id, request in requests:
-                    node_ready = yield from self._client.ready(node_id)
-                    if not node_ready:
-                        # We will request it on next routine
-                        continue
-                    log.debug("Sending FetchRequest to node %s", node_id)
-                    task = ensure_future(
-                        self._proc_fetch_request(node_id, request),
-                        loop=self._loop)
-                    self._fetch_tasks.add(task)
-                    self._in_flight.add(node_id)
-
-                done_set, _ = yield from asyncio.wait(
-                    chain(self._fetch_tasks, [self._wait_consume_future]),
-                    loop=self._loop,
-                    timeout=timeout,
-                    return_when=asyncio.FIRST_COMPLETED)
-
-                # Process fetch tasks results if any
-                done_fetches = self._fetch_tasks.intersection(done_set)
-                if done_fetches:
-                    has_new_data = any(fut.result() for fut in done_fetches)
-                    if has_new_data:
-                        # we added some messages to self._records,
-                        # wake up getters
-                        self._notify(self._wait_empty_future)
-                    self._fetch_tasks -= done_fetches
-        except asyncio.CancelledError:
-            pass
-        except Exception:  # pragma: no cover
-            log.error("Unexpected error in fetcher routine", exc_info=True)
+            yield from x
 
     def _notify(self, future):
         if future is not None and not future.done():
             future.set_result(None)
 
-    def _create_fetch_requests(self):
-        """Create fetch requests for all assigned partitions, grouped by node.
+    @asyncio.coroutine
+    def _fetch_requests_routine(self):
+        """ Implements a background task to populate internal fetch queue
+        ``self._records`` with prefetched messages. This helps isolate the
+        ``getall/getone`` calls from actual calls to broker. This way we don't
+        need to think of what happens if user calls get in 2 tasks, etc.
 
-        FetchRequests skipped if:
-        * no leader, or node has already fetches in flight
-        * we have data for this partition
-        * we have data for other partitions on this node
+            The loop is quite complicated due to a large set of events that
+        can allow new fetches to be send. Those include previous fetches,
+        offset resets, metadata updates to discover new leaders for partitions,
+        data consumed for partition.
 
-        Returns:
-            dict: {node_id: FetchRequest, ...}
+            Previously the offset reset was performed separately, but it did
+        not perform too reliably. In ``kafka-python`` and Java client the reset
+        is perform in ``poll()`` before each fetch, which works good for sync
+        systems. But with ``aiokafka`` the user can actually break such
+        behaviour quite easily by performing actions from different tasks.
         """
-        if self._subscriptions.needs_partition_assignment:
-            return {}, self._fetcher_timeout
+        try:
+            assignment = None
+            while True:
+                # If we lose assignment we just cancel all current tasks,
+                # wait for new assignment and restart the loop
+                if assignment is None or not assignment.active:
+                    for task in self._pending_tasks:
+                        # Those tasks should have proper handling for
+                        # cancellation
+                        if not task.done():
+                            task.cancel()
+                        yield from task
+                    self._pending_tasks.clear()
 
+                    subscription = self._subscriptions.subscription
+                    if subscription is None or \
+                            subscription.assignment is None:
+                        yield from self._subscriptions.wait_for_assignment()
+                    assignment = self._subscriptions.subscription.assignment
+                assert assignment is not None and assignment.active
+
+                # Reset consuming signal future.
+                self._wait_consume_future = create_future(loop=self._loop)
+                # Determine what action to take per node
+                fetch_requests, reset_requests, timeout, invalid_metadata = \
+                    self._get_actions_per_node(assignment)
+                # Start fetch tasks
+                for node_id, request in fetch_requests:
+                    task = ensure_future(
+                        self._proc_fetch_request(assignment, node_id, request),
+                        loop=self._loop)
+                    self._pending_tasks.add(task)
+                    self._in_flight.add(node_id)
+                # Start update position tasks
+                for node_id, tps in reset_requests.items():
+                    task = ensure_future(
+                        self._update_fetch_positions(assignment, node_id, tps),
+                        loop=self._loop)
+                    self._pending_tasks.add(task)
+                    self._in_flight.add(node_id)
+                # Apart from pending requests we also need to react to other
+                # events to send new fetches as soon as possible
+                other_futs = [self._wait_consume_future,
+                              assignment.unassign_future]
+                if invalid_metadata:
+                    fut = self._client.force_metadata_update()
+                    other_futs.append(fut)
+
+                done_set, _ = yield from asyncio.wait(
+                    chain(self._pending_tasks, other_futs),
+                    loop=self._loop,
+                    timeout=timeout,
+                    return_when=asyncio.FIRST_COMPLETED)
+
+                # Process fetch tasks results if any
+                done_pending = self._pending_tasks.intersection(done_set)
+                if done_pending:
+                    has_new_data = any(fut.result() for fut in done_pending)
+                    if has_new_data:
+                        # we added some messages to self._records,
+                        # wake up getters
+                        self._notify(self._wait_empty_future)
+                    self._pending_tasks -= done_pending
+        except asyncio.CancelledError:
+            pass
+        except Exception:  # pragma: no cover
+            log.error("Unexpected error in fetcher routine", exc_info=True)
+
+    def _get_actions_per_node(self, assignment):
+        """ For each assigned partition determine the action needed to be
+        performed and group those by leader node id.
+        """
         # create the fetch info as a dict of lists of partition info tuples
         # which can be passed to FetchRequest() via .items()
-        fetchable = collections.defaultdict(
-            lambda: collections.defaultdict(list))
+        fetchable = collections.defaultdict(list)
+        awaiting_reset = collections.defaultdict(list)
         backoff_by_nodes = collections.defaultdict(list)
+        invalid_metadata = False
 
-        fetchable_partitions = self._subscriptions.fetchable_partitions()
-        for tp in fetchable_partitions:
+        for tp in assignment.tps:
+            tp_state = assignment.state_value(tp)
             node_id = self._client.cluster.leader_for_partition(tp)
-            if tp in self._records:
-                record = self._records[tp]
-                # Calculate backoff for this node if data is only recently
-                # fetched. If data is consumed before backoff we will
-                # include this partition in this fetch request
-                backoff = record.calculate_backoff()
-                if backoff:
-                    backoff_by_nodes[node_id].append(backoff)
-                # We have some prefetched data for this partition already
-                continue
+            backoff = 0
             if node_id in self._in_flight:
                 # We have in-flight fetches to this node
                 continue
-            if node_id is None or node_id == -1:
+            elif node_id is None or node_id == -1:
                 log.debug("No leader found for partition %s."
                           " Waiting metadata update", tp)
+                invalid_metadata = True
+            elif not tp_state.has_valid_position:
+                awaiting_reset[node_id].append(tp)
+            # We moved this below to be after reset condition. We need to reset
+            # right away, even if the cache contains results.
+            elif tp in self._records:
+                # We have data still not consumed by user. In this case we
+                # usually wait for the user to finish consumption, but to avoid
+                # blocking other partitions we have a timeout here.
+                record = self._records[tp]
+                backoff = record.calculate_backoff()
+                if backoff:
+                    backoff_by_nodes[node_id].append(backoff)
             else:
-                # fetch if there is a leader and no in-flight requests
-                position = self._subscriptions.assignment[tp].position
-                partition_info = (
-                    tp.partition,
-                    position,
-                    self._max_partition_fetch_bytes)
-                fetchable[node_id][tp.topic].append(partition_info)
+                position = tp_state.position
+                fetchable[node_id].append((tp, position))
                 log.debug(
                     "Adding fetch request for partition %s at offset %d",
                     tp, position)
 
-        requests = []
+        fetch_requests = []
         for node_id, partition_data in fetchable.items():
-            # Shuffle partition data to help get more equal consumption
-            partition_data = list(partition_data.items())
-            random.shuffle(partition_data)  # shuffle topics
-            for _, partition in partition_data:
-                random.shuffle(partition)  # shuffle partitions
             if node_id in backoff_by_nodes:
                 # At least one partition is still waiting to be consumed
                 continue
+            if node_id in awaiting_reset:
+                # First we need to reset offset for some partitions, then we
+                # will fetch next page of results
+                continue
+
+            # Shuffle partition data to help get more equal consumption
+            random.shuffle(partition_data)  # shuffle topics
+            # Create fetch request
+            by_topics = collections.defaultdict(list)
+            for tp, position in partition_data:
+                by_topics[tp.topic].append((
+                    tp.partition,
+                    position,
+                    self._max_partition_fetch_bytes))
             req = self._fetch_request_class(
                 -1,  # replica_id
                 self._fetch_max_wait_ms,
                 self._fetch_min_bytes,
-                partition_data)
-            requests.append((node_id, req))
+                list(by_topics.items()))
+            fetch_requests.append((node_id, req))
+
         if backoff_by_nodes:
-            # Return min time til any node will be ready to send event
+            # Return min time till any node will be ready to send event
             # (max of it's backoffs)
             backoff = min(map(max, backoff_by_nodes.values()))
         else:
             backoff = self._fetcher_timeout
-        return requests, backoff
+        return fetch_requests, awaiting_reset, backoff, invalid_metadata
 
     @asyncio.coroutine
-    def _proc_fetch_request(self, node_id, request):
+    def _proc_fetch_request(self, assignment, node_id, request):
         needs_wakeup = False
-        needs_position_update = []
+
         try:
             response = yield from self._client.send(node_id, request)
         except Errors.KafkaError as err:
             log.error("Failed fetch messages from %s: %s", node_id, err)
             return False
+        except asyncio.CancelledError:
+            # Either `close()` or partition unassigned. Either way the result
+            # is no longer of interest.
+            return False
         finally:
             self._in_flight.remove(node_id)
+
+        assert assignment.active
 
         fetch_offsets = {}
         for topic, partitions in request.topics:
@@ -386,21 +458,11 @@ class Fetcher:
             for partition, error_code, highwater, raw_batch in partitions:
                 tp = TopicPartition(topic, partition)
                 error_type = Errors.for_code(error_code)
-                if not self._subscriptions.is_fetchable(tp):
-                    # this can happen when a rebalance happened
-                    log.debug("Ignoring fetched records for partition %s"
-                              " since it is no longer fetchable", tp)
+                fetch_offset = fetch_offsets[tp]
+                tp_state = assignment.state_value(tp)
 
-                elif error_type is Errors.NoError:
-                    tp_assignment = self._subscriptions.assignment[tp]
-                    tp_assignment.highwater = highwater
-
-                    # `drop_pending_message_set` is set after a seek to another
-                    # position. If we request the *new* position we have to
-                    # drop this flag, so we catch future seek's.
-                    fetch_offset = fetch_offsets[tp]
-                    if fetch_offset == tp_assignment.position:
-                        tp_assignment.drop_pending_message_set = False
+                if error_type is Errors.NoError:
+                    tp_state.highwater = highwater
 
                     records = MemoryRecords(raw_batch)
                     if records.has_next():
@@ -411,9 +473,10 @@ class Fetcher:
 
                         message_iterator = self._unpack_records(tp, records)
                         self._records[tp] = FetchResult(
-                            tp, records=message_iterator,
-                            subscriptions=self._subscriptions,
+                            tp, message_iterator=message_iterator,
+                            assignment=assignment,
                             backoff=self._prefetch_backoff,
+                            fetch_offset=fetch_offset,
                             loop=self._loop)
 
                         # We added at least 1 successful record
@@ -430,17 +493,16 @@ class Fetcher:
                             "message size the broker will allow.",
                             tp, fetch_offset, self._max_partition_fetch_bytes)
                         self._set_error(tp, err)
+                        tp_state.consumed_to(tp_state.position + 1)
                         needs_wakeup = True
-                        self._subscriptions.assignment[tp].position += 1
 
                 elif error_type in (Errors.NotLeaderForPartitionError,
                                     Errors.UnknownTopicOrPartitionError):
-                    self._client.force_metadata_update()
+                    yield from self._client.force_metadata_update()
                 elif error_type is Errors.OffsetOutOfRangeError:
-                    fetch_offset = fetch_offsets[tp]
-                    if self._subscriptions.has_default_offset_reset_policy():
-                        self._subscriptions.need_offset_reset(tp)
-                        needs_position_update.append(tp)
+                    if self._default_reset_strategy != \
+                            OffsetResetStrategy.NONE:
+                        tp_state.await_reset(tp, self._default_reset_strategy)
                     else:
                         err = Errors.OffsetOutOfRangeError({tp: fetch_offset})
                         self._set_error(tp, err)
@@ -456,14 +518,6 @@ class Fetcher:
                 else:
                     log.warn('Unexpected error while fetching data: %s',
                              error_type.__name__)
-
-        if needs_position_update:
-            try:
-                yield from self.update_fetch_positions(needs_position_update)
-            except Exception:  # pragma: no cover
-                log.error(
-                    "Unexpected error updating fetch positions", exc_info=True)
-
         return needs_wakeup
 
     def _set_error(self, tp, error):
@@ -472,109 +526,85 @@ class Fetcher:
             error=error, backoff=self._prefetch_backoff, loop=self._loop)
 
     @asyncio.coroutine
-    def update_fetch_positions(self, partitions):
-        """Update the fetch positions for the provided partitions.
-
-        Arguments:
-            partitions (list of TopicPartitions): partitions to update
-
-        Raises:
-            NoOffsetForPartitionError: if no offset is stored for a given
-                partition and no reset policy is available
+    def _update_fetch_positions(self, assignment, node_id, tps):
+        """ This task will be called if there is no valid position for
+        partition. It may be right after assignment, on seek_to_* calls of
+        Consumer or if current position went out of range.
         """
-        futures = []
-        # reset the fetch position to the committed position
-        for tp in partitions:
-            if not self._subscriptions.is_assigned(tp):
-                log.warning("partition %s is not assigned - skipping offset"
-                            " update", tp)
-                continue
-            elif self._subscriptions.is_fetchable(tp):
-                log.warning(
-                    "partition %s is still fetchable -- skipping offset"
-                    " update", tp)
+        needs_wakeup = False
+        # The list of partitions provided can consist of paritions that are
+        # awaiting reset already and freshly assigned partitions. The second
+        # ones can yet have no commit point fetched, so we will check that.
+        for tp in tps:
+            tp_state = assignment.state_value(tp)
+            if tp_state.awaiting_reset:
                 continue
 
-            assignment = self._subscriptions.assignment[tp]
-            if self._subscriptions.is_offset_reset_needed(tp):
-                log.debug("partition %s needs offset reset", tp)
-                futures.append(self._reset_offset(tp, assignment))
-            elif self._subscriptions.assignment[tp].committed is None:
-                # there's no committed position, so we need to reset with the
-                # default strategy
-                log.debug(
-                    "partition %s has no committed position, resetting with"
-                    " default strategy", tp)
-                self._subscriptions.need_offset_reset(tp)
-                futures.append(self._reset_offset(tp, assignment))
-            else:
-                committed = self._subscriptions.assignment[tp].committed
-                log.debug("Resetting offset for partition %s to the committed"
-                          " offset %s", tp, committed)
-                self._subscriptions.seek(tp, committed)
+            committed = tp_state.committed
+            # None means the Coordinator has yet to update the offset
+            if committed is None:
+                try:
+                    yield from tp_state.wait_for_committed()
+                except asyncio.CancelledError:
+                    self._in_flight.remove(node_id)
+                    return needs_wakeup
+                committed = tp_state.committed
+            assert committed is not None
 
-        if futures:
-            yield from asyncio.gather(*futures, loop=self._loop)
-
-    @asyncio.coroutine
-    def get_offsets_by_times(self, timestamps, timeout_ms):
-        offsets = yield from self._retrieve_offsets(timestamps, timeout_ms)
-        for tp in timestamps:
-            if tp not in offsets:
-                offsets[tp] = None
-            else:
-                offset, timestamp = offsets[tp]
-                if offset == UNKNOWN_OFFSET:
-                    offsets[tp] = None
+            if committed.offset == UNKNOWN_OFFSET:
+                # No offset stored in Kafka, need to reset
+                if self._default_reset_strategy != OffsetResetStrategy.NONE:
+                    tp_state.await_reset(self._default_reset_strategy)
                 else:
-                    offsets[tp] = OffsetAndTimestamp(offset, timestamp)
-        return offsets
+                    err = Errors.NoOffsetForPartitionError(tp)
+                    self._set_error(tp, err)
+                    needs_wakeup = True
+                log.debug(
+                    "No committed offset found for %s", tp)
+            else:
+                # There could have been a seek() call of some sort while
+                # waiting for committed point
+                if not tp_state.has_valid_position and not \
+                        tp_state.awaiting_reset:
+                    log.debug("Resetting offset for partition %s to the "
+                              "committed offset %s", tp, committed)
+                    tp_state.reset_to(committed.offset)
 
-    @asyncio.coroutine
-    def beginning_offsets(self, partitions, timeout_ms):
-        timestamps = {tp: OffsetResetStrategy.EARLIEST for tp in partitions}
-        offsets = yield from self._retrieve_offsets(timestamps, timeout_ms)
-        return {
-            tp: offset for (tp, (offset, ts)) in offsets.items()
-        }
+        topic_data = collections.defaultdict(list)
+        needs_reset = []
+        for tp in tps:
+            tp_state = assignment.state_value(tp)
+            if tp_state.awaiting_reset:
+                needs_reset.append(tp)
+            else:
+                continue
 
-    @asyncio.coroutine
-    def end_offsets(self, partitions, timeout_ms):
-        timestamps = {tp: OffsetResetStrategy.LATEST for tp in partitions}
-        offsets = yield from self._retrieve_offsets(timestamps, timeout_ms)
-        return {
-            tp: offset for (tp, (offset, ts)) in offsets.items()
-        }
+            strategy = tp_state.reset_strategy
+            assert strategy is not None
+            log.debug("Resetting offset for partition %s using %s strategy.",
+                      tp, OffsetResetStrategy.to_str(strategy))
+            topic_data[tp.topic].append((tp.partition, strategy))
 
-    @asyncio.coroutine
-    def _reset_offset(self, partition, assignment):
-        """Reset offsets for the given partition using
-        the offset reset strategy.
+        if not topic_data:
+            return needs_wakeup
 
-        Arguments:
-            partition (TopicPartition): the partition that needs reset offset
+        try:
+            offsets = yield from self._proc_offset_request(node_id, topic_data)
+        except Errors.KafkaError as err:
+            log.error("Failed fetch offsets from %s: %s", node_id, err)
+            return needs_wakeup
+        except asyncio.CancelledError:
+            return needs_wakeup
+        finally:
+            self._in_flight.remove(node_id)
 
-        Raises:
-            NoOffsetForPartitionError: if no offset reset strategy is defined
-        """
-        timestamp = assignment.reset_strategy
-        assert timestamp is not None
-        if timestamp is OffsetResetStrategy.EARLIEST:
-            strategy = 'earliest'
-        else:
-            strategy = 'latest'
-
-        log.debug("Resetting offset for partition %s to %s offset.",
-                  partition, strategy)
-        offsets = yield from self._retrieve_offsets({partition: timestamp})
-        assert partition in offsets
-        offset = offsets[partition][0]
-
-        # we might lose the assignment while fetching the offset,
-        # so check it is still active
-        if self._subscriptions.is_assigned(partition) and \
-                self._subscriptions.assignment[partition] is assignment:
-            self._subscriptions.seek(partition, offset)
+        for tp in needs_reset:
+            offset = offsets[tp][0]
+            tp_state = assignment.state_value(tp)
+            # There could have been some `seek` call while fetching offset
+            if tp_state.awaiting_reset:
+                tp_state.reset_to(offset)
+        return True
 
     @asyncio.coroutine
     def _retrieve_offsets(self, timestamps, timeout_ms=float("inf")):
@@ -683,9 +713,6 @@ class Fetcher:
             version = 1
         request = OffsetRequest[version](-1, list(topic_data.items()))
 
-        if not (yield from self._client.ready(node_id)):
-            raise Errors.NodeNotReadyError(node_id)
-
         response = yield from self._client.send(node_id, request)
 
         res_offsets = {}
@@ -750,6 +777,12 @@ class Fetcher:
 
         """
         while True:
+            # While the background routine will fetch new records up till new
+            # assignment is finished, we don't want to return records, that may
+            # not belong to this instance after rebalance.
+            if self._subscriptions.reassignment_in_progress:
+                yield from self._subscriptions.wait_for_assignment()
+
             for tp in list(self._records.keys()):
                 if partitions and tp not in partitions:
                     # Cleanup results for unassigned partitons
@@ -782,6 +815,12 @@ class Fetcher:
         """ Returns previously fetched records and updates consumed offsets.
         """
         while True:
+            # While the background routine will fetch new records up till new
+            # assignment is finished, we don't want to return records, that may
+            # not belong to this instance after rebalance.
+            if self._subscriptions.reassignment_in_progress:
+                yield from self._subscriptions.wait_for_assignment()
+
             start_time = self._loop.time()
             drained = {}
             for tp in list(self._records.keys()):
@@ -836,6 +875,59 @@ class Fetcher:
             # Decrease timeout accordingly
             timeout = timeout - (self._loop.time() - start_time)
             timeout = max(0, timeout)
+
+    @asyncio.coroutine
+    def get_offsets_by_times(self, timestamps, timeout_ms):
+        offsets = yield from self._retrieve_offsets(timestamps, timeout_ms)
+        for tp in timestamps:
+            if tp not in offsets:
+                offsets[tp] = None
+            else:
+                offset, timestamp = offsets[tp]
+                if offset == UNKNOWN_OFFSET:
+                    offsets[tp] = None
+                else:
+                    offsets[tp] = OffsetAndTimestamp(offset, timestamp)
+        return offsets
+
+    @asyncio.coroutine
+    def beginning_offsets(self, partitions, timeout_ms):
+        timestamps = {tp: OffsetResetStrategy.EARLIEST for tp in partitions}
+        offsets = yield from self._retrieve_offsets(timestamps, timeout_ms)
+        return {
+            tp: offset for (tp, (offset, ts)) in offsets.items()
+        }
+
+    @asyncio.coroutine
+    def end_offsets(self, partitions, timeout_ms):
+        timestamps = {tp: OffsetResetStrategy.LATEST for tp in partitions}
+        offsets = yield from self._retrieve_offsets(timestamps, timeout_ms)
+        return {
+            tp: offset for (tp, (offset, ts)) in offsets.items()
+        }
+
+    @asyncio.coroutine
+    def request_offset_reset(self, tps, strategy):
+        """ Force a position reset. Called from Consumer of `seek_to_*` API's.
+        """
+        assignment = self._subscriptions.subscription.assignment
+        assert assignment is not None
+
+        waiters = []
+        for tp in tps:
+            tp_state = assignment.state_value(tp)
+            tp_state.await_reset(strategy)
+            waiters.append(tp_state.wait_for_position())
+        # XXX: Maybe we should use a different future or rename? Not really
+        # describing the purpose.
+        self._notify(self._wait_consume_future)
+
+        yield from asyncio.wait(
+            [asyncio.gather(*waiters, loop=self._loop),
+             assignment.unassign_future],
+            loop=self._loop, return_when=asyncio.FIRST_COMPLETED
+        )
+        return assignment.active
 
     def _unpack_records(self, tp, records):
         # NOTE: if the batch is not compressed it's equal to 1 record in

--- a/aiokafka/consumer/fetcher.py
+++ b/aiokafka/consumer/fetcher.py
@@ -516,7 +516,7 @@ class Fetcher:
                 elif error_type is Errors.OffsetOutOfRangeError:
                     if self._default_reset_strategy != \
                             OffsetResetStrategy.NONE:
-                        tp_state.await_reset(tp, self._default_reset_strategy)
+                        tp_state.await_reset(self._default_reset_strategy)
                     else:
                         err = Errors.OffsetOutOfRangeError({tp: fetch_offset})
                         self._set_error(tp, err)

--- a/aiokafka/consumer/group_coordinator.py
+++ b/aiokafka/consumer/group_coordinator.py
@@ -1012,7 +1012,7 @@ class GroupCoordinator(BaseCoordinator):
                     else:
                         log.error("Unknown error fetching offsets for %s: %s",
                                   tp, error)
-                        raise error
+                        raise Errors.KafkaError(repr(error))
                 # record the position with the offset
                 # (-1 indicates no committed offset to fetch)
                 if offset == UNKNOWN_OFFSET:

--- a/aiokafka/consumer/group_coordinator.py
+++ b/aiokafka/consumer/group_coordinator.py
@@ -626,15 +626,15 @@ class GroupCoordinator(BaseCoordinator):
 
                 t0 = self._loop.time()
                 success = yield from self._do_heartbeat()
-                if success:
-                    last_ok_heartbeat = self._loop.time()
-                else:
-                    sleep_time = retry_backoff
-                    continue
             except asyncio.CancelledError:
                 return
 
-            sleep_time = max((0, hb_interval - self._loop.time() + t0))
+            if success:
+                last_ok_heartbeat = self._loop.time()
+                sleep_time = max((0, hb_interval - self._loop.time() + t0))
+            else:
+                sleep_time = retry_backoff
+
             session_time = self._loop.time() - last_ok_heartbeat
             if session_time > session_timeout:
                 # the session timeout has expired without seeing a successful

--- a/aiokafka/consumer/group_coordinator.py
+++ b/aiokafka/consumer/group_coordinator.py
@@ -716,6 +716,7 @@ class GroupCoordinator(BaseCoordinator):
         event_waiter = None
         try:
             while assignment.active:
+                commit_refresh_needed.clear()
                 success = yield from self._maybe_refresh_commit_offsets(
                     assignment)
 
@@ -724,7 +725,6 @@ class GroupCoordinator(BaseCoordinator):
                     timeout = retry_backoff_ms
                 else:
                     timeout = None
-                    commit_refresh_needed.clear()
                     event_waiter = ensure_future(
                         commit_refresh_needed.wait(), loop=self._loop)
                     wait_futures.append(event_waiter)

--- a/aiokafka/consumer/group_coordinator.py
+++ b/aiokafka/consumer/group_coordinator.py
@@ -1,7 +1,6 @@
 import asyncio
 import collections
 import logging
-from copy import copy
 
 from kafka.coordinator.assignors.roundrobin import RoundRobinPartitionAssignor
 from kafka.coordinator.protocol import ConsumerProtocol
@@ -22,21 +21,19 @@ from aiokafka.util import ensure_future, create_future
 
 log = logging.getLogger(__name__)
 
+UNKNOWN_OFFSET = -1
+
 
 class BaseCoordinator(object):
 
     def __init__(self, client, subscription, *, loop,
-                 exclude_internal_topics=True,
-                 assignment_changed_cb=None
-                 ):
-        self.loop = loop
+                 exclude_internal_topics=True):
+        self._loop = loop
         self._client = client
         self._exclude_internal_topics = exclude_internal_topics
         self._subscription = subscription
-        self._assignment_changed_cb = assignment_changed_cb
 
         self._metadata_snapshot = {}  # Is updated by metadata listener
-        self._assignment_snapshot = None  # Is only present on Leader consumer
         self._cluster = client.cluster
 
         # update initial subscription state using currently known metadata
@@ -44,48 +41,34 @@ class BaseCoordinator(object):
         self._cluster.add_listener(self._handle_metadata_update)
 
     def _handle_metadata_update(self, cluster):
-        if self._subscription.subscribed_pattern:
+        subscription = self._subscription
+        if subscription.subscribed_pattern:
             topics = []
             for topic in cluster.topics(self._exclude_internal_topics):
-                if self._subscription.subscribed_pattern.match(topic):
+                if subscription.subscribed_pattern.match(topic):
                     topics.append(topic)
 
-            if set(topics) != self._subscription.subscription:
-                self._subscription.change_subscription(topics)
+            if subscription.subscription is None or \
+                    set(topics) != subscription.subscription.topics:
+                subscription.subscribe_from_pattern(topics)
 
-        if self._subscription.partitions_auto_assigned():
+        if subscription.partitions_auto_assigned() and \
+                self._group_subscription is not None:
             metadata_snapshot = self._get_metadata_snapshot()
             if self._metadata_snapshot != metadata_snapshot:
+                log.debug("Metadata for topic has changed from %s to %s. ",
+                          self._metadata_snapshot, metadata_snapshot)
                 self._metadata_snapshot = metadata_snapshot
-
-                if self._metadata_changed():
-                    log.debug("Metadata for topic has changed from %s to %s. ",
-                              self._assignment_snapshot, metadata_snapshot)
-
-    def _metadata_changed(self):
-        return (
-            self._assignment_snapshot is not None and
-            self._assignment_snapshot != self._metadata_snapshot)
+                self._on_metadata_change()
 
     def _get_metadata_snapshot(self):
         partitions_per_topic = {}
-        for topic in self._subscription.group_subscription():
+        for topic in self._group_subscription:
             partitions = self._cluster.partitions_for_topic(topic) or []
             # Partitions are always from 0 to N, so no reason to check each
             # partition separately, only length is enough
             partitions_per_topic[topic] = len(partitions)
         return partitions_per_topic
-
-    def _on_change_assignment(self):
-        if self._assignment_changed_cb is not None:
-            self._assignment_changed_cb()
-
-    @asyncio.coroutine
-    def ensure_partitions_assigned(self):
-        """ Will be called by consumer before any operation regarding
-            assignment
-        """
-        return
 
 
 class NoGroupCoordinator(BaseCoordinator):
@@ -102,14 +85,8 @@ class NoGroupCoordinator(BaseCoordinator):
           update and added to subscription.
     """
 
-    def __init__(self, *args, **kw):
-        super().__init__(*args, **kw)
-        self._assignment_snapshot = {}
-
-    def _handle_metadata_update(self, cluster):
-        super()._handle_metadata_update(cluster)
-        if self._metadata_changed():
-            self.assign_all_partitions()
+    def _on_metadata_change(self):
+        self.assign_all_partitions()
 
     def assign_all_partitions(self, check_unknown=False):
         """ Assign all partitions from subscribed topics to this consumer.
@@ -117,7 +94,7 @@ class NoGroupCoordinator(BaseCoordinator):
             subscribed topic is not found in metadata response.
         """
         partitions = []
-        for topic in self._subscription.subscription:
+        for topic in self._subscription.subscription.topics:
             p_ids = self._cluster.partitions_for_topic(topic)
             if not p_ids and check_unknown:
                 raise Errors.UnknownTopicOrPartitionError()
@@ -125,8 +102,16 @@ class NoGroupCoordinator(BaseCoordinator):
                 partitions.append(TopicPartition(topic, p_id))
         self._subscription.assign_from_subscribed(partitions)
 
-        self._assignment_snapshot = self._metadata_snapshot
-        self._on_change_assignment()
+        # Reset all committed points, as the GroupCoordinator would
+        assignment = self._subscription.subscription.assignment
+        for tp in partitions:
+            tp_state = assignment.state_value(tp)
+            tp_state.reset_committed(
+                OffsetAndMetadata(UNKNOWN_OFFSET, ""))
+
+    @property
+    def _group_subscription(self):
+        return self._subscription.subscription.topics
 
     @asyncio.coroutine
     def close(self):
@@ -173,8 +158,7 @@ class GroupCoordinator(BaseCoordinator):
                  retry_backoff_ms=100,
                  enable_auto_commit=True, auto_commit_interval_ms=5000,
                  assignors=(RoundRobinPartitionAssignor,),
-                 exclude_internal_topics=True,
-                 assignment_changed_cb=None
+                 exclude_internal_topics=True
                  ):
         """Initialize the coordination manager.
 
@@ -206,12 +190,13 @@ class GroupCoordinator(BaseCoordinator):
             retry_backoff_ms (int): Milliseconds to backoff when retrying on
                 errors. Default: 100.
         """
+        # Leader node will keep track of the whole group's metadata.
+        self._group_subscription = None
+
         super().__init__(
             client, subscription, loop=loop,
-            exclude_internal_topics=exclude_internal_topics,
-            assignment_changed_cb=assignment_changed_cb)
+            exclude_internal_topics=exclude_internal_topics)
 
-        self._loop = loop
         self._session_timeout_ms = session_timeout_ms
         self._heartbeat_interval_ms = heartbeat_interval_ms
         self._retry_backoff_ms = retry_backoff_ms
@@ -223,75 +208,80 @@ class GroupCoordinator(BaseCoordinator):
         self.member_id = JoinGroupRequest.UNKNOWN_MEMBER_ID
         self.group_id = group_id
         self.coordinator_id = None
-        self.rejoin_needed = True
-        self.pending_rejoin_fut = None
-        # `ensure_active_group` can be called from several places
-        # (from consumer and from heartbeat task), so we need lock
-        self._rejoin_lock = asyncio.Lock(loop=loop)
-        self._auto_commit_task = None
 
-        # _closing future used as a signal to heartbeat task for finish ASAP
+        # Coordination flags and futures
+        self._rejoin_needed_fut = create_future(loop=loop)
+        self._coordinator_dead_fut = create_future(loop=loop)
+
+        self._coordination_task = ensure_future(
+            self._coordination_routine(), loop=loop)
+
+        def _on_coordination_done(fut):
+            try:
+                fut.result()
+            except Exception:  # pragma: no cover
+                log.error(
+                    "Unexpected error in coordinator routine", exc_info=True)
+        self._coordination_task.add_done_callback(_on_coordination_done)
+
+        # Will be started/stopped by coordination task
+        self._heartbeat_task = None
+
+        self._coordinator_lookup_lock = asyncio.Lock(loop=loop)
+        # Will synchronize edits to TopicPartitionState.committed, as it may be
+        # changed from user code by calling ``commit()``.
+        self._commit_lock = asyncio.Lock(loop=loop)
+
+        self._next_autocommit_deadline = \
+            loop.time() + auto_commit_interval_ms / 1000
+
+        # Will be set on close
         self._closing = create_future(loop=loop)
 
-        self.heartbeat_task = ensure_future(
-            self._heartbeat_task_routine(), loop=loop)
-
-        if self._enable_auto_commit:
-            interval = self._auto_commit_interval_ms / 1000
-            self._auto_commit_task = ensure_future(
-                self.auto_commit_routine(interval), loop=loop)
+    def _on_metadata_change(self):
+        self.request_rejoin()
 
     @asyncio.coroutine
-    def close(self):
-        """Close the coordinator, leave the current group
-        and reset local generation/memberId."""
-        self._closing.set_result(None)
-        if self._auto_commit_task:
-            yield from self._auto_commit_task
-            self._auto_commit_task = None
-
-        if self.heartbeat_task:
-            self.heartbeat_task.cancel()
-            try:
-                yield from self.heartbeat_task
-            except asyncio.CancelledError:
-                pass
-            self.heartbeat_task = None
-
-        if not (yield from self.coordinator_unknown()) and self.generation > 0:
-            # this is a minimal effort attempt to leave the group. we do not
-            # attempt any resending if the request fails or times out.
-            request = LeaveGroupRequest(self.group_id, self.member_id)
-            try:
-                yield from self._send_req(
-                    self.coordinator_id, request,
-                    group=ConnectionGroup.COORDINATION)
-            except Errors.KafkaError as err:
-                log.error("LeaveGroup request failed: %s", err)
-            else:
-                log.info("LeaveGroup request succeeded")
-
-    @asyncio.coroutine
-    def _send_req(self, node_id, request, *, group):
-        """send request to Kafka node and mark coordinator as `dead`
-        in error case
+    def _send_req(self, request):
+        """ Send request to coordinator node. In case the coordinator is not
+        ready a respective error will be raised.
         """
+        node_id = self.coordinator_id
+        if node_id is None:
+            raise Errors.GroupCoordinatorNotAvailableError()
         try:
-            resp = yield from self._client.send(node_id, request, group=group)
+            resp = yield from self._client.send(
+                node_id, request, group=ConnectionGroup.COORDINATION)
         except Errors.KafkaError as err:
             log.error(
                 'Error sending %s to node %s [%s] -- marking coordinator dead',
                 request.__class__.__name__, node_id, err)
             self.coordinator_dead()
             raise err
-        else:
-            if not hasattr(resp, 'error_code'):
-                return resp
-            error_type = Errors.for_code(resp.error_code)
-            if error_type is Errors.NoError:
-                return resp
+        return resp
+
+    @asyncio.coroutine
+    def close(self):
+        """Close the coordinator, leave the current group
+        and reset local generation/memberId."""
+        if self._closing.done():
+            return
+
+        self._closing.set_result(None)
+        # We must let the coordination task properly finish all pending work
+        yield from self._coordination_task
+        yield from self._stop_heartbeat_task()
+
+        if self.generation > 0:
+            # this is a minimal effort attempt to leave the group. we do not
+            # attempt any resending if the request fails or times out.
+            request = LeaveGroupRequest(self.group_id, self.member_id)
+            try:
+                yield from self._send_req(request)
+            except Errors.KafkaError as err:
+                log.error("LeaveGroup request failed: %s", err)
             else:
-                raise error_type()
+                log.info("LeaveGroup request succeeded")
 
     def _lookup_assignor(self, name):
         for assignor in self._assignors:
@@ -300,22 +290,26 @@ class GroupCoordinator(BaseCoordinator):
         return None
 
     @asyncio.coroutine
-    def _on_join_prepare(self, generation, member_id):
-        self._subscription.mark_for_reassignment()
-        self._assignment_snapshot = None
+    def _on_join_prepare(self, previous_assignment):
+        self._subscription.begin_reassignment()
+        self._group_subscription = None
 
         # commit offsets prior to rebalance if auto-commit enabled
-        try:
-            yield from self._maybe_auto_commit_offsets_sync()
-        except Errors.KafkaError as err:
-            log.error("OffsetCommit failed before join, ignoring: %s", err)
+        if previous_assignment is not None:
+            try:
+                yield from self._maybe_do_last_autocommit(previous_assignment)
+            except Errors.KafkaError as err:
+                # We would retry any retriable commit already
+                log.error("OffsetCommit failed before join, ignoring: %s", err)
+            revoked = previous_assignment.tps
+        else:
+            revoked = set([])
 
         # execute the user's callback before rebalance
         log.info("Revoking previously assigned partitions %s for group %s",
-                 self._subscription.assigned_partitions(), self.group_id)
+                 revoked, self.group_id)
         if self._subscription.listener:
             try:
-                revoked = set(self._subscription.assigned_partitions())
                 res = self._subscription.listener.on_partitions_revoked(
                     revoked)
                 if asyncio.iscoroutine(res):
@@ -340,9 +334,9 @@ class GroupCoordinator(BaseCoordinator):
         # the leader will begin watching for changes to any of the topics
         # the group is interested in, which ensures that all metadata changes
         # will eventually be seen
-        self._subscription.group_subscribe(all_subscribed_topics)
+        self._group_subscription = all_subscribed_topics
         if not self._subscription.subscribed_pattern:
-            self._client.set_topics(self._subscription.group_subscription())
+            self._client.set_topics(self._group_subscription)
         # If somewhere we forced a metadata update (like in some `set_topics`
         # call) we should wait for it before performing assignment
         yield from self._client._maybe_wait_metadata()
@@ -355,12 +349,10 @@ class GroupCoordinator(BaseCoordinator):
         log.debug("Finished assignment for group %s: %s",
                   self.group_id, assignments)
 
-        # `group_subscribe()` will not trigger a metadata update if we only
-        # removed some topics (client has all needed metadata already).
-        # But in that case the snapshot could be outdated, so we update
-        # `_metadata_snapshot` too.
-        self._assignment_snapshot = self._metadata_snapshot = \
-            self._get_metadata_snapshot()
+        # `set_topics()` will not trigger a metadata update if we only
+        # removed some topics (client has all needed metadata already),
+        # so we force a snapshot update.
+        self._metadata_snapshot = self._get_metadata_snapshot()
 
         group_assignment = {}
         for member_id, assignment in assignments.items():
@@ -376,9 +368,6 @@ class GroupCoordinator(BaseCoordinator):
         assignment = ConsumerProtocol.ASSIGNMENT.decode(
             member_assignment_bytes)
 
-        # Will be used by Consumer.committed and Consumer.seek_to_commited API
-        self._subscription.needs_fetch_committed_offsets = True
-
         # update partition assignment
         self._subscription.assign_from_subscribed(assignment.partitions())
 
@@ -386,8 +375,6 @@ class GroupCoordinator(BaseCoordinator):
         # based on the received assignment
         assignor.on_assignment(assignment)
 
-        self.pending_rejoin_fut.set_result(None)
-        self.pending_rejoin_fut = None
         assigned = set(self._subscription.assigned_partitions())
         log.info("Setting newly assigned partitions %s for group %s",
                  assigned, self.group_id)
@@ -405,124 +392,369 @@ class GroupCoordinator(BaseCoordinator):
                               self._subscription.listener, self.group_id,
                               assigned)
 
-        self._on_change_assignment()
+    def coordinator_dead(self):
+        """ Mark the current coordinator as dead.
+        NOTE: this will not force a group rejoin. If new coordinator is able to
+        recognize this member we will just continue with current generation.
+        """
+        if self.coordinator_id is not None:
+            log.warning(
+                "Marking the coordinator dead (node %s)for group %s.",
+                self.coordinator_id, self.group_id)
+            self.coordinator_id = None
+            self._coordinator_dead_fut.set_result(None)
 
-    @asyncio.coroutine
-    def refresh_committed_offsets(self):
-        """Fetch committed offsets for assigned partitions."""
-        if self._subscription.needs_fetch_committed_offsets:
-            offsets = yield from self.fetch_committed_offsets(
-                self._subscription.assigned_partitions())
+    def reset_generation(self):
+        """ Coordinator did not recognize either generation or member_id. Will
+        need to re-join the group.
+        """
+        self.generation = OffsetCommitRequest.DEFAULT_GENERATION_ID
+        self.member_id = JoinGroupRequest.UNKNOWN_MEMBER_ID
+        self.request_rejoin()
 
-            for partition, offset in offsets.items():
-                # verify assignment is still active
-                if self._subscription.is_assigned(partition):
-                    partition = self._subscription.assignment[partition]
-                    partition.committed = offset.offset
+    def request_rejoin(self):
+        if not self._rejoin_needed_fut.done():
+            self._rejoin_needed_fut.set_result(None)
 
-            self._subscription.needs_fetch_committed_offsets = False
-
-    @asyncio.coroutine
-    def fetch_committed_offsets(self, partitions):
-        """Fetch the current committed offsets for specified partitions
-
-        Arguments:
-            partitions (list of TopicPartition): partitions to fetch
+    def need_rejoin(self, subscription):
+        """Check whether the group should be rejoined
 
         Returns:
-            dict: {TopicPartition: OffsetAndMetadata}
+            bool: True if consumer should rejoin group, False otherwise
         """
-        if not partitions:
-            return {}
+        return (
+            subscription.assignment is None or self._rejoin_needed_fut.done()
+        )
+
+    @asyncio.coroutine
+    def ensure_coordinator_known(self):
+        """ Block until the coordinator for this group is known.
+        """
+        if self.coordinator_id is not None:
+            return
+
+        with (yield from self._coordinator_lookup_lock):
+            retry_backoff = self._retry_backoff_ms / 1000
+            while self.coordinator_id is None:
+                try:
+                    coordinator_id = yield from self._do_coordinator_lookup()
+                except Errors.KafkaError as err:
+                    log.error("Group Coordinator Request failed: %s", err)
+                    yield from self._client.force_metadata_update()
+                    yield from asyncio.sleep(retry_backoff, loop=self._loop)
+                    continue
+
+                # Try to connect to confirm that the connection can be
+                # established.
+                ready = yield from self._client.ready(
+                    coordinator_id, group=ConnectionGroup.COORDINATION)
+                if not ready:
+                    yield from asyncio.sleep(retry_backoff, loop=self._loop)
+                    continue
+
+                self.coordinator_id = coordinator_id
+                self._coordinator_dead_fut = create_future(loop=self._loop)
+                log.info("Discovered coordinator %s for group %s",
+                         self.coordinator_id, self.group_id)
+
+    @asyncio.coroutine
+    def _do_coordinator_lookup(self):
+        node_id = self._client.get_random_node()
+        assert node_id is not None, "Did we not perform bootstrap?"
+
+        log.debug(
+            "Sending group coordinator request for group %s to broker "
+            "%s", self.group_id, node_id)
+        request = GroupCoordinatorRequest(self.group_id)
+        resp = yield from self._client.send(
+            node_id, request, group=ConnectionGroup.DEFAULT)
+        log.debug("Received group coordinator response %s", resp)
+        error_type = Errors.for_code(resp.error_code)
+        if error_type is not Errors.NoError:
+            err = error_type()
+            raise err
+        return resp.coordinator_id
+
+    @asyncio.coroutine
+    def _coordination_routine(self):
+        """ Main background task, that keeps track of changes in group
+        coordination. This task will spawn/stop heartbeat task and perform
+        autocommit in times it's safe to do so.
+        """
+        retry_backoff = self._retry_backoff_ms / 1000
+        subscription = self._subscription.subscription
+        assignment = None
+        performed_join_prepare = False
+
+        while not self._closing.done():
+            # Check if there was a change to subscription
+            if subscription is not None and not subscription.active:
+                # The subscription can change few times, so we can not rely on
+                # flags or topic lists. For example if user changes
+                # subscription from X to Y and back to X we still need to
+                # rejoin group.
+                self.request_rejoin()
+                subscription = self._subscription.subscription
+            if subscription is None:
+                yield from asyncio.wait(
+                    [self._subscription.wait_for_subscription(),
+                     self._closing],
+                    return_when=asyncio.FIRST_COMPLETED, loop=self._loop)
+                if self._closing.done():
+                    return
+                subscription = self._subscription.subscription
+            assert subscription is not None and subscription.active
+            auto_assigned = self._subscription.partitions_auto_assigned()
+
+            # Ensure active group
+            yield from self.ensure_coordinator_known()
+            if auto_assigned and self.need_rejoin(subscription):
+                if not performed_join_prepare:
+                    # NOTE: We pass the previously used assignment here.
+                    yield from self._on_join_prepare(assignment)
+                    performed_join_prepare = True
+
+                # NOTE: we did not stop heartbeat task before to keep the
+                # member alive during the callback, as it can commit offsets.
+                # See the ``RebalanceInProgressError`` case in heartbeat
+                # handling.
+                yield from self._stop_heartbeat_task()
+
+                # We will only try to perform the rejoin once. If it fails,
+                # we will spin this loop another time, checking for coordinator
+                # and subscription changes.
+                # NOTE: We do re-join in sync. The group rebalance will fail on
+                # subscription change and coordinator failure by itself and
+                # this way we don't need to worry about racing or cancellation
+                # issues that could occur if re-join were to be a task.
+                success = yield from self._do_rejoin_group(subscription)
+                if success:
+                    performed_join_prepare = False
+                    assignment = subscription.assignment
+                    self._start_heartbeat_task()
+                else:
+                    # Backoff is done in group rejoin
+                    continue
+
+            assert assignment is not None and assignment.active
+
+            # We will only try to commit offsets once here. In error case the
+            # returned wait_timeout will be ``retry_backoff``. In success case
+            # time to next autocommit deadline. If autocommit is disabled
+            # timeout will be ``None``, ie. no timeout.
+            wait_timeout = yield from self._maybe_do_autocommit(assignment)
+
+            # During an autocommit or as a result of rebalance some partitions
+            # commit cache may have been invalidated.
+            success = yield from self._maybe_refresh_commit_offsets(assignment)
+            if not success:
+                wait_timeout = retry_backoff
+
+            futures = [
+                self._closing,  # Will exit fast if close() called
+                self._coordinator_dead_fut,
+                subscription.unsubscribe_future]
+            # In case of manual assignment this future will be always set and
+            # we don't want a heavy loop here.
+            # NOTE: metadata changes are for partition count and pattern
+            # subscription, which is irrelevant in case of user assignment.
+            if auto_assigned:
+                futures.append(self._rejoin_needed_fut)
+
+            done, _ = yield from asyncio.wait(
+                futures, timeout=wait_timeout, loop=self._loop,
+                return_when=asyncio.FIRST_COMPLETED)
+
+    def _start_heartbeat_task(self):
+        if self._heartbeat_task is None:
+            self._heartbeat_task = ensure_future(
+                self._heartbeat_routine(), loop=self._loop)
+
+    @asyncio.coroutine
+    def _stop_heartbeat_task(self):
+        if self._heartbeat_task is not None:
+            if not self._heartbeat_task.done():
+                self._heartbeat_task.cancel()
+            yield from self._heartbeat_task
+            self._heartbeat_task = None
+
+    @asyncio.coroutine
+    def _heartbeat_routine(self):
+        last_ok_heartbeat = self._loop.time()
+        hb_interval = self._heartbeat_interval_ms / 1000
+        session_timeout = self._session_timeout_ms / 1000
+        retry_backoff = self._retry_backoff_ms / 1000
+        sleep_time = hb_interval
 
         while True:
-            yield from self.ensure_coordinator_known()
-            node_id = self.coordinator_id
-
-            log.debug(
-                "Fetching committed offsets for partitions: %s", partitions)
-            # construct the request
-            topic_partitions = collections.defaultdict(set)
-            for tp in partitions:
-                topic_partitions[tp.topic].add(tp.partition)
-
-            request = OffsetFetchRequest(
-                self.group_id,
-                list(topic_partitions.items())
-            )
-
             try:
-                offsets = yield from self._proc_offsets_fetch_request(
-                    node_id, request)
+                yield from asyncio.sleep(sleep_time, loop=self._loop)
+                yield from self.ensure_coordinator_known()
+
+                t0 = self._loop.time()
+                success = yield from self._do_heartbeat()
+                if success:
+                    last_ok_heartbeat = self._loop.time()
+                else:
+                    sleep_time = retry_backoff
+                    continue
+            except asyncio.CancelledError:
+                return
+
+            sleep_time = max((0, hb_interval - self._loop.time() + t0))
+            session_time = self._loop.time() - last_ok_heartbeat
+            if session_time > session_timeout:
+                # the session timeout has expired without seeing a successful
+                # heartbeat, so we should probably make sure the coordinator
+                # is still healthy.
+                log.error(
+                    "Heartbeat session expired - marking coordinator dead")
+                self.coordinator_dead()
+
+    @asyncio.coroutine
+    def _do_heartbeat(self):
+        request = HeartbeatRequest(
+            self.group_id, self.generation, self.member_id)
+        log.debug("Heartbeat: %s[%s] %s",
+                  self.group_id, self.generation, self.member_id)
+
+        resp = yield from self._send_req(request)
+        error_type = Errors.for_code(resp.error_code)
+        if error_type is Errors.NoError:
+            log.debug(
+                "Received successful heartbeat response for group %s",
+                self.group_id)
+            return True
+        if error_type in (Errors.GroupCoordinatorNotAvailableError,
+                          Errors.NotCoordinatorForGroupError):
+            log.warning(
+                "Heartbeat failed for group %s: coordinator (node %s)"
+                " is either not started or not valid",
+                self.group_id, self.coordinator_id)
+            self.coordinator_dead()
+        elif error_type is Errors.RebalanceInProgressError:
+            log.warning(
+                "Heartbeat failed for group %s because it is rebalancing",
+                self.group_id)
+            self.request_rejoin()
+            # it is valid to continue heartbeating while the group is
+            # rebalancing. This ensures that the coordinator keeps the
+            # member in the group for as long as the duration of the
+            # rebalance timeout. If we stop sending heartbeats,
+            # however, then the session timeout may expire before we
+            # can rejoin.
+            return True
+        elif error_type is Errors.IllegalGenerationError:
+            log.warning(
+                "Heartbeat failed for group %s: generation id is not "
+                " current.", self.group_id)
+            self.reset_generation()
+        elif error_type is Errors.UnknownMemberIdError:
+            log.warning(
+                "Heartbeat failed: local member_id was not recognized;"
+                " resetting and re-joining group")
+            self.reset_generation()
+        else:
+            err = error_type()
+            log.error("Heartbeat failed: %r", err)
+        return False
+
+    @asyncio.coroutine
+    def _do_rejoin_group(self, subscription):
+        rebalance = CoordinatorGroupRebalance(
+            self, self.group_id, self.coordinator_id,
+            subscription, self._assignors, self._session_timeout_ms,
+            self._retry_backoff_ms, loop=self._loop)
+        assignment = yield from rebalance.perform_group_join()
+
+        if not subscription.active:
+            log.debug("Subscription changed during rebalance from %s to %s. "
+                      "Rejoining group.",
+                      subscription.topics,
+                      self._subscription.subscription.topics)
+            return False
+        if assignment is None:
+            return False
+
+        protocol, member_assignment_bytes = assignment
+        yield from self._on_join_complete(
+            self.generation, self.member_id,
+            protocol, member_assignment_bytes)
+        return True
+
+    @asyncio.coroutine
+    def _maybe_do_autocommit(self, assignment):
+        if not self._enable_auto_commit:
+            return None
+        now = self._loop.time()
+        interval = self._auto_commit_interval_ms / 1000
+        backoff = self._retry_backoff_ms / 1000
+        if now > self._next_autocommit_deadline:
+            try:
+                with (yield from self._commit_lock):
+                    yield from self._do_commit_offsets(
+                        assignment, assignment.all_consumed_offsets())
+            except Errors.KafkaError as error:
+                log.warning("Auto offset commit failed: %s", error)
+                if error.retriable:
+                    # Retry after backoff.
+                    self._next_autocommit_deadline = now + backoff
+                    return backoff
+            except Exception as error:  # pragma: no cover
+                log.exception("Auto offset commit errored: %s", error)
+            # If we had an unrecoverable error we expect the user to handle it
+            # from another source (say Fetcher, like authorization errors).
+            self._next_autocommit_deadline = now + interval
+
+        return max(0, self._next_autocommit_deadline - self._loop.time())
+
+    @asyncio.coroutine
+    def _maybe_do_last_autocommit(self, assignment):
+        if not self._enable_auto_commit:
+            return
+        yield from self.commit_offsets(
+            assignment, assignment.all_consumed_offsets())
+
+    @asyncio.coroutine
+    def commit_offsets(self, assignment, offsets):
+        """Commit specific offsets
+
+        Arguments:
+            offsets (dict {TopicPartition: OffsetAndMetadata}): what to commit
+
+        Raises KafkaError on failure
+        """
+        while True:
+            yield from self.ensure_coordinator_known()
+            try:
+                with (yield from self._commit_lock):
+                    yield from asyncio.shield(
+                        self._do_commit_offsets(assignment, offsets),
+                        loop=self._loop)
+            except (Errors.UnknownMemberIdError,
+                    Errors.IllegalGenerationError,
+                    Errors.RebalanceInProgressError) as err:
+                raise Errors.CommitFailedError(
+                    "Commit cannot be completed since the group has already "
+                    "rebalanced and may have assigned the partitions "
+                    "to another member")
             except Errors.KafkaError as err:
                 if not err.retriable:
                     raise err
                 else:
                     # wait backoff and try again
                     yield from asyncio.sleep(
-                        self._retry_backoff_ms / 1000, loop=self.loop)
+                        self._retry_backoff_ms / 1000, loop=self._loop)
             else:
-                return offsets
+                break
 
     @asyncio.coroutine
-    def _proc_offsets_fetch_request(self, node_id, request):
-        response = yield from self._send_req(
-            node_id, request, group=ConnectionGroup.COORDINATION)
-        offsets = {}
-        for topic, partitions in response.topics:
-            for partition, offset, metadata, error_code in partitions:
-                tp = TopicPartition(topic, partition)
-                error_type = Errors.for_code(error_code)
-                if error_type is not Errors.NoError:
-                    error = error_type()
-                    log.debug("Error fetching offset for %s: %s", tp, error)
-                    if error_type is Errors.GroupLoadInProgressError:
-                        # just retry
-                        raise error
-                    elif error_type is Errors.NotCoordinatorForGroupError:
-                        # re-discover the coordinator and retry
-                        self.coordinator_dead()
-                        raise error
-                    elif error_type in (Errors.UnknownMemberIdError,
-                                        Errors.IllegalGenerationError):
-                        # need to re-join group
-                        self._subscription.mark_for_reassignment()
-                        raise error
-                    elif error_type is Errors.UnknownTopicOrPartitionError:
-                        log.warning(
-                            "OffsetFetchRequest -- unknown topic %s", topic)
-                        continue
-                    else:
-                        log.error("Unknown error fetching offsets for %s: %s",
-                                  tp, error)
-                        raise error
-                elif offset >= 0:
-                    # record the position with the offset
-                    # (-1 indicates no committed offset to fetch)
-                    offsets[tp] = OffsetAndMetadata(offset, metadata)
-                else:
-                    log.debug(
-                        "No committed offset for partition %s", tp)
-
-        return offsets
-
-    @asyncio.coroutine
-    def commit_offsets(self, offsets):
-        """Commit specific offsets asynchronously.
-
-        Arguments:
-            offsets (dict {TopicPartition: OffsetAndMetadata}): what to commit
-
-        Raises error on failure
-        """
-        self._subscription.needs_fetch_committed_offsets = True
-        if not offsets:
-            log.debug('No offsets to commit')
-            return True
-
-        if (yield from self.coordinator_unknown()):
-            raise Errors.GroupCoordinatorNotAvailableError()
-        node_id = self.coordinator_id
+    def _do_commit_offsets(self, assignment, offsets):
+        # Signal all topics that we are starting commit
+        for tp in offsets:
+            assert tp in assignment.tps
+            tp_state = assignment.state_value(tp)
+            tp_state.begin_commit()
 
         # create the offset commit request
         offset_data = collections.defaultdict(list)
@@ -541,28 +773,26 @@ class GroupCoordinator(BaseCoordinator):
         )
 
         log.debug("Sending offset-commit request with %s for group %s to %s",
-                  offsets, self.group_id, node_id)
+                  offsets, self.group_id, self.coordinator_id)
 
-        response = yield from self._send_req(
-            node_id, request, group=ConnectionGroup.COORDINATION)
+        response = yield from self._send_req(request)
 
+        errored = collections.OrderedDict()
         unauthorized_topics = set()
         for topic, partitions in response.topics:
             for partition, error_code in partitions:
                 tp = TopicPartition(topic, partition)
-                offset = offsets[tp]
-
                 error_type = Errors.for_code(error_code)
                 if error_type is Errors.NoError:
                     log.debug(
                         "Committed offset %s for partition %s", offset, tp)
-                    if self._subscription.is_assigned(tp):
-                        partition = self._subscription.assignment[tp]
-                        partition.committed = offset.offset
+                    offset = offsets[tp]
+                    tp_state = assignment.state_value(tp)
+                    tp_state.update_committed(offset)
                 elif error_type is Errors.GroupAuthorizationFailedError:
                     log.error("OffsetCommit failed for group %s - %s",
                               self.group_id, error_type.__name__)
-                    raise error_type()
+                    errored[tp] = error_type()
                 elif error_type is Errors.TopicAuthorizationFailedError:
                     unauthorized_topics.add(topic)
                 elif error_type in (Errors.OffsetMetadataTooLargeError,
@@ -572,23 +802,22 @@ class GroupCoordinator(BaseCoordinator):
                         "OffsetCommit failed for group %s on partition %s"
                         " due to %s, will retry", self.group_id, tp,
                         error_type.__name__)
-                    raise error_type()
+                    errored[tp] = error_type()
                 elif error_type is Errors.GroupLoadInProgressError:
                     # just retry
                     log.info(
                         "OffsetCommit failed for group %s because group is"
                         " initializing (%s), will retry", self.group_id,
                         error_type.__name__)
-                    raise error_type()
+                    errored[tp] = error_type()
                 elif error_type in (Errors.GroupCoordinatorNotAvailableError,
-                                    Errors.NotCoordinatorForGroupError,
-                                    Errors.RequestTimedOutError):
+                                    Errors.NotCoordinatorForGroupError):
                     log.info(
                         "OffsetCommit failed for group %s due to a"
                         " coordinator error (%s), will find new coordinator"
                         " and retry", self.group_id, error_type.__name__)
                     self.coordinator_dead()
-                    raise error_type()
+                    errored[tp] = error_type()
                 elif error_type in (Errors.UnknownMemberIdError,
                                     Errors.IllegalGenerationError,
                                     Errors.RebalanceInProgressError):
@@ -597,243 +826,125 @@ class GroupCoordinator(BaseCoordinator):
                     log.error(
                         "OffsetCommit failed for group %s due to group"
                         " error (%s), will rejoin", self.group_id, error)
-                    self._subscription.mark_for_reassignment()
-                    raise error
+                    if error_type is Errors.RebalanceInProgressError:
+                        self.request_rejoin()
+                    else:
+                        self.reset_generation()
+                    # need to re-join group
+                    error = error_type(self.group_id)
+                    log.error(
+                        "OffsetCommit failed for group %s due to group"
+                        " error (%s), will rejoin", self.group_id, error)
+                    errored[tp] = error
+
                 else:
                     log.error(
                         "OffsetCommit failed for group %s on partition %s"
                         " with offset %s: %s", self.group_id, tp, offset,
                         error_type.__name__)
-                    raise error_type()
+                    errored[tp] = error_type()
 
+        if errored:
+            first_error = list(errored.values())[0]
+            raise first_error
         if unauthorized_topics:
             log.error("OffsetCommit failed for unauthorized topics %s",
                       unauthorized_topics)
             raise Errors.TopicAuthorizationFailedError(unauthorized_topics)
 
     @asyncio.coroutine
-    def _maybe_auto_commit_offsets_sync(self):
-        if not self._enable_auto_commit:
-            return
-
-        yield from self.ensure_coordinator_known()
-        yield from self.commit_offsets(
-            self._subscription.all_consumed_offsets())
-
-    @asyncio.coroutine
-    def auto_commit_routine(self, interval):
-        while not self._closing.done():
-            if (yield from self.coordinator_unknown()):
-                log.debug(
-                    "Cannot auto-commit offsets because the coordinator is"
-                    " unknown, will retry after backoff")
-                yield from asyncio.sleep(
-                    self._retry_backoff_ms / 1000, loop=self.loop)
-                continue
-
-            yield from asyncio.wait(
-                [self._closing], timeout=interval, loop=self.loop)
-
-            # select offsets that should be committed
-            offsets = {}
-            for partition in self._subscription.assigned_partitions():
-                tp = self._subscription.assignment[partition]
-                if tp.position != tp.committed and tp.has_valid_position:
-                    offsets[partition] = OffsetAndMetadata(tp.position, '')
-
-            try:
-                yield from self.commit_offsets(offsets)
-            except Errors.KafkaError as error:
-                if error.retriable and not self._closing.done():
-                    log.debug("Failed to auto-commit offsets: %s, will retry"
-                              " immediately", error)
-                else:
-                    log.warning("Auto offset commit failed: %s", error)
+    def _maybe_refresh_commit_offsets(self, assignment):
+        with (yield from self._commit_lock):
+            need_update = assignment.missing_commit_cache()
+            if need_update:
+                try:
+                    offsets = yield from self._do_fetch_commit_offsets(
+                        need_update)
+                except Errors.KafkaError as err:
+                    if not err.retriable:
+                        log.exception("Failed to fetch committed offsets")
+                    else:
+                        log.debug("Failed to fetch committed offsets: %r", err)
+                    return False
+                for tp in need_update:
+                    tp_state = assignment.state_value(tp)
+                    if tp in offsets:
+                        tp_state.reset_committed(offsets[tp])
+                    else:
+                        tp_state.reset_committed(
+                            OffsetAndMetadata(UNKNOWN_OFFSET, ""))
+        return True
 
     @asyncio.coroutine
-    def coordinator_unknown(self):
-        """Check if we know who the coordinator is
-        and have an active connection
+    def fetch_committed_offsets(self, partitions):
+        """Fetch the current committed offsets for specified partitions
+
+        Arguments:
+            partitions (list of TopicPartition): partitions to fetch
 
         Returns:
-            bool: True if the coordinator is unknown
+            dict: {TopicPartition: OffsetAndMetadata}
         """
-        if self.coordinator_id is None:
-            return True
-
-        ready = yield from self._client.ready(self.coordinator_id)
-        return not ready
-
-    @asyncio.coroutine
-    def ensure_coordinator_known(self):
-        """Block until the coordinator for this group is known
-        (and we have an active connection -- Java client uses unsent queue).
-        """
-        while (yield from self.coordinator_unknown()):
-            node_id = self._client.get_random_node()
-            if node_id is None or not (yield from self._client.ready(node_id)):
-                raise Errors.NoBrokersAvailable()
-
-            log.debug(
-                "Sending group coordinator request for group %s to broker %s",
-                self.group_id, node_id)
-            request = GroupCoordinatorRequest(self.group_id)
-            try:
-                resp = yield from self._send_req(
-                    node_id, request, group=ConnectionGroup.DEFAULT)
-            except Errors.KafkaError as err:
-                log.error("Group Coordinator Request failed: %s", err)
-                yield from asyncio.sleep(
-                    self._retry_backoff_ms / 1000, loop=self.loop)
-                if err.retriable is True:
-                    yield from self._client.force_metadata_update()
-            else:
-                log.debug("Received group coordinator response %s", resp)
-                if not (yield from self.coordinator_unknown()):
-                    # We already found the coordinator, so ignore the response
-                    log.debug("Coordinator already known, ignoring response")
-                    break
-                self.coordinator_id = resp.coordinator_id
-                log.info("Discovered coordinator %s for group %s",
-                         self.coordinator_id, self.group_id)
-
-    def need_rejoin(self):
-        """Check whether the group should be rejoined
-
-        Returns:
-            bool: True if consumer should rejoin group, False otherwise
-        """
-        return (self._subscription.partitions_auto_assigned() and
-                (self.rejoin_needed or
-                 self._subscription.needs_partition_assignment or
-                 self._metadata_changed()))
-
-    @asyncio.coroutine
-    def ensure_active_group(self):
-        """Ensure that the group is active (i.e. joined and synced)"""
-        with (yield from self._rejoin_lock):
-            if not self.need_rejoin():
-                return
-
-            if self.pending_rejoin_fut is None:
-                yield from self._on_join_prepare(
-                    self.generation, self.member_id)
-                self.pending_rejoin_fut = create_future(loop=self._loop)
-
-            while self.need_rejoin():
-                yield from self.ensure_coordinator_known()
-                # Here we create a copy of subscription so we can check if it
-                # changed during rebalance.
-                subscription = copy(self._subscription.subscription)
-                rebalance = CoordinatorGroupRebalance(
-                    self, self.group_id, self.coordinator_id,
-                    subscription, self._assignors, self._session_timeout_ms,
-                    self._retry_backoff_ms, loop=self.loop)
-                assignment = yield from rebalance.perform_group_join()
-
-                if (subscription != self._subscription.subscription):
-                    log.debug("Subscription changed during rebalance "
-                              "from %s to %s. Rejoining group.",
-                              subscription, self._subscription.subscription)
-                    continue
-                if assignment is not None:
-                    protocol, member_assignment_bytes = assignment
-                    yield from self._on_join_complete(
-                        self.generation, self.member_id,
-                        protocol, member_assignment_bytes)
-                    return
-
-    @asyncio.coroutine
-    def ensure_partitions_assigned(self):
-        if self.pending_rejoin_fut is not None:
-            yield from asyncio.shield(self.pending_rejoin_fut, loop=self._loop)
-
-    def coordinator_dead(self, error=None):
-        """Mark the current coordinator as dead."""
-        if self.coordinator_id is not None:
-            log.warning(
-                "Marking the coordinator dead (node %s)for group %s: %s.",
-                self.coordinator_id, self.group_id, error)
-            self.coordinator_id = None
-        # TODO: Coordinator's state is stored in Zookeeper. Even if it goes
-        #       down the group might not break if a new one is elected fast
-        self.rejoin_needed = True
-
-    @asyncio.coroutine
-    def _heartbeat_task_routine(self):
-        last_ok_heartbeat = self.loop.time()
-        hb_interval = self._heartbeat_interval_ms / 1000
-        session_timeout = self._session_timeout_ms / 1000
-        retry_backoff_time = self._retry_backoff_ms / 1000
-        sleep_time = hb_interval
+        if not partitions:
+            return {}
 
         while True:
-            yield from asyncio.sleep(sleep_time, loop=self.loop)
-            if not self._subscription.partitions_auto_assigned():
-                # no partitions assigned yet, just wait
-                sleep_time = retry_backoff_time
-                continue
-
+            yield from self.ensure_coordinator_known()
             try:
-                yield from self.ensure_active_group()
+                offsets = yield from self._do_fetch_commit_offsets(partitions)
             except Errors.KafkaError as err:
-                log.error("Skipping heartbeat: no active group: %r", err)
-                last_ok_heartbeat = self.loop.time()
-                sleep_time = retry_backoff_time
-                continue
-
-            t0 = self.loop.time()
-            request = HeartbeatRequest(
-                self.group_id, self.generation, self.member_id)
-            log.debug("Heartbeat: %s[%s] %s",
-                      self.group_id, self.generation, self.member_id)
-            try:
-                yield from self._send_req(
-                    self.coordinator_id, request,
-                    group=ConnectionGroup.COORDINATION)
-            except (Errors.GroupCoordinatorNotAvailableError,
-                    Errors.NotCoordinatorForGroupError):
-                log.warning(
-                    "Heartbeat failed for group %s: coordinator (node %s)"
-                    " is either not started or not valid",
-                    self.group_id, self.coordinator_id)
-                self.coordinator_dead()
-            except Errors.RebalanceInProgressError:
-                log.warning(
-                    "Heartbeat failed for group %s because it is rebalancing",
-                    self.group_id)
-                self.rejoin_needed = True
-            except Errors.IllegalGenerationError:
-                log.warning(
-                    "Heartbeat failed for group %s: generation id is not "
-                    " current.", self.group_id)
-                self.rejoin_needed = True
-            except Errors.UnknownMemberIdError:
-                log.warning(
-                    "Heartbeat failed: local member_id was not recognized;"
-                    " resetting and re-joining group")
-                self.member_id = JoinGroupRequest.UNKNOWN_MEMBER_ID
-                self.rejoin_needed = True
-            except Errors.KafkaError as err:
-                log.error("Heartbeat failed: %s", err)
+                if not err.retriable:
+                    raise err
+                else:
+                    # wait backoff and try again
+                    yield from asyncio.sleep(
+                        self._retry_backoff_ms / 1000, loop=self._loop)
             else:
-                log.debug(
-                    "Received successful heartbeat response for group %s",
-                    self.group_id)
-                last_ok_heartbeat = self.loop.time()
+                return offsets
 
-            if self.rejoin_needed:
-                sleep_time = retry_backoff_time
-            else:
-                sleep_time = max((0, hb_interval - self.loop.time() + t0))
-            session_time = self.loop.time() - last_ok_heartbeat
-            if session_time > session_timeout:
-                # we haven't received a successful heartbeat in one session
-                # interval so mark the coordinator dead
-                log.error(
-                    "Heartbeat session expired - marking coordinator dead")
-                self.coordinator_dead()
-                continue
+    @asyncio.coroutine
+    def _do_fetch_commit_offsets(self, partitions):
+        log.debug("Fetching committed offsets for partitions: %s", partitions)
+        # construct the request
+        topic_partitions = collections.defaultdict(list)
+        for tp in partitions:
+            topic_partitions[tp.topic].append(tp.partition)
+
+        request = OffsetFetchRequest(
+            self.group_id,
+            list(topic_partitions.items())
+        )
+        response = yield from self._send_req(request)
+        offsets = {}
+        for topic, partitions in response.topics:
+            for partition, offset, metadata, error_code in partitions:
+                tp = TopicPartition(topic, partition)
+                error_type = Errors.for_code(error_code)
+                if error_type is not Errors.NoError:
+                    error = error_type()
+                    log.debug("Error fetching offset for %s: %s", tp, error)
+                    if error_type is Errors.GroupLoadInProgressError:
+                        # just retry
+                        raise error
+                    elif error_type is Errors.NotCoordinatorForGroupError:
+                        # re-discover the coordinator and retry
+                        self.coordinator_dead()
+                        raise error
+                    elif error_type is Errors.UnknownTopicOrPartitionError:
+                        log.warning(
+                            "OffsetFetchRequest -- unknown topic %s", topic)
+                        continue
+                    else:
+                        log.error("Unknown error fetching offsets for %s: %s",
+                                  tp, error)
+                        raise error
+                # record the position with the offset
+                # (-1 indicates no committed offset to fetch)
+                if offset == UNKNOWN_OFFSET:
+                    log.debug("No committed offset for partition %s", tp)
+                else:
+                    offsets[tp] = OffsetAndMetadata(offset, metadata)
+        return offsets
 
 
 class CoordinatorGroupRebalance:
@@ -841,29 +952,20 @@ class CoordinatorGroupRebalance:
         assigned topics, so we can detect assignment changes. This includes
         subscription pattern changes.
 
-        `coordinator` object will be used to modify:
-            * member_id
-            * generation
-            * rejoin_needed
-        and call methods:
-            * _perform_assignment
-            * coordinator_dead
-            * coordinator_unknown
-
         On how to handle cases read in https://cwiki.apache.org/confluence/\
             display/KAFKA/Kafka+Client-side+Assignment+Proposal
     """
 
     __slots__ = ("_coordinator", "group_id", "coordinator_id", "_subscription",
                  "_assignors", "_session_timeout_ms", "_retry_backoff_ms",
-                 "loop")
+                 "_loop")
 
     def __init__(self, coordinator, group_id, coordinator_id, subscription,
                  assignors, session_timeout_ms, retry_backoff_ms, *, loop):
         self._coordinator = coordinator
         self.group_id = group_id
         self.coordinator_id = coordinator_id
-        self.loop = loop
+        self._loop = loop
 
         self._subscription = subscription
         self._assignors = assignors
@@ -882,8 +984,7 @@ class CoordinatorGroupRebalance:
         # send a join group request to the coordinator
         log.info("(Re-)joining group %s", self.group_id)
 
-        topics = self._subscription
-        assert topics is not None, 'Consumer has not subscribed to topics'
+        topics = self._subscription.topics
         metadata_list = []
         for assignor in self._assignors:
             metadata = assignor.metadata(topics)
@@ -903,37 +1004,21 @@ class CoordinatorGroupRebalance:
         log.debug("Sending JoinGroup (%s) to coordinator %s",
                   request, self.coordinator_id)
         try:
-            response = yield from self._coordinator._send_req(
-                self.coordinator_id, request,
-                group=ConnectionGroup.COORDINATION)
-        except Errors.GroupLoadInProgressError:
-            log.debug("Attempt to join group %s rejected since coordinator %s"
-                      " is loading the group.", self.group_id,
-                      self.coordinator_id)
-        except Errors.UnknownMemberIdError:
-            # reset the member id and retry immediately
-            self._coordinator.member_id = JoinGroupRequest.UNKNOWN_MEMBER_ID
-            log.debug(
-                "Attempt to join group %s failed due to unknown member id",
-                self.group_id)
-            return
-        except (Errors.GroupCoordinatorNotAvailableError,
-                Errors.NotCoordinatorForGroupError) as err:
-            # re-discover the coordinator and retry with backoff
-            self._coordinator.coordinator_dead()
-            log.debug("Attempt to join group %s failed due to obsolete "
-                      "coordinator information: %s", self.group_id,
-                      err)
-        except Errors.KafkaError as err:
-            log.error(
-                "Error in join group '%s' response: %s", self.group_id, err)
-            if not err.retriable:
-                raise
-        else:
+            response = yield from self._coordinator._send_req(request)
+        except Errors.KafkaError:
+            # Return right away. It's a connection error, so backoff will be
+            # handled by coordinator lookup
+            return None
+
+        if not self._subscription.active:
+            # Subscription changed. Ignore response and restart group join
+            return None
+
+        error_type = Errors.for_code(response.error_code)
+        if error_type is Errors.NoError:
             log.debug("Join group response %s", response)
             self._coordinator.member_id = response.member_id
             self._coordinator.generation = response.generation_id
-            self._coordinator.rejoin_needed = False
             protocol = response.group_protocol
             log.info("Joined group '%s' (generation %s) with member_id %s",
                      self.group_id, response.generation_id, response.member_id)
@@ -941,27 +1026,41 @@ class CoordinatorGroupRebalance:
             if response.leader_id == response.member_id:
                 log.info("Elected group leader -- performing partition"
                          " assignments using %s", protocol)
-                cor = self._on_join_leader(response)
+                assignment_bytes = yield from self._on_join_leader(response)
             else:
-                cor = self._on_join_follower()
+                assignment_bytes = yield from self._on_join_follower()
 
-            try:
-                member_assignment_bytes = yield from cor
-            except (Errors.UnknownMemberIdError,
-                    Errors.RebalanceInProgressError,
-                    Errors.IllegalGenerationError):
-                # The current group is already not correct, maybe we were too
-                # slow and timeouted or a new rebalance is required.
-                pass
-            except Errors.KafkaError as err:
-                if not err.retriable:
-                    raise
-            else:
-                return (protocol, member_assignment_bytes)
-
-        # backoff wait - failure case
-        yield from asyncio.sleep(
-            self._retry_backoff_ms / 1000, loop=self.loop)
+            if assignment_bytes is None:
+                return None
+            return (protocol, assignment_bytes)
+        elif error_type is Errors.GroupLoadInProgressError:
+            # Backoff and retry
+            log.debug("Attempt to join group %s rejected since coordinator %s"
+                      " is loading the group.", self.group_id,
+                      self.coordinator_id)
+            yield from asyncio.sleep(
+                self._retry_backoff_ms / 1000, loop=self._loop)
+        elif error_type is Errors.UnknownMemberIdError:
+            # reset the member id and retry immediately
+            self._coordinator.reset_generation()
+            log.debug(
+                "Attempt to join group %s failed due to unknown member id",
+                self.group_id)
+        elif error_type in (Errors.GroupCoordinatorNotAvailableError,
+                            Errors.NotCoordinatorForGroupError):
+            # Coordinator changed we should be able to find it immediately
+            err = error_type()
+            self._coordinator.coordinator_dead()
+            log.debug("Attempt to join group %s failed due to obsolete "
+                      "coordinator information: %s", self.group_id,
+                      err)
+        else:
+            err = error_type()
+            log.error(
+                "Unexpected error in join group '%s' response: %s",
+                self.group_id, err)
+            raise Errors.KafkaError(repr(err))
+        return None
 
     @asyncio.coroutine
     def _on_join_follower(self):
@@ -1016,37 +1115,46 @@ class CoordinatorGroupRebalance:
 
     @asyncio.coroutine
     def _send_sync_group_request(self, request):
-        if (yield from self._coordinator.coordinator_unknown()):
-            raise Errors.GroupCoordinatorNotAvailableError()
+        # We need to reset the rejoin future right after the assignment to
+        # capture metadata changes after join group was performed. We do not
+        # set it directly after JoinGroup to avoid a false rejoin in case
+        # ``_perform_assignment()`` does a metadata update.
+        self._coordinator._rejoin_needed_fut = create_future(loop=self._loop)
 
         response = None
         try:
-            response = yield from self._coordinator._send_req(
-                self.coordinator_id, request,
-                group=ConnectionGroup.COORDINATION)
+            response = yield from self._coordinator._send_req(request)
+        except Errors.KafkaError:
+            # We lost connection to coordinator. No need to try and finish this
+            # group join, just rejoin again.
+            self._coordinator.request_rejoin()
+            return None
+
+        error_type = Errors.for_code(response.error_code)
+        if error_type is Errors.NoError:
             log.info("Successfully synced group %s with generation %s",
                      self.group_id, self._coordinator.generation)
             return response.member_assignment
-        except Errors.RebalanceInProgressError as err:
-            log.debug("SyncGroup for group %s failed due to coordinator"
+
+        # Error case
+        self._coordinator.request_rejoin()
+        if error_type is Errors.RebalanceInProgressError:
+            log.debug("SyncGroup for group %s failed due to group"
                       " rebalance", self.group_id)
-            raise err
-        except (Errors.UnknownMemberIdError,
-                Errors.IllegalGenerationError) as err:
+        elif error_type is (Errors.UnknownMemberIdError,
+                            Errors.IllegalGenerationError):
+            err = error_type()
             log.debug("SyncGroup for group %s failed due to %s,",
                       self.group_id, err)
-            self._coordinator.member_id = JoinGroupRequest.UNKNOWN_MEMBER_ID
-            raise err
-        except (Errors.GroupCoordinatorNotAvailableError,
-                Errors.NotCoordinatorForGroupError) as err:
+            self._coordinator.reset_generation()
+        elif error_type in (Errors.GroupCoordinatorNotAvailableError,
+                            Errors.NotCoordinatorForGroupError):
             log.debug("SyncGroup for group %s failed due to %s",
                       self.group_id, err)
             self._coordinator.coordinator_dead()
-            raise err
-        except Errors.KafkaError as err:
+        elif error_type is Errors.KafkaError:
+            err = error_type()
             log.error("Unexpected error from SyncGroup: %s", err)
-            raise err
-        finally:
-            if response is None:
-                # Always rejoin on error
-                self._coordinator.rejoin_needed = True
+            raise Errors.KafkaError(repr(err))
+
+        return None

--- a/aiokafka/consumer/group_coordinator.py
+++ b/aiokafka/consumer/group_coordinator.py
@@ -782,7 +782,8 @@ class GroupCoordinator(BaseCoordinator):
                 log.warning("Auto offset commit failed: %s", error)
                 if error.retriable:
                     # Retry after backoff.
-                    self._next_autocommit_deadline = now + backoff
+                    self._next_autocommit_deadline = \
+                        self._loop.time() + backoff
                     return backoff
             except Exception as error:  # pragma: no cover
                 log.exception("Auto offset commit errored: %s", error)
@@ -1043,10 +1044,6 @@ class CoordinatorGroupRebalance:
         On how to handle cases read in https://cwiki.apache.org/confluence/\
             display/KAFKA/Kafka+Client-side+Assignment+Proposal
     """
-
-    __slots__ = ("_coordinator", "group_id", "coordinator_id", "_subscription",
-                 "_assignors", "_session_timeout_ms", "_retry_backoff_ms",
-                 "_loop")
 
     def __init__(self, coordinator, group_id, coordinator_id, subscription,
                  assignors, session_timeout_ms, retry_backoff_ms, *, loop):

--- a/aiokafka/consumer/subscription_state.py
+++ b/aiokafka/consumer/subscription_state.py
@@ -278,7 +278,7 @@ class Subscription:
     def _assign(self, topic_partitions: Set[TopicPartition]):
         for tp in topic_partitions:
             assert tp.topic in self._topics, \
-                "Received an assignment for unsubscribed topic: %s" % tp
+                "Received an assignment for unsubscribed topic: %s" % (tp, )
 
         if self._assignment is not None:
             self._assignment._unassign()

--- a/aiokafka/consumer/subscription_state.py
+++ b/aiokafka/consumer/subscription_state.py
@@ -1,0 +1,527 @@
+import logging
+from asyncio import AbstractEventLoop as ALoop, shield
+from enum import Enum
+from typing import Set, Pattern, Dict
+
+from aiokafka.errors import IllegalStateError
+from aiokafka.structs import OffsetAndMetadata, TopicPartition
+from aiokafka.abc import ConsumerRebalanceListener
+from aiokafka.util import create_future
+
+log = logging.getLogger(__name__)
+
+
+class SubscriptionType(Enum):
+
+    NONE = 1
+    AUTO_TOPICS = 2
+    AUTO_PATTERN = 3
+    USER_ASSIGNED = 4
+
+
+class SubscriptionState:
+    """ Intermidiate bridge to coordinate work between Consumer, Coordinator
+    and Fetcher primitives.
+
+        The class is different from kafka-python's implementation to provide
+    a more friendly way to interact in asynchronous paradigm. The changes
+    focus on making the internals less mutable (subscription, topic state etc.)
+    paired with futures for when those change.
+        Before there was a lot of trouble if user say did a subscribe between
+    yield statements of a rebalance or other critical IO operation.
+    """
+
+    _subscription_type = SubscriptionType.NONE  # type: SubscriptionType
+    _subscribed_pattern = None  # type: str
+    _subscription = None  # type: Subscription
+    _listener = None  # type: ConsumerRebalanceListener
+
+    def __init__(self, *, loop: ALoop):
+        self._subscription_waiters = []  # type: List[Future]
+        self._assignment_waiters = []  # type: List[Future]
+        self._loop = loop  # type: ALoop
+
+    @property
+    def subscription(self) -> "Subscription":
+        return self._subscription
+
+    @property
+    def subscription_type(self) -> SubscriptionType:
+        return self._subscription_type
+
+    @property
+    def subscribed_pattern(self) -> Pattern:
+        return self._subscribed_pattern
+
+    @property
+    def listener(self) -> ConsumerRebalanceListener:
+        return self._listener
+
+    def assigned_partitions(self) -> Set[TopicPartition]:
+        if self._subscription is None:
+            return set([])
+        if self._subscription.assignment is None:
+            return set([])
+        return self._subscription.assignment.tps
+
+    @property
+    def reassignment_in_progress(self):
+        if self._subscription is None:
+            return True
+        return self._subscription._reassignment_in_progress
+
+    def partitions_auto_assigned(self) -> bool:
+        return (
+            self._subscription_type == SubscriptionType.AUTO_TOPICS or
+            self._subscription_type == SubscriptionType.AUTO_PATTERN
+        )
+
+    def all_consumed_offsets(self) -> Dict[TopicPartition, OffsetAndMetadata]:
+        """Returns consumed offsets as {TopicPartition: OffsetAndMetadata}"""
+        assignment = self._subscription.assignment
+        assert assignment is not None
+        return assignment.all_consumed_offsets()
+
+    def is_assigned(self, tp: TopicPartition) -> bool:
+        if self._subscription is None:
+            return False
+        if self._subscription.assignment is None:
+            return False
+        return tp in self._subscription.assignment.tps
+
+    def _set_subscription_type(self, subscription_type: SubscriptionType):
+        if (self._subscription_type == SubscriptionType.NONE or
+                self._subscription_type == subscription_type):
+            self._subscription_type = subscription_type
+        else:
+            raise IllegalStateError(
+                "Subscription to topics, partitions and pattern are mutually "
+                "exclusive")
+
+    def _change_subscription(self, subscription: "Subscription"):
+        log.info('Updating subscribed topics to: %s', subscription.topics)
+        # Set old subscription as inactive
+        if self._subscription is not None:
+            self._subscription._unsubscribe()
+        self._subscription = subscription
+        self._notify_subscription_waiters()
+
+    def _assigned_state(self, tp: TopicPartition) -> "TopicPartitionState":
+        assert self._subscription is not None
+        assert self._subscription.assignment is not None
+        tp_state = self._subscription.assignment.state_value(tp)
+        if tp_state is None:
+            raise IllegalStateError(
+                "No current assignment for partition %s" % tp)
+        return tp_state
+
+    def _notify_subscription_waiters(self):
+        for waiter in self._subscription_waiters:
+            if not waiter.done():
+                waiter.set_result(None)
+        self._subscription_waiters.clear()
+
+    def _notify_assignment_waiters(self):
+        for waiter in self._assignment_waiters:
+            if not waiter.done():
+                waiter.set_result(None)
+        self._assignment_waiters.clear()
+
+    # Consumer callable API:
+
+    def subscribe(self, topics: Set[str], listener=None):
+        """ Subscribe to a list (or tuple) of topics
+
+        Caller: Consumer.
+        Affects: SubscriptionState.subscription
+        """
+        assert isinstance(topics, set)
+        assert (listener is None or
+                isinstance(listener, ConsumerRebalanceListener))
+        self._set_subscription_type(SubscriptionType.AUTO_TOPICS)
+
+        self._change_subscription(Subscription(topics, loop=self._loop))
+        self._listener = listener
+        self._notify_subscription_waiters()
+
+    def subscribe_pattern(self, pattern: Pattern, listener=None):
+        """ Subscribe to all topics matching a regex pattern.
+        Subsequent calls `subscribe_from_pattern()` by Coordinator will provide
+        the actual subscription topics.
+
+        Caller: Consumer.
+        Affects: SubscriptionState.subscribed_pattern
+        """
+        assert hasattr(pattern, "match"), "Expected Pattern type"
+        assert (listener is None or
+                isinstance(listener, ConsumerRebalanceListener))
+        self._set_subscription_type(SubscriptionType.AUTO_PATTERN)
+
+        self._subscribed_pattern = pattern
+        self._listener = listener
+
+    def assign_from_user(self, partitions: Set[TopicPartition]):
+        """ Manually assign partitions. After this call automatic assignment
+        will be impossible and will raise an ``IllegalStateError``.
+
+        Caller: Consumer.
+        Affects: SubscriptionState.subscription
+        """
+        self._set_subscription_type(SubscriptionType.USER_ASSIGNED)
+
+        self._change_subscription(
+            ManualSubscription(partitions, loop=self._loop))
+        self._notify_assignment_waiters()
+
+    def unsubscribe(self):
+        """ Unsubscribe from the last subscription. This will also clear the
+        subscription type.
+
+        Caller: Consumer.
+        Affects: SubscriptionState.subscription
+        """
+        # Set old subscription as inactive
+        if self._subscription is not None:
+            self._subscription._unsubscribe()
+
+        self._subscription = None
+        self._subscribed_pattern = None
+        self._listener = None
+        self._subscription_type = SubscriptionType.NONE
+
+    def need_offset_reset(self, tp: Set[TopicPartition], strategy: int):
+        """ Reset fetch position to either end or start
+
+        Caller: Consumer.
+        Affects: TopicPartitionState.reset_strategy
+        """
+        self._assigned_state(tp).await_reset(strategy)
+
+    # Coordinator callable API:
+
+    def subscribe_from_pattern(self, topics: Set[str]):
+        """ Change subscription on cluster metadata update if a new topic
+        created or one is removed.
+
+        Caller: Coordinator
+        Affects: SubscriptionState.subscription
+        """
+        assert self._subscription_type == SubscriptionType.AUTO_PATTERN
+        self._change_subscription(Subscription(topics, loop=self._loop))
+
+    def assign_from_subscribed(self, assignment: Set[TopicPartition]):
+        """ Set assignment if automatic assignment is used.
+
+        Caller: Coordinator
+        Affects: SubscriptionState.subscription.assignment
+        """
+        assert self._subscription_type in [
+            SubscriptionType.AUTO_PATTERN, SubscriptionType.AUTO_TOPICS]
+
+        self._subscription._assign(assignment)
+        self._notify_assignment_waiters()
+
+    def committed(self, tp: TopicPartition, offset_meta: OffsetAndMetadata):
+        """ Saved the position to Kafka.
+
+        Caller: Coordinator
+        Affects: TopicPartitionState.committed
+        """
+        self._assigned_state(tp).committed(offset_meta)
+
+    def begin_reassignment(self):
+        """ Signal from Coordinator that a group re-join is needed. For example
+        this will be called if a commit or heartbeat fails with an
+        InvalidMember error.
+        """
+        self._subscription._begin_reassignment()
+
+    def wait_for_subscription(self):
+        fut = create_future(loop=self._loop)
+        self._subscription_waiters.append(fut)
+        return fut
+
+    # Fetcher callable API:
+
+    def seek(self, tp: TopicPartition, offset: int):
+        """ Force reset of position to the specified offset.
+
+        Caller: Consumer, Fetcher
+        Affects: TopicPartitionState.position
+        """
+        self._assigned_state(tp).seek(offset)
+
+    def wait_for_assignment(self):
+        fut = create_future(loop=self._loop)
+        self._assignment_waiters.append(fut)
+        return fut
+
+
+class Subscription:
+    """ Describes current subscription to a list of topics. In case of pattern
+    subscription a new instance of this class will be created if number of
+    matched topics change.
+
+    States:
+        * Subscribed
+        * Assigned (assignment was set)
+        * Unsubscribed
+    """
+
+    def __init__(self, topics: Set[str], *, loop: ALoop):
+        self._topics = frozenset(topics)  # type: Set[str]
+        self._assignment = None  # type: Assignment
+        self._loop = loop  # type: ALoop
+        self.unsubscribe_future = create_future(loop)  # type: Future
+        self._reassignment_in_progress = True
+
+    @property
+    def active(self):
+        return self.unsubscribe_future.done() is False
+
+    @property
+    def topics(self):
+        return self._topics
+
+    @property
+    def assignment(self):
+        return self._assignment
+
+    @property
+    def reassignment_in_progress(self):
+        return self._reassignment_in_progress
+
+    def _assign(self, topic_partitions: Set[TopicPartition]):
+        for tp in topic_partitions:
+            assert tp.topic in self._topics, \
+                "Received an assignment for unsubscribed topic: %s" % tp
+
+        if self._assignment is not None:
+            self._assignment._unassign()
+
+        self._assignment = Assignment(topic_partitions, loop=self._loop)
+        self._reassignment_in_progress = False
+
+    def _unsubscribe(self):
+        self.unsubscribe_future.set_result(None)
+        if self._assignment is not None:
+            self._assignment._unassign()
+
+    def _begin_reassignment(self):
+        self._reassignment_in_progress = True
+
+
+class ManualSubscription(Subscription):
+    """ Describes a user assignment
+    """
+
+    def __init__(self, user_assignment: Set[TopicPartition], *, loop):
+        topics = set([])
+        for tp in user_assignment:
+            topics.add(tp.topic)
+
+        self._topics = frozenset(topics)
+        self._assignment = Assignment(user_assignment, loop=loop)
+        self._loop = loop
+        self.unsubscribe_future = create_future(loop)
+
+    def _assign(self, topic_partitions: Set[TopicPartition]):
+        assert False, "Should not be called"
+
+    @property
+    def reassignment_in_progress(self):
+        return False
+
+    def _begin_reassignment(self):
+        assert False, "Should not be called"
+
+
+class Assignment:
+    """ Describes current partition assignment. New instance will be created
+    on each group rebalance if automatic assignment is used.
+
+    States:
+        * Assigned
+        * Unassigned
+    """
+
+    def __init__(self, topic_partitions: Set[TopicPartition], *, loop):
+        assert isinstance(topic_partitions, (list, set, tuple))
+
+        self._topic_partitions = frozenset(topic_partitions)
+
+        self._tp_state = {}  # type: Dict[TopicPartition:TopicPartitionState]
+        for tp in self._topic_partitions:
+            self._tp_state[tp] = TopicPartitionState(loop=loop)
+
+        self._loop = loop
+        self.unassign_future = create_future(loop)
+
+    @property
+    def tps(self):
+        return self._topic_partitions
+
+    @property
+    def active(self):
+        return self.unassign_future.done() is False
+
+    def _unassign(self):
+        self.unassign_future.set_result(None)
+
+    def state_value(self, tp: TopicPartition) -> "TopicPartitionState":
+        return self._tp_state.get(tp)
+
+    def all_consumed_offsets(self) -> Dict[TopicPartition, OffsetAndMetadata]:
+        """ Returns consumed offsets as {TopicPartition: OffsetAndMetadata} """
+        all_consumed = {}
+        for tp in self._topic_partitions:
+            state = self.state_value(tp)
+            if state.has_valid_position:
+                all_consumed[tp] = OffsetAndMetadata(state.position, '')
+        return all_consumed
+
+    def missing_commit_cache(self):
+        """ Return all partitions that don't have a commit point cache """
+        missing = []
+        for tp in self._topic_partitions:
+            tp_state = self.state_value(tp)
+            if tp_state.committed is None:
+                missing.append(tp)
+        return missing
+
+
+class PartitionStatus(Enum):
+
+    ASSIGNED = 0
+    AWAITING_RESET = 1
+    CONSUMING = 2
+    UNASSIGNED = 3
+
+
+class TopicPartitionState(object):
+    """ Shared Partition metadata state.
+
+    After creation the workflow is similar to:
+
+        * Partition assigned to this consumer (ASSIGNED)
+        * Coordinator checks the latest commit offset for partition (
+          ASSIGNED -> AWAITING_RESET)
+        * Fetcher either uses commit save point or resets position in respect
+          to defined reset policy (AWAITING_RESET -> CONSUMING)
+        * Fetcher loads a new batch of records, yields results to consumer
+          and updates consumed position (CONSUMING)
+        * Assignment changed or subscription changed (CONSUMING -> UNASSIGNED)
+
+    """
+
+    def __init__(self, *, loop):
+        # Synchronized values
+        self._committed = None  # Last committed position and metadata
+        self._committed_fut = create_future(loop=loop)
+
+        self.highwater = None  # Last fetched highwater mark
+        self._position = None  # The current position of the topic
+        self._position_fut = create_future(loop=loop)
+
+        # Will be set by `seek_to_beginning` or `seek_to_end` if called by user
+        # or by Fetcher after confirming that current position is no longer
+        # reachable.
+        self._reset_strategy = None  # type: int
+        self._status = PartitionStatus.ASSIGNED  # type: PartitionStatus
+
+        self._loop = loop
+
+    @property
+    def committed(self) -> OffsetAndMetadata:
+        return self._committed
+
+    @property
+    def has_valid_position(self) -> bool:
+        return self._position is not None
+
+    @property
+    def position(self) -> int:
+        assert self._position is not None
+        return self._position
+
+    @property
+    def awaiting_reset(self):
+        return self._reset_strategy is not None
+
+    @property
+    def reset_strategy(self) -> int:
+        return self._reset_strategy
+
+    def await_reset(self, strategy):
+        """ Called by either Coonsumer in `seek_to_*` or by Coordinator after
+        setting initial committed point.
+        """
+        self._reset_strategy = strategy
+        self._position = None
+        if self._position_fut.done():
+            self._position_fut = create_future(loop=self._loop)
+        self._status = PartitionStatus.AWAITING_RESET
+
+    # Committed manipulation
+
+    def reset_committed(self, offset_meta: OffsetAndMetadata):
+        """ Called by Coordinator on initial commit query after assignment.
+        """
+        self._committed = offset_meta
+        self._committed_fut.set_result(None)
+        if self._status == PartitionStatus.ASSIGNED:
+            self._status = PartitionStatus.AWAITING_RESET
+
+    def begin_commit(self):
+        """ Signal that currently we started committing offset for this
+        partition, so we can't rely on commit cache. It can be bad if we
+        reset offset to previous commit point.
+        """
+        self._committed = None
+        if self._committed_fut.done():
+            self._committed_fut = create_future(loop=self._loop)
+
+    def update_committed(self, offset_meta: OffsetAndMetadata):
+        """ Called by Coordinator on successfull commit to update commit cache.
+        """
+        self._committed = offset_meta
+        if not self._committed_fut.done():
+            self._committed_fut.set_result(None)
+
+    def wait_for_committed(self):
+        return shield(self._committed_fut, loop=self._loop)
+
+    # Position manipulation
+
+    def consumed_to(self, position: int):
+        """ Called by Fetcher when yielding results to Consumer
+        """
+        assert self._status == PartitionStatus.CONSUMING
+        self._position = position
+
+    def reset_to(self, position: int):
+        """ Called by Fetcher after performing a reset to force position to
+        a new point.
+        """
+        assert self._status == PartitionStatus.AWAITING_RESET
+        self._position = position
+        self._reset_strategy = None
+        self._status = PartitionStatus.CONSUMING
+        if not self._position_fut.done():
+            self._position_fut.set_result(None)
+
+    def seek(self, position: int):
+        """ Called by Consumer to force position to a specific offset
+        """
+        self._position = position
+        self._reset_strategy = None
+        self._status = PartitionStatus.CONSUMING
+        if not self._position_fut.done():
+            self._position_fut.set_result(None)
+
+    def wait_for_position(self):
+        return shield(self._position_fut, loop=self._loop)
+
+    def __repr__(self):
+        return "TopicPartitionState<Status={} position={}>".format(
+            self._status, self._position)

--- a/aiokafka/consumer/subscription_state.py
+++ b/aiokafka/consumer/subscription_state.py
@@ -46,10 +46,6 @@ class SubscriptionState:
         return self._subscription
 
     @property
-    def subscription_type(self) -> SubscriptionType:
-        return self._subscription_type
-
-    @property
     def subscribed_pattern(self) -> Pattern:
         return self._subscribed_pattern
 
@@ -75,12 +71,6 @@ class SubscriptionState:
             self._subscription_type == SubscriptionType.AUTO_TOPICS or
             self._subscription_type == SubscriptionType.AUTO_PATTERN
         )
-
-    def all_consumed_offsets(self) -> Dict[TopicPartition, OffsetAndMetadata]:
-        """Returns consumed offsets as {TopicPartition: OffsetAndMetadata}"""
-        assignment = self._subscription.assignment
-        assert assignment is not None
-        return assignment.all_consumed_offsets()
 
     def is_assigned(self, tp: TopicPartition) -> bool:
         if self._subscription is None:
@@ -112,7 +102,7 @@ class SubscriptionState:
         tp_state = self._subscription.assignment.state_value(tp)
         if tp_state is None:
             raise IllegalStateError(
-                "No current assignment for partition %s" % tp)
+                "No current assignment for partition {}".format(tp))
         return tp_state
 
     def _notify_subscription_waiters(self):
@@ -281,10 +271,6 @@ class Subscription:
     def assignment(self):
         return self._assignment
 
-    @property
-    def reassignment_in_progress(self):
-        return self._reassignment_in_progress
-
     def _assign(self, topic_partitions: Set[TopicPartition]):
         for tp in topic_partitions:
             assert tp.topic in self._topics, \
@@ -319,14 +305,15 @@ class ManualSubscription(Subscription):
         self._loop = loop
         self.unsubscribe_future = create_future(loop)
 
-    def _assign(self, topic_partitions: Set[TopicPartition]):
+    def _assign(
+            self, topic_partitions: Set[TopicPartition]):  # pragma: no cover
         assert False, "Should not be called"
 
     @property
     def _reassignment_in_progress(self):
         return False
 
-    def _begin_reassignment(self):
+    def _begin_reassignment(self):  # pragma: no cover
         assert False, "Should not be called"
 
 
@@ -485,8 +472,7 @@ class TopicPartitionState(object):
             self._committed_fut.set_result(None)
 
     def wait_for_committed(self):
-        if self._committed is not None:
-            return
+        assert self._committed is not None
         self._assignment.commit_refresh_needed.set()
         return shield(self._committed_fut, loop=self._loop)
 

--- a/aiokafka/consumer/subscription_state.py
+++ b/aiokafka/consumer/subscription_state.py
@@ -472,7 +472,7 @@ class TopicPartitionState(object):
             self._committed_fut.set_result(None)
 
     def wait_for_committed(self):
-        assert self._committed is not None
+        assert self._committed is None
         self._assignment.commit_refresh_needed.set()
         return shield(self._committed_fut, loop=self._loop)
 

--- a/aiokafka/consumer/subscription_state.py
+++ b/aiokafka/consumer/subscription_state.py
@@ -1,6 +1,10 @@
 import logging
 from asyncio import AbstractEventLoop as ALoop, shield, Event
-from enum import Enum
+try:
+    from enum import Enum
+except ImportError:
+    Enum = object
+
 from typing import Set, Pattern, Dict
 
 from aiokafka.errors import IllegalStateError

--- a/aiokafka/consumer/subscription_state.py
+++ b/aiokafka/consumer/subscription_state.py
@@ -1,9 +1,6 @@
 import logging
 from asyncio import AbstractEventLoop as ALoop, shield, Event
-try:
-    from enum import Enum
-except ImportError:
-    Enum = object
+from enum import Enum
 
 from typing import Set, Pattern, Dict
 

--- a/examples/simple_produce.py
+++ b/examples/simple_produce.py
@@ -8,11 +8,14 @@ async def send_one():
         loop=loop, bootstrap_servers='localhost:9092')
     # Get cluster layout and topic/partition allocation
     await producer.start()
-    try:
-        # Produce messages
-        res = await producer.send_and_wait("my_topic", b"Super message")
-        print(res)
-    finally:
-        await producer.stop()
+    while True:
+        try:
+            # Produce messages
+            res = await producer.send_and_wait("test-topic", b"Super message")
+            print(res)
+            await asyncio.sleep(1)
+        except:
+            await producer.stop()
+            raise
 
 loop.run_until_complete(send_one())

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 flake8==3.5.0
-pytest==3.3.2
+pytest<3.3.0  # Python3.3 dropped in 3.3. And some problems with catchlog
 pytest-cov==2.5.1
 pytest-catchlog==1.2.2
 docker-py==1.10.6

--- a/setup.py
+++ b/setup.py
@@ -77,13 +77,14 @@ install_requires = ['kafka-python==1.3.3']
 
 PY_VER = sys.version_info
 
-if PY_VER <= (3, 4):
+if PY_VER >= (3, 5):
+    pass
+elif PY_VER >= (3, 4):
     install_requires.append('typing')
-
-if PY_VER == (3, 3):
+elif PY_VER >= (3, 3):
+    install_requires.append('typing')
     install_requires.append('asyncio')
-
-if PY_VER < (3, 3):
+else:
     raise RuntimeError("aiokafka doesn't suppport Python earlier than 3.3")
 
 

--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,7 @@ if PY_VER >= (3, 4):
     pass
 elif PY_VER >= (3, 3):
     install_requires.append('asyncio')
+    install_requires.append('enum')
 else:
     raise RuntimeError("aiokafka doesn't suppport Python earlier than 3.3")
 

--- a/setup.py
+++ b/setup.py
@@ -77,12 +77,13 @@ install_requires = ['kafka-python==1.3.3']
 
 PY_VER = sys.version_info
 
-if PY_VER >= (3, 4):
-    pass
-elif PY_VER >= (3, 3):
+if PY_VER <= (3, 4):
+    install_requires.append('typing')
+
+if PY_VER == (3, 3):
     install_requires.append('asyncio')
-    install_requires.append('enum')
-else:
+
+if PY_VER < (3, 3):
     raise RuntimeError("aiokafka doesn't suppport Python earlier than 3.3")
 
 

--- a/tests/_testutil.py
+++ b/tests/_testutil.py
@@ -147,11 +147,11 @@ class KafkaIntegrationTestCase(unittest.TestCase):
     def tearDown(self):
         super().tearDown()
         for coro, args, kw in reversed(self._cleanup):
-            self.loop.run_until_complete(coro(*args, **kw))
+            task = asyncio.wait_for(coro(*args, **kw), 30, loop=self.loop)
+            self.loop.run_until_complete(task)
 
     def add_cleanup(self, cb_or_coro, *args, **kw):
-        self._cleanup.append(
-            (cb_or_coro, args, kw))
+        self._cleanup.append((cb_or_coro, args, kw))
 
     @asyncio.coroutine
     def wait_topic(self, client, topic):

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -369,6 +369,8 @@ class TestConsumerIntegration(KafkaIntegrationTestCase):
             consumer.subscribe(pattern="^(spome(")
         with self.assertRaises(ValueError):
             consumer.subscribe("some_topic")  # should be a list
+        with self.assertRaises(TypeError):
+            consumer.subscribe(topics=["some_topic"], listener=object())
 
     @run_until_complete
     def test_compress_decompress(self):
@@ -558,10 +560,15 @@ class TestConsumerIntegration(KafkaIntegrationTestCase):
             yield from consumer.seek_to_end(tp1)
 
     @run_until_complete
-    def test_consumer_seek_type_errors(self):
+    def test_consumer_seek_errors(self):
         consumer = yield from self.consumer_factory()
         self.add_cleanup(consumer.stop)
+        tp = TopicPartition("topic", 0)
 
+        with self.assertRaises(ValueError):
+            consumer.seek(tp, -1)
+        with self.assertRaises(ValueError):
+            consumer.seek(tp, "")
         with self.assertRaises(TypeError):
             yield from consumer.seek_to_beginning(1)
         with self.assertRaises(TypeError):

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -671,6 +671,7 @@ class TestConsumerIntegration(KafkaIntegrationTestCase):
             consumer = yield from self.consumer_factory(
                 max_poll_records=0)
 
+    @pytest.mark.ssl
     @run_until_complete
     def test_ssl_consume(self):
         # Produce by PLAINTEXT, Consume by SSL

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,20 +1,23 @@
 import asyncio
+import re
 from unittest import mock
 
 from kafka.protocol.group import JoinGroupRequest_v0 as JoinGroupRequest
+from kafka.protocol.commit import OffsetCommitRequest, OffsetCommitResponse_v2
 import kafka.common as Errors
-from kafka.consumer.subscription_state import SubscriptionState
 
 from ._testutil import KafkaIntegrationTestCase, run_until_complete
 
 from aiokafka import ConsumerRebalanceListener
 from aiokafka.errors import (
-    NoBrokersAvailable, GroupCoordinatorNotAvailableError, KafkaError)
+    NoBrokersAvailable, GroupCoordinatorNotAvailableError, KafkaError,
+    for_code)
 from aiokafka.producer import AIOKafkaProducer
 from aiokafka.client import AIOKafkaClient
 from aiokafka.structs import OffsetAndMetadata, TopicPartition
 from aiokafka.consumer.group_coordinator import (
     GroupCoordinator, CoordinatorGroupRebalance)
+from aiokafka.consumer.subscription_state import SubscriptionState
 
 
 class RebalanceListenerForTest(ConsumerRebalanceListener):
@@ -46,13 +49,17 @@ class MockedKafkaErrCode:
 class TestKafkaCoordinatorIntegration(KafkaIntegrationTestCase):
     @run_until_complete
     def test_coordinator_workflow(self):
+        # Check if 2 coordinators will coordinate rebalances correctly
+
         client = AIOKafkaClient(loop=self.loop, bootstrap_servers=self.hosts)
         yield from client.bootstrap()
         yield from self.wait_topic(client, 'topic1')
         yield from self.wait_topic(client, 'topic2')
 
-        subscription = SubscriptionState('latest')
-        subscription.subscribe(topics=('topic1', 'topic2'))
+        # Check if the initial group join is performed correctly with minimal
+        # setup
+        subscription = SubscriptionState(loop=self.loop)
+        subscription.subscribe(topics=set(['topic1', 'topic2']))
         coordinator = GroupCoordinator(
             client, subscription, loop=self.loop,
             session_timeout_ms=10000,
@@ -60,31 +67,34 @@ class TestKafkaCoordinatorIntegration(KafkaIntegrationTestCase):
             retry_backoff_ms=100)
 
         self.assertEqual(coordinator.coordinator_id, None)
-        self.assertEqual(coordinator.rejoin_needed, True)
+        self.assertTrue(coordinator.need_rejoin(subscription.subscription))
 
         yield from coordinator.ensure_coordinator_known()
         self.assertNotEqual(coordinator.coordinator_id, None)
 
-        yield from coordinator.ensure_active_group()
+        if subscription.subscription.assignment is None:
+            yield from subscription.wait_for_assignment()
         self.assertNotEqual(coordinator.coordinator_id, None)
-        self.assertEqual(coordinator.rejoin_needed, False)
+        self.assertFalse(coordinator.need_rejoin(subscription.subscription))
 
         tp_list = subscription.assigned_partitions()
         self.assertEqual(tp_list, set([('topic1', 0), ('topic1', 1),
                                        ('topic2', 0), ('topic2', 1)]))
 
-        # start second coordinator
+        # Check if adding an additional coordinator will rebalance correctly
         client2 = AIOKafkaClient(loop=self.loop, bootstrap_servers=self.hosts)
         yield from client2.bootstrap()
-        subscription2 = SubscriptionState('latest')
-        subscription2.subscribe(topics=('topic1', 'topic2'))
+        subscription2 = SubscriptionState(loop=self.loop)
+        subscription2.subscribe(topics=set(['topic1', 'topic2']))
         coordinator2 = GroupCoordinator(
             client2, subscription2, loop=self.loop,
             session_timeout_ms=10000,
             heartbeat_interval_ms=500,
             retry_backoff_ms=100)
-        yield from coordinator2.ensure_active_group()
-        yield from coordinator.ensure_active_group()
+        yield from asyncio.gather(
+            subscription.wait_for_assignment(),
+            subscription2.wait_for_assignment()
+        )
 
         tp_list = subscription.assigned_partitions()
         self.assertEqual(len(tp_list), 2)
@@ -93,11 +103,12 @@ class TestKafkaCoordinatorIntegration(KafkaIntegrationTestCase):
         tp_list |= tp_list2
         self.assertEqual(tp_list, set([('topic1', 0), ('topic1', 1),
                                        ('topic2', 0), ('topic2', 1)]))
+
+        # Check is closing the first coordinator will rebalance the second
         yield from coordinator.close()
         yield from client.close()
 
-        yield from asyncio.sleep(0.6, loop=self.loop)  # wait heartbeat
-        yield from coordinator2.ensure_active_group()
+        yield from subscription2.wait_for_assignment()
         tp_list = subscription2.assigned_partitions()
         self.assertEqual(tp_list, set([('topic1', 0), ('topic1', 1),
                                        ('topic2', 0), ('topic2', 1)]))
@@ -105,127 +116,106 @@ class TestKafkaCoordinatorIntegration(KafkaIntegrationTestCase):
         yield from coordinator2.close()
         yield from client2.close()
 
-    @run_until_complete
-    def test_failed_broker_conn(self):
-        client = AIOKafkaClient(loop=self.loop, bootstrap_servers=self.hosts)
-        subscription = SubscriptionState('latest')
-        subscription.subscribe(topics=('topic1',))
-        coordinator = GroupCoordinator(
-            client, subscription, loop=self.loop)
+    # @run_until_complete
+    # def test_failed_group_join(self):
+    #     client = AIOKafkaClient(loop=self.loop, bootstrap_servers=self.hosts)
+    #     subscription = SubscriptionState('latest')
+    #     subscription.subscribe(topics=('topic1',))
+    #     coordinator = GroupCoordinator(
+    #         client, subscription, loop=self.loop,
+    #         retry_backoff_ms=10)
 
-        with self.assertRaises(NoBrokersAvailable):
-            yield from coordinator.ensure_coordinator_known()
+    #     @asyncio.coroutine
+    #     def do_rebalance():
+    #         rebalance = CoordinatorGroupRebalance(
+    #             coordinator, coordinator.group_id, coordinator.coordinator_id,
+    #             subscription.subscription, coordinator._assignors,
+    #             coordinator._session_timeout_ms,
+    #             coordinator._retry_backoff_ms,
+    #             loop=self.loop)
+    #         yield from rebalance.perform_group_join()
 
-    @run_until_complete
-    def test_failed_group_join(self):
-        client = AIOKafkaClient(loop=self.loop, bootstrap_servers=self.hosts)
-        subscription = SubscriptionState('latest')
-        subscription.subscribe(topics=('topic1',))
-        coordinator = GroupCoordinator(
-            client, subscription, loop=self.loop,
-            retry_backoff_ms=10)
+    #     yield from client.bootstrap()
+    #     yield from self.wait_topic(client, 'topic1')
 
-        @asyncio.coroutine
-        def do_rebalance():
-            rebalance = CoordinatorGroupRebalance(
-                coordinator, coordinator.group_id, coordinator.coordinator_id,
-                subscription.subscription, coordinator._assignors,
-                coordinator._session_timeout_ms,
-                coordinator._retry_backoff_ms,
-                loop=self.loop)
-            yield from rebalance.perform_group_join()
+    #     mocked = mock.MagicMock()
+    #     coordinator._client = mocked
 
-        yield from client.bootstrap()
-        yield from self.wait_topic(client, 'topic1')
+    #     # no exception expected, just wait
+    #     mocked.send.side_effect = Errors.GroupLoadInProgressError()
+    #     yield from do_rebalance()
+    #     self.assertEqual(coordinator.need_rejoin(), True)
 
-        mocked = mock.MagicMock()
-        coordinator._client = mocked
+    #     mocked.send.side_effect = Errors.InvalidGroupIdError()
+    #     with self.assertRaises(Errors.InvalidGroupIdError):
+    #         yield from do_rebalance()
+    #     self.assertEqual(coordinator.need_rejoin(), True)
 
-        # no exception expected, just wait
-        mocked.send.side_effect = Errors.GroupLoadInProgressError()
-        yield from do_rebalance()
-        self.assertEqual(coordinator.need_rejoin(), True)
+    #     # no exception expected, member_id should be reseted
+    #     coordinator.member_id = 'some_invalid_member_id'
+    #     mocked.send.side_effect = Errors.UnknownMemberIdError()
+    #     yield from do_rebalance()
+    #     self.assertEqual(coordinator.need_rejoin(), True)
+    #     self.assertEqual(
+    #         coordinator.member_id, JoinGroupRequest.UNKNOWN_MEMBER_ID)
 
-        mocked.send.side_effect = Errors.InvalidGroupIdError()
-        with self.assertRaises(Errors.InvalidGroupIdError):
-            yield from do_rebalance()
-        self.assertEqual(coordinator.need_rejoin(), True)
+    #     # no exception expected, coordinator_id should be reseted
+    #     coordinator.coordinator_id = 'some_id'
+    #     mocked.send.side_effect = Errors.GroupCoordinatorNotAvailableError()
+    #     yield from do_rebalance()
+    #     self.assertEqual(coordinator.need_rejoin(), True)
+    #     self.assertEqual(coordinator.coordinator_id, None)
+    #     yield from client.close()
 
-        # no exception expected, member_id should be reseted
-        coordinator.member_id = 'some_invalid_member_id'
-        mocked.send.side_effect = Errors.UnknownMemberIdError()
-        yield from do_rebalance()
-        self.assertEqual(coordinator.need_rejoin(), True)
-        self.assertEqual(
-            coordinator.member_id, JoinGroupRequest.UNKNOWN_MEMBER_ID)
+    # @run_until_complete
+    # def test_failed_sync_group(self):
+    #     client = AIOKafkaClient(loop=self.loop, bootstrap_servers=self.hosts)
+    #     subscription = SubscriptionState('latest')
+    #     subscription.subscribe(topics=('topic1',))
+    #     coordinator = GroupCoordinator(
+    #         client, subscription, loop=self.loop,
+    #         heartbeat_interval_ms=20000)
 
-        # no exception expected, coordinator_id should be reseted
-        coordinator.coordinator_id = 'some_id'
-        mocked.send.side_effect = Errors.GroupCoordinatorNotAvailableError()
-        yield from do_rebalance()
-        self.assertEqual(coordinator.need_rejoin(), True)
-        self.assertEqual(coordinator.coordinator_id, None)
-        yield from client.close()
+    #     @asyncio.coroutine
+    #     def do_sync_group():
+    #         rebalance = CoordinatorGroupRebalance(
+    #             coordinator, coordinator.group_id, coordinator.coordinator_id,
+    #             subscription.subscription, coordinator._assignors,
+    #             coordinator._session_timeout_ms,
+    #             coordinator._retry_backoff_ms,
+    #             loop=self.loop)
+    #         yield from rebalance._on_join_follower()
 
-    @run_until_complete
-    def test_failed_sync_group(self):
-        client = AIOKafkaClient(loop=self.loop, bootstrap_servers=self.hosts)
-        subscription = SubscriptionState('latest')
-        subscription.subscribe(topics=('topic1',))
-        coordinator = GroupCoordinator(
-            client, subscription, loop=self.loop,
-            heartbeat_interval_ms=20000)
+    #     with self.assertRaises(GroupCoordinatorNotAvailableError):
+    #         yield from do_sync_group()
 
-        @asyncio.coroutine
-        def do_sync_group():
-            rebalance = CoordinatorGroupRebalance(
-                coordinator, coordinator.group_id, coordinator.coordinator_id,
-                subscription.subscription, coordinator._assignors,
-                coordinator._session_timeout_ms,
-                coordinator._retry_backoff_ms,
-                loop=self.loop)
-            yield from rebalance._on_join_follower()
+    #     mocked = mock.MagicMock()
+    #     coordinator._client = mocked
 
-        with self.assertRaises(GroupCoordinatorNotAvailableError):
-            yield from do_sync_group()
+    #     coordinator.member_id = 'some_invalid_member_id'
+    #     coordinator.coordinator_unknown = asyncio.coroutine(lambda: False)
+    #     mocked.send.side_effect = Errors.UnknownMemberIdError()
+    #     with self.assertRaises(Errors.UnknownMemberIdError):
+    #         yield from do_sync_group()
+    #     self.assertEqual(
+    #         coordinator.member_id, JoinGroupRequest.UNKNOWN_MEMBER_ID)
 
-        mocked = mock.MagicMock()
-        coordinator._client = mocked
+    #     mocked.send.side_effect = Errors.NotCoordinatorForGroupError()
+    #     coordinator.coordinator_id = 'some_id'
+    #     with self.assertRaises(Errors.NotCoordinatorForGroupError):
+    #         yield from do_sync_group()
+    #     self.assertEqual(coordinator.coordinator_id, None)
 
-        coordinator.member_id = 'some_invalid_member_id'
-        coordinator.coordinator_unknown = asyncio.coroutine(lambda: False)
-        mocked.send.side_effect = Errors.UnknownMemberIdError()
-        with self.assertRaises(Errors.UnknownMemberIdError):
-            yield from do_sync_group()
-        self.assertEqual(
-            coordinator.member_id, JoinGroupRequest.UNKNOWN_MEMBER_ID)
+    #     mocked.send.side_effect = KafkaError()
+    #     with self.assertRaises(KafkaError):
+    #         yield from do_sync_group()
 
-        mocked.send.side_effect = Errors.NotCoordinatorForGroupError()
-        coordinator.coordinator_id = 'some_id'
-        with self.assertRaises(Errors.NotCoordinatorForGroupError):
-            yield from do_sync_group()
-        self.assertEqual(coordinator.coordinator_id, None)
-
-        mocked.send.side_effect = KafkaError()
-        with self.assertRaises(KafkaError):
-            yield from do_sync_group()
-
-        # client sends LeaveGroupRequest to group coordinator
-        # if generation > 0 (means that client is a member of group)
-        # expecting no exception in this case (error should be ignored in close
-        # method)
-        coordinator.generation = 33
-        yield from coordinator.close()
-
-    @run_until_complete
-    def test_with_nocommit_support(self):
-        client = AIOKafkaClient(loop=self.loop, bootstrap_servers=self.hosts)
-        subscription = SubscriptionState('latest')
-        subscription.subscribe(topics=('topic1',))
-        coordinator = GroupCoordinator(
-            client, subscription, loop=self.loop,
-            enable_auto_commit=False)
-        self.assertEqual(coordinator._auto_commit_task, None)
+    #     # client sends LeaveGroupRequest to group coordinator
+    #     # if generation > 0 (means that client is a member of group)
+    #     # expecting no exception in this case (error should be ignored in close
+    #     # method)
+    #     coordinator.generation = 33
+    #     yield from coordinator.close()
 
     @run_until_complete
     def test_subscribe_pattern(self):
@@ -233,8 +223,7 @@ class TestKafkaCoordinatorIntegration(KafkaIntegrationTestCase):
         yield from client.bootstrap()
 
         test_listener = RebalanceListenerForTest()
-        subscription = SubscriptionState('latest')
-        subscription.subscribe(pattern='st-topic*', listener=test_listener)
+        subscription = SubscriptionState(loop=self.loop)
         coordinator = GroupCoordinator(
             client, subscription, loop=self.loop,
             group_id='subs-pattern-group')
@@ -242,9 +231,13 @@ class TestKafkaCoordinatorIntegration(KafkaIntegrationTestCase):
         yield from self.wait_topic(client, 'st-topic1')
         yield from self.wait_topic(client, 'st-topic2')
 
-        yield from coordinator.ensure_active_group()
+        subscription.subscribe_pattern(
+            re.compile('st-topic*'), listener=test_listener)
+        client.set_topics([])
+        yield from subscription.wait_for_assignment()
+
         self.assertNotEqual(coordinator.coordinator_id, None)
-        self.assertEqual(coordinator.rejoin_needed, False)
+        self.assertFalse(coordinator.need_rejoin(subscription.subscription))
 
         tp_list = subscription.assigned_partitions()
         assigned = set([('st-topic1', 0), ('st-topic1', 1),
@@ -260,14 +253,18 @@ class TestKafkaCoordinatorIntegration(KafkaIntegrationTestCase):
     def test_get_offsets(self):
         client = AIOKafkaClient(loop=self.loop, bootstrap_servers=self.hosts)
         yield from client.bootstrap()
+        yield from self.wait_topic(client, 'topic1')
+        tp1 = TopicPartition('topic1', 0)
+        tp2 = TopicPartition('topic1', 1)
 
-        subscription = SubscriptionState('earliest')
-        subscription.subscribe(topics=('topic1',))
+        subscription = SubscriptionState(loop=self.loop)
+        subscription.subscribe(topics=set(['topic1']))
         coordinator = GroupCoordinator(
             client, subscription, loop=self.loop,
             group_id='getoffsets-group')
+        yield from subscription.wait_for_assignment()
+        assignment = subscription.subscription.assignment
 
-        yield from self.wait_topic(client, 'topic1')
         producer = AIOKafkaProducer(
             loop=self.loop, bootstrap_servers=self.hosts)
         yield from producer.start()
@@ -276,121 +273,147 @@ class TestKafkaCoordinatorIntegration(KafkaIntegrationTestCase):
         yield from producer.send('topic1', b'third msg', partition=1)
         yield from producer.stop()
 
-        yield from coordinator.ensure_active_group()
-
         offsets = {TopicPartition('topic1', 0): OffsetAndMetadata(1, ''),
                    TopicPartition('topic1', 1): OffsetAndMetadata(2, '')}
-        yield from coordinator.commit_offsets(offsets)
+        yield from coordinator.commit_offsets(assignment, offsets)
 
-        self.assertEqual(subscription.all_consumed_offsets(), {})
-        subscription.seek(('topic1', 0), 0)
-        subscription.seek(('topic1', 1), 0)
-        yield from coordinator.refresh_committed_offsets()
-        self.assertEqual(subscription.assignment[('topic1', 0)].committed, 1)
-        self.assertEqual(subscription.assignment[('topic1', 1)].committed, 2)
-
-        yield from coordinator.close()
-        yield from client.close()
-
-    @run_until_complete
-    def test_offsets_failed_scenarios(self):
-        client = AIOKafkaClient(loop=self.loop, bootstrap_servers=self.hosts)
-        yield from client.bootstrap()
-        yield from self.wait_topic(client, 'topic1')
-        subscription = SubscriptionState('earliest')
-        subscription.subscribe(topics=('topic1',))
-        coordinator = GroupCoordinator(
-            client, subscription, loop=self.loop,
-            group_id='test-offsets-group')
-
-        yield from coordinator.ensure_active_group()
-
-        offsets = {TopicPartition('topic1', 0): OffsetAndMetadata(1, '')}
-        yield from coordinator.commit_offsets(offsets)
-        with mock.patch('aiokafka.errors.for_code') as mocked:
-            mocked.return_value = Errors.GroupAuthorizationFailedError
-            with self.assertRaises(Errors.GroupAuthorizationFailedError):
-                yield from coordinator.commit_offsets(offsets)
-
-            mocked.return_value = Errors.TopicAuthorizationFailedError
-            with self.assertRaises(Errors.TopicAuthorizationFailedError):
-                yield from coordinator.commit_offsets(offsets)
-
-            mocked.return_value = Errors.InvalidCommitOffsetSizeError
-            with self.assertRaises(Errors.InvalidCommitOffsetSizeError):
-                yield from coordinator.commit_offsets(offsets)
-
-            mocked.return_value = Errors.GroupLoadInProgressError
-            with self.assertRaises(Errors.GroupLoadInProgressError):
-                yield from coordinator.commit_offsets(offsets)
-
-            mocked.return_value = Errors.RebalanceInProgressError
-            with self.assertRaises(Errors.RebalanceInProgressError):
-                yield from coordinator.commit_offsets(offsets)
-            self.assertEqual(subscription.needs_partition_assignment, True)
-            subscription.needs_partition_assignment = False
-
-            mocked.return_value = Errors.UnknownMemberIdError
-            with self.assertRaises(Errors.UnknownMemberIdError):
-                yield from coordinator.commit_offsets(offsets)
-            self.assertEqual(subscription.needs_partition_assignment, True)
-
-            mocked.return_value = KafkaError
-            with self.assertRaises(KafkaError):
-                yield from coordinator.commit_offsets(offsets)
-
-            mocked.return_value = Errors.NotCoordinatorForGroupError
-            with self.assertRaises(Errors.NotCoordinatorForGroupError):
-                yield from coordinator.commit_offsets(offsets)
-            self.assertEqual(coordinator.coordinator_id, None)
-
-            with self.assertRaises(Errors.GroupCoordinatorNotAvailableError):
-                yield from coordinator.commit_offsets(offsets)
+        self.assertEqual(assignment.all_consumed_offsets(), {})
+        subscription.seek(tp1, 0)
+        subscription.seek(tp2, 0)
+        self.assertEqual(assignment.state_value(tp1).committed.offset, 1)
+        self.assertEqual(assignment.state_value(tp2).committed.offset, 2)
 
         yield from coordinator.close()
         yield from client.close()
 
-    @run_until_complete
-    def test_fetchoffsets_failed_scenarios(self):
-        client = AIOKafkaClient(loop=self.loop, bootstrap_servers=self.hosts)
-        yield from client.bootstrap()
-        yield from self.wait_topic(client, 'topic1')
-        subscription = SubscriptionState('earliest')
-        subscription.subscribe(topics=('topic1',))
-        coordinator = GroupCoordinator(
-            client, subscription, loop=self.loop,
-            group_id='fetch-offsets-group')
+    # @run_until_complete
+    # def test_commit_failed_scenarios(self):
+    #     client = AIOKafkaClient(loop=self.loop, bootstrap_servers=self.hosts)
+    #     yield from client.bootstrap()
+    #     yield from self.wait_topic(client, 'topic1')
+    #     subscription = SubscriptionState(loop=self.loop)
+    #     subscription.subscribe(topics=set(['topic1']))
+    #     coordinator = GroupCoordinator(
+    #         client, subscription, loop=self.loop,
+    #         group_id='test-offsets-group')
 
-        yield from coordinator.ensure_active_group()
+    #     yield from subscription.wait_for_assignment()
+    #     assignment = subscription.subscription.assignment
 
-        offsets = {TopicPartition('topic1', 0): OffsetAndMetadata(1, '')}
-        with mock.patch('aiokafka.errors.for_code') as mocked:
-            mocked.side_effect = MockedKafkaErrCode(
-                Errors.GroupLoadInProgressError, Errors.NoError)
-            yield from coordinator.fetch_committed_offsets(offsets)
+    #     offsets = {TopicPartition('topic1', 0): OffsetAndMetadata(1, '')}
+    #     yield from coordinator.commit_offsets(assignment, offsets)
+    #     with mock.patch('aiokafka.errors.for_code') as mocked:
+    #         # Not retriable errors are propagated
+    #         mocked.return_value = Errors.GroupAuthorizationFailedError
+    #         with self.assertRaises(Errors.GroupAuthorizationFailedError):
+    #             yield from coordinator.commit_offsets(assignment, offsets)
 
-            mocked.side_effect = MockedKafkaErrCode(
-                Errors.UnknownMemberIdError, Errors.NoError)
-            with self.assertRaises(Errors.UnknownMemberIdError):
-                yield from coordinator.fetch_committed_offsets(offsets)
-            self.assertEqual(subscription.needs_partition_assignment, True)
+    #         mocked.return_value = Errors.TopicAuthorizationFailedError
+    #         with self.assertRaises(Errors.TopicAuthorizationFailedError):
+    #             yield from coordinator.commit_offsets(assignment, offsets)
 
-            mocked.side_effect = None
-            mocked.return_value = Errors.UnknownTopicOrPartitionError
-            r = yield from coordinator.fetch_committed_offsets(offsets)
-            self.assertEqual(r, {})
+    #         mocked.return_value = Errors.InvalidCommitOffsetSizeError
+    #         with self.assertRaises(Errors.InvalidCommitOffsetSizeError):
+    #             yield from coordinator.commit_offsets(assignment, offsets)
 
-            mocked.return_value = KafkaError
-            with self.assertRaises(KafkaError):
-                yield from coordinator.fetch_committed_offsets(offsets)
+    #         mocked.return_value = Errors.OffsetMetadataTooLargeError
+    #         with self.assertRaises(Errors.OffsetMetadataTooLargeError):
+    #             yield from coordinator.commit_offsets(assignment, offsets)
 
-            mocked.side_effect = MockedKafkaErrCode(
-                Errors.NotCoordinatorForGroupError,
-                Errors.NoError, Errors.NoError, Errors.NoError)
-            yield from coordinator.fetch_committed_offsets(offsets)
+    #         # retriable erros should be retried
+    #         mocked.side_effect = [
+    #             Errors.GroupLoadInProgressError,
+    #             Errors.GroupLoadInProgressError,
+    #             Errors.NoError
+    #         ]
+    #         with self.assertRaises(Errors.GroupLoadInProgressError):
+    #             yield from coordinator.commit_offsets(assignment, offsets)
 
-        yield from coordinator.close()
-        yield from client.close()
+    #         # If rebalance is needed we can't commit offset
+    #         mocked.return_value = Errors.RebalanceInProgressError
+    #         with self.assertRaises(Errors.CommitFailedError):
+    #             yield from coordinator.commit_offsets(assignment, offsets)
+    #         self.assertTrue(coordinator.need_rejoin(subscription.subscription))
+    #         self.assertIsNotNone(coordinator.member_id)
+    #         mocked.side_effect = for_code
+    #         yield from subscription.wait_for_assignment()
+    #         assignment = subscription.subscription.assignment
+
+    #         mocked.return_value = Errors.UnknownMemberIdError
+    #         with self.assertRaises(Errors.CommitFailedError):
+    #             yield from coordinator.commit_offsets(assignment, offsets)
+    #         self.assertTrue(coordinator.need_rejoin(subscription.subscription))
+    #         self.assertIsNone(coordinator.member_id)
+    #         mocked.side_effect = for_code
+    #         yield from subscription.wait_for_assignment()
+    #         assignment = subscription.subscription.assignment
+
+    #         # Unknown errors are just propagated too
+    #         mocked.return_value = KafkaError
+    #         with self.assertRaises(KafkaError):
+    #             yield from coordinator.commit_offsets(assignment, offsets)
+
+
+
+    #         # mocked.side_effect = [
+    #         #     Errors.GroupCoordinatorNotAvailableError,
+    #         #     Errors.NoError
+    #         # ]
+    #         # with self.assertRaises(Errors.GroupCoordinatorNotAvailableError):
+    #         #     yield from coordinator.commit_offsets(assignment, offsets)
+
+    #         # mocked.return_value = Errors.NotCoordinatorForGroupError
+    #         # with self.assertRaises(Errors.NotCoordinatorForGroupError):
+    #         #     yield from coordinator.commit_offsets(assignment, offsets)
+    #         # self.assertEqual(coordinator.coordinator_id, None)
+
+    #         # with self.assertRaises(Errors.GroupCoordinatorNotAvailableError):
+    #         #     yield from coordinator.commit_offsets(assignment, offsets)
+
+    #     yield from coordinator.close()
+    #     yield from client.close()
+
+    # @run_until_complete
+    # def test_fetchoffsets_failed_scenarios(self):
+    #     client = AIOKafkaClient(loop=self.loop, bootstrap_servers=self.hosts)
+    #     yield from client.bootstrap()
+    #     yield from self.wait_topic(client, 'topic1')
+    #     subscription = SubscriptionState('earliest')
+    #     subscription.subscribe(topics=('topic1',))
+    #     coordinator = GroupCoordinator(
+    #         client, subscription, loop=self.loop,
+    #         group_id='fetch-offsets-group')
+
+    #     yield from coordinator.ensure_active_group()
+
+    #     offsets = {TopicPartition('topic1', 0): OffsetAndMetadata(1, '')}
+    #     with mock.patch('aiokafka.errors.for_code') as mocked:
+    #         mocked.side_effect = MockedKafkaErrCode(
+    #             Errors.GroupLoadInProgressError, Errors.NoError)
+    #         yield from coordinator.fetch_committed_offsets(offsets)
+
+    #         mocked.side_effect = MockedKafkaErrCode(
+    #             Errors.UnknownMemberIdError, Errors.NoError)
+    #         with self.assertRaises(Errors.UnknownMemberIdError):
+    #             yield from coordinator.fetch_committed_offsets(offsets)
+    #         self.assertEqual(subscription.needs_partition_assignment, True)
+
+    #         mocked.side_effect = None
+    #         mocked.return_value = Errors.UnknownTopicOrPartitionError
+    #         r = yield from coordinator.fetch_committed_offsets(offsets)
+    #         self.assertEqual(r, {})
+
+    #         mocked.return_value = KafkaError
+    #         with self.assertRaises(KafkaError):
+    #             yield from coordinator.fetch_committed_offsets(offsets)
+
+    #         mocked.side_effect = MockedKafkaErrCode(
+    #             Errors.NotCoordinatorForGroupError,
+    #             Errors.NoError, Errors.NoError, Errors.NoError)
+    #         yield from coordinator.fetch_committed_offsets(offsets)
+
+    #     yield from coordinator.close()
+    #     yield from client.close()
 
     @run_until_complete
     def test_coordinator_subscription_replace_on_rebalance(self):
@@ -401,8 +424,9 @@ class TestKafkaCoordinatorIntegration(KafkaIntegrationTestCase):
         yield from client.bootstrap()
         yield from self.wait_topic(client, 'topic1')
         yield from self.wait_topic(client, 'topic2')
-        subscription = SubscriptionState('earliest')
-        subscription.subscribe(topics=('topic1',))
+        subscription = SubscriptionState(loop=self.loop)
+        subscription.subscribe(topics=set(['topic1']))
+        client.set_topics(('topic1', ))
         coordinator = GroupCoordinator(
             client, subscription, loop=self.loop,
             group_id='race-rebalance-subscribe-replace',
@@ -415,16 +439,19 @@ class TestKafkaCoordinatorIntegration(KafkaIntegrationTestCase):
                 # Change the subscription to different topic before we finish
                 # rebalance
                 res = _perform_assignment(*args, **kw)
-                subscription.subscribe(topics=('topic2', ))
-                client.set_topics(('topic2', ))
+                if subscription.subscription.topics == set(["topic1"]):
+                    subscription.subscribe(topics=set(['topic2']))
+                    client.set_topics(('topic2', ))
                 return res
             mocked.side_effect = _new
 
-            yield from coordinator.ensure_active_group()
-            # yield from asyncio.sleep(10, loop=self.loop)
-            self.assertEqual(subscription.needs_partition_assignment, False)
-            topics = set([tp.topic for tp in subscription.assignment])
+            yield from subscription.wait_for_assignment()
+            topics = set([
+                tp.topic for tp in subscription.assigned_partitions()])
             self.assertEqual(topics, {'topic2'})
+
+            # There should only be 2 rebalances to finish the task
+            self.assertEqual(mocked.call_count, 2)
 
         yield from coordinator.close()
         yield from client.close()
@@ -436,8 +463,8 @@ class TestKafkaCoordinatorIntegration(KafkaIntegrationTestCase):
         yield from client.bootstrap()
         yield from self.wait_topic(client, 'topic1')
         yield from self.wait_topic(client, 'topic2')
-        subscription = SubscriptionState('earliest')
-        subscription.subscribe(topics=('topic1',))
+        subscription = SubscriptionState(loop=self.loop)
+        subscription.subscribe(topics=set(['topic1']))
         coordinator = GroupCoordinator(
             client, subscription, loop=self.loop,
             group_id='race-rebalance-subscribe-append',
@@ -450,15 +477,19 @@ class TestKafkaCoordinatorIntegration(KafkaIntegrationTestCase):
                 # Change the subscription to different topic before we finish
                 # rebalance
                 res = _perform_assignment(*args, **kw)
-                subscription.subscribe(topics=('topic1', 'topic2', ))
-                client.set_topics(('topic1', 'topic2', ))
+                if subscription.subscription.topics == set(["topic1"]):
+                    subscription.subscribe(topics=set(['topic1', 'topic2']))
+                    client.set_topics(('topic1', 'topic2', ))
                 return res
             mocked.side_effect = _new
 
-            yield from coordinator.ensure_active_group()
-            self.assertEqual(subscription.needs_partition_assignment, False)
-            topics = set([tp.topic for tp in subscription.assignment])
+            yield from subscription.wait_for_assignment()
+            topics = set([
+                tp.topic for tp in subscription.assigned_partitions()])
             self.assertEqual(topics, {'topic1', 'topic2'})
+
+            # There should only be 2 rebalances to finish the task
+            self.assertEqual(mocked.call_count, 2)
 
         yield from coordinator.close()
         yield from client.close()
@@ -478,19 +509,18 @@ class TestKafkaCoordinatorIntegration(KafkaIntegrationTestCase):
         client = AIOKafkaClient(loop=self.loop, bootstrap_servers=self.hosts)
         yield from client.bootstrap()
         self.add_cleanup(client.close)
-        subscription = SubscriptionState('earliest')
-        client.set_topics(["topic1"])
-        subscription.subscribe(topics=('topic1',))
+        subscription = SubscriptionState(loop=self.loop)
+        client.set_topics(("topic1", ))
+        subscription.subscribe(topics=set(['topic1']))
         coordinator = GroupCoordinator(
             client, subscription, loop=self.loop,
             group_id='race-rebalance-metadata-update',
             heartbeat_interval_ms=20000000)
         self.add_cleanup(coordinator.close)
-        yield from coordinator.ensure_active_group()
+        yield from subscription.wait_for_assignment()
         # Check that topic's partitions are properly assigned
-        self.assertEqual(subscription.needs_partition_assignment, False)
         self.assertEqual(
-            set(subscription.assignment.keys()),
+            subscription.assigned_partitions(),
             {TopicPartition("topic1", 0), TopicPartition("topic1", 1)})
 
         _metadata_update = client._metadata_update
@@ -504,12 +534,14 @@ class TestKafkaCoordinatorIntegration(KafkaIntegrationTestCase):
                 return res
             mocked.side_effect = _new
 
-            subscription.subscribe(topics=('topic2', ))
+            # This case will assure, that the started metadata update will be
+            # waited for before assigning partitions. ``set_topics`` will start
+            # the metadata update
+            subscription.subscribe(topics=set(['topic2']))
             client.set_topics(('topic2', ))
-            yield from coordinator.ensure_active_group()
-            self.assertEqual(subscription.needs_partition_assignment, False)
+            yield from subscription.wait_for_assignment()
             self.assertEqual(
-                set(subscription.assignment.keys()),
+                subscription.assigned_partitions(),
                 {TopicPartition("topic2", 0), TopicPartition("topic2", 1)})
 
     @run_until_complete
@@ -524,30 +556,31 @@ class TestKafkaCoordinatorIntegration(KafkaIntegrationTestCase):
         client.set_topics(['other_topic'])
         yield from client.force_metadata_update()
 
-        subscription = SubscriptionState('earliest')
+        subscription = SubscriptionState(loop=self.loop)
         coordinator = GroupCoordinator(
             client, subscription, loop=self.loop,
             group_id='race-rebalance-subscribe-append',
             heartbeat_interval_ms=2000000)
-        subscription.subscribe(topics=('topic1',))
-        yield from client.set_topics(subscription.group_subscription())
-        yield from coordinator.ensure_active_group()
+        subscription.subscribe(topics=set(['topic1']))
+        yield from client.set_topics(('topic1', ))
+        yield from subscription.wait_for_assignment()
 
         _perform_assignment = coordinator._perform_assignment
         with mock.patch.object(coordinator, '_perform_assignment') as mocked:
             mocked.side_effect = _perform_assignment
 
-            subscription.subscribe(topics=('topic2',))
-            yield from client.set_topics(subscription.group_subscription())
+            subscription.subscribe(topics=set(['topic2']))
+            yield from client.set_topics(('topic2', ))
 
             # Should only trigger 1 rebalance, but will trigger 2 with bug:
             #   Metadata snapshot will change:
             #   {'topic1': {0, 1}} -> {'topic1': {0, 1}, 'topic2': {0, 1}}
             #   And then again:
             #   {'topic1': {0, 1}, 'topic2': {0, 1}} -> {'topic2': {0, 1}}
-            yield from coordinator.ensure_active_group()
+            yield from subscription.wait_for_assignment()
             yield from client.force_metadata_update()
-            yield from coordinator.ensure_active_group()
+            self.assertFalse(
+                coordinator.need_rejoin(subscription.subscription))
             self.assertEqual(mocked.call_count, 1)
 
         yield from coordinator.close()
@@ -559,30 +592,32 @@ class TestKafkaCoordinatorIntegration(KafkaIntegrationTestCase):
         client = AIOKafkaClient(loop=self.loop, bootstrap_servers=self.hosts)
         yield from client.bootstrap()
         yield from self.wait_topic(client, 'topic1')
-        subscription = SubscriptionState('earliest')
-        subscription.subscribe(topics=('topic1',))
+        subscription = SubscriptionState(loop=self.loop)
+        subscription.subscribe(topics=set(['topic1']))
         coordinator = GroupCoordinator(
             client, subscription, loop=self.loop,
-            group_id='test-offsets-group')
-        yield from coordinator.ensure_active_group()
+            group_id='test-offsets-group', session_timeout_ms=6000,
+            heartbeat_interval_ms=1000)
+        yield from subscription.wait_for_assignment()
+        assignment = subscription.subscription.assignment
 
-        # during OffsetCommit, UnknownMemberIdError is raised
         offsets = {TopicPartition('topic1', 0): OffsetAndMetadata(1, '')}
-        with mock.patch('aiokafka.errors.for_code') as mocked:
-            mocked.return_value = Errors.UnknownMemberIdError
-            with self.assertRaises(Errors.UnknownMemberIdError):
-                yield from coordinator.commit_offsets(offsets)
-            self.assertEqual(subscription.needs_partition_assignment, True)
-
-        # same exception is raised during ensure_active_group()'s call to
-        # commit_offsets() via _on_join_prepare() but doesn't break this method
-        with mock.patch.object(coordinator, "commit_offsets") as mocked:
+        # during OffsetCommit, UnknownMemberIdError is raised
+        _orig_send_req = coordinator._send_req
+        resp_topics = [("topic1", [(0, Errors.UnknownMemberIdError.errno)])]
+        with mock.patch.object(coordinator, "_send_req") as mocked:
             @asyncio.coroutine
-            def mock_commit_offsets(*args, **kwargs):
-                raise Errors.UnknownMemberIdError()
-            mocked.side_effect = mock_commit_offsets
+            def mock_send_req(request):
+                if request.API_KEY == OffsetCommitRequest[0].API_KEY:
+                    return OffsetCommitResponse_v2(resp_topics)
+                return (yield from _orig_send_req(request))
+            mocked.side_effect = mock_send_req
 
-            yield from coordinator.ensure_active_group()
+            with self.assertRaises(Errors.CommitFailedError):
+                yield from coordinator.commit_offsets(assignment, offsets)
+            self.assertTrue(coordinator.need_rejoin(subscription.subscription))
+            # Waiting will assure we could rebalance even if commit fails
+            yield from subscription.wait_for_assignment()
 
         yield from coordinator.close()
         yield from client.close()

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -323,13 +323,10 @@ class TestFetcher(unittest.TestCase):
         client.cluster.leader_for_partition.return_value = 0
         client._api_version = (0, 10, 1)
 
-        subscriptions = SubscriptionState('latest')
+        subscriptions = SubscriptionState(loop=self.loop)
         fetcher = Fetcher(client, subscriptions, loop=self.loop)
         tp0 = TopicPartition("topic", 0)
         tp1 = TopicPartition("topic", 1)
-
-        subscriptions = SubscriptionState('latest')
-        fetcher = Fetcher(client, subscriptions, loop=self.loop)
 
         # Timeouting will result in KafkaTimeoutError
         with mock.patch.object(fetcher, "_proc_offset_requests") as mocked:

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -38,298 +38,301 @@ class TestFetcher(unittest.TestCase):
     def _assert_logs_noop(self):
         yield
 
-    @run_until_complete
-    def test_update_fetch_positions(self):
-        client = AIOKafkaClient(
-            loop=self.loop,
-            bootstrap_servers=[])
-        subscriptions = SubscriptionState('latest')
-        fetcher = Fetcher(client, subscriptions, loop=self.loop)
-        partition = TopicPartition('test', 0)
-        # partition is not assigned, should be ignored
-        yield from fetcher.update_fetch_positions([partition])
+    # @run_until_complete
+    # def test_update_fetch_positions(self):
+    #     client = AIOKafkaClient(
+    #         loop=self.loop,
+    #         bootstrap_servers=[])
+    #     subscriptions = SubscriptionState('latest')
+    #     fetcher = Fetcher(client, subscriptions, loop=self.loop)
+    #     partition = TopicPartition('test', 0)
+    #     # partition is not assigned, should be ignored
+    #     yield from fetcher.update_fetch_positions([partition])
 
-        state = TopicPartitionState()
-        state.seek(0)
-        subscriptions.assignment[partition] = state
-        # partition is fetchable, no need to update position
-        yield from fetcher.update_fetch_positions([partition])
+    #     state = TopicPartitionState()
+    #     state.seek(0)
+    #     subscriptions.assignment[partition] = state
+    #     # partition is fetchable, no need to update position
+    #     yield from fetcher.update_fetch_positions([partition])
 
-        client.ready = mock.MagicMock()
-        client.ready.side_effect = asyncio.coroutine(lambda a: True)
-        client.force_metadata_update = mock.MagicMock()
-        client.force_metadata_update.side_effect = asyncio.coroutine(
-            lambda: False)
-        client.send = mock.MagicMock()
-        client.send.side_effect = asyncio.coroutine(
-            lambda n, r: OffsetResponse[0]([('test', [(0, 0, [4])])]))
-        state.await_reset(OffsetResetStrategy.LATEST)
-        client.cluster.leader_for_partition = mock.MagicMock()
-        client.cluster.leader_for_partition.side_effect = [None, -1, 0]
-        yield from fetcher.update_fetch_positions([partition])
-        self.assertEqual(state.position, 4)
+    #     client.ready = mock.MagicMock()
+    #     client.ready.side_effect = asyncio.coroutine(lambda a: True)
+    #     client.force_metadata_update = mock.MagicMock()
+    #     client.force_metadata_update.side_effect = asyncio.coroutine(
+    #         lambda: False)
+    #     client.send = mock.MagicMock()
+    #     client.send.side_effect = asyncio.coroutine(
+    #         lambda n, r: OffsetResponse[0]([('test', [(0, 0, [4])])]))
+    #     state.await_reset(OffsetResetStrategy.LATEST)
+    #     client.cluster.leader_for_partition = mock.MagicMock()
+    #     client.cluster.leader_for_partition.side_effect = [None, -1, 0]
+    #     yield from fetcher.update_fetch_positions([partition])
+    #     self.assertEqual(state.position, 4)
 
-        client.cluster.leader_for_partition = mock.MagicMock()
-        client.cluster.leader_for_partition.return_value = 1
-        client.send = mock.MagicMock()
-        client.send.side_effect = asyncio.coroutine(
-            lambda n, r: OffsetResponse[0]([('test', [(0, 3, [])])]))
-        state.await_reset(OffsetResetStrategy.LATEST)
-        with self.assertRaises(UnknownTopicOrPartitionError):
-            yield from fetcher.update_fetch_positions([partition])
+    #     client.cluster.leader_for_partition = mock.MagicMock()
+    #     client.cluster.leader_for_partition.return_value = 1
+    #     client.send = mock.MagicMock()
+    #     client.send.side_effect = asyncio.coroutine(
+    #         lambda n, r: OffsetResponse[0]([('test', [(0, 3, [])])]))
+    #     state.await_reset(OffsetResetStrategy.LATEST)
+    #     with self.assertRaises(UnknownTopicOrPartitionError):
+    #         yield from fetcher.update_fetch_positions([partition])
 
-        client.send.side_effect = asyncio.coroutine(
-            lambda n, r: OffsetResponse[0]([('test', [(0, -1, [])])]))
-        with self.assertRaises(UnknownError):
-            yield from fetcher.update_fetch_positions([partition])
-        yield from fetcher.close()
+    #     client.send.side_effect = asyncio.coroutine(
+    #         lambda n, r: OffsetResponse[0]([('test', [(0, -1, [])])]))
+    #     with self.assertRaises(UnknownError):
+    #         yield from fetcher.update_fetch_positions([partition])
+    #     yield from fetcher.close()
 
-    @run_until_complete
-    def test_proc_fetch_request(self):
-        client = AIOKafkaClient(
-            loop=self.loop,
-            bootstrap_servers=[])
-        subscriptions = SubscriptionState('latest')
-        fetcher = Fetcher(client, subscriptions, loop=self.loop)
+    # @run_until_complete
+    # def test_proc_fetch_request(self):
+    #     client = AIOKafkaClient(
+    #         loop=self.loop,
+    #         bootstrap_servers=[])
+    #     subscriptions = SubscriptionState(loop=self.loop)
+    #     fetcher = Fetcher(
+    #         client, subscriptions, auto_offset_reset="latest", loop=self.loop)
 
-        tp = TopicPartition('test', 0)
-        tp_info = (tp.topic, [(tp.partition, 155, 100000)])
-        req = FetchRequest(
-            -1,  # replica_id
-            100, 100, [tp_info])
+    #     tp = TopicPartition('test', 0)
+    #     tp_info = (tp.topic, [(tp.partition, 155, 100000)])
+    #     req = FetchRequest(
+    #         -1,  # replica_id
+    #         100, 100, [tp_info])
 
-        client.ready = mock.MagicMock()
-        client.ready.side_effect = asyncio.coroutine(lambda a: True)
-        client.force_metadata_update = mock.MagicMock()
-        client.force_metadata_update.side_effect = asyncio.coroutine(
-            lambda: False)
-        client.send = mock.MagicMock()
+    #     client.ready = mock.MagicMock()
+    #     client.ready.side_effect = asyncio.coroutine(lambda a: True)
+    #     client.force_metadata_update = mock.MagicMock()
+    #     client.force_metadata_update.side_effect = asyncio.coroutine(
+    #         lambda: False)
+    #     client.send = mock.MagicMock()
 
-        builder = LegacyRecordBatchBuilder(
-            magic=1, compression_type=0, batch_size=99999999)
-        builder.append(offset=4, value=b"test msg", key=None, timestamp=None)
-        raw_batch = bytes(builder.build())
+    #     builder = LegacyRecordBatchBuilder(
+    #         magic=1, compression_type=0, batch_size=99999999)
+    #     builder.append(offset=4, value=b"test msg", key=None, timestamp=None)
+    #     raw_batch = bytes(builder.build())
 
-        client.send.side_effect = asyncio.coroutine(
-            lambda n, r: FetchResponse(
-                [('test', [(0, 0, 9, raw_batch)])]))
-        fetcher._in_flight.add(0)
-        needs_wake_up = yield from fetcher._proc_fetch_request(0, req)
-        self.assertEqual(needs_wake_up, False)
+    #     client.send.side_effect = asyncio.coroutine(
+    #         lambda n, r: FetchResponse(
+    #             [('test', [(0, 0, 9, raw_batch)])]))
+    #     fetcher._in_flight.add(0)
+    #     needs_wake_up = yield from fetcher._proc_fetch_request(
+    #         assignment, 0, req)
+    #     self.assertEqual(needs_wake_up, False)
 
-        state = TopicPartitionState()
-        state.seek(0)
-        subscriptions.assignment[tp] = state
-        subscriptions.needs_partition_assignment = False
-        fetcher._in_flight.add(0)
-        needs_wake_up = yield from fetcher._proc_fetch_request(0, req)
-        self.assertEqual(needs_wake_up, True)
-        buf = fetcher._records[tp]
-        self.assertEqual(buf.getone(), None)  # invalid offset, msg is ignored
+    #     state = TopicPartitionState()
+    #     state.seek(0)
+    #     subscriptions.assignment[tp] = state
+    #     subscriptions.needs_partition_assignment = False
+    #     fetcher._in_flight.add(0)
+    #     needs_wake_up = yield from fetcher._proc_fetch_request(0, req)
+    #     self.assertEqual(needs_wake_up, True)
+    #     buf = fetcher._records[tp]
+    #     self.assertEqual(buf.getone(), None)  # invalid offset, msg is ignored
 
-        state.seek(4)
-        fetcher._in_flight.add(0)
-        fetcher._records.clear()
-        needs_wake_up = yield from fetcher._proc_fetch_request(0, req)
-        self.assertEqual(needs_wake_up, True)
-        buf = fetcher._records[tp]
-        self.assertEqual(buf.getone().value, b"test msg")
+    #     state.seek(4)
+    #     fetcher._in_flight.add(0)
+    #     fetcher._records.clear()
+    #     needs_wake_up = yield from fetcher._proc_fetch_request(0, req)
+    #     self.assertEqual(needs_wake_up, True)
+    #     buf = fetcher._records[tp]
+    #     self.assertEqual(buf.getone().value, b"test msg")
 
-        # error -> no partition found
-        client.send.side_effect = asyncio.coroutine(
-            lambda n, r: FetchResponse(
-                [('test', [(0, 3, 9, raw_batch)])]))
-        fetcher._in_flight.add(0)
-        fetcher._records.clear()
-        needs_wake_up = yield from fetcher._proc_fetch_request(0, req)
-        self.assertEqual(needs_wake_up, False)
+    #     # error -> no partition found
+    #     client.send.side_effect = asyncio.coroutine(
+    #         lambda n, r: FetchResponse(
+    #             [('test', [(0, 3, 9, raw_batch)])]))
+    #     fetcher._in_flight.add(0)
+    #     fetcher._records.clear()
+    #     needs_wake_up = yield from fetcher._proc_fetch_request(0, req)
+    #     self.assertEqual(needs_wake_up, False)
 
-        # error -> topic auth failed
-        client.send.side_effect = asyncio.coroutine(
-            lambda n, r: FetchResponse(
-                [('test', [(0, 29, 9, raw_batch)])]))
-        fetcher._in_flight.add(0)
-        fetcher._records.clear()
-        needs_wake_up = yield from fetcher._proc_fetch_request(0, req)
-        self.assertEqual(needs_wake_up, True)
-        with self.assertRaises(TopicAuthorizationFailedError):
-            yield from fetcher.next_record([])
+    #     # error -> topic auth failed
+    #     client.send.side_effect = asyncio.coroutine(
+    #         lambda n, r: FetchResponse(
+    #             [('test', [(0, 29, 9, raw_batch)])]))
+    #     fetcher._in_flight.add(0)
+    #     fetcher._records.clear()
+    #     needs_wake_up = yield from fetcher._proc_fetch_request(0, req)
+    #     self.assertEqual(needs_wake_up, True)
+    #     with self.assertRaises(TopicAuthorizationFailedError):
+    #         yield from fetcher.next_record([])
 
-        # error -> unknown
-        client.send.side_effect = asyncio.coroutine(
-            lambda n, r: FetchResponse(
-                [('test', [(0, -1, 9, raw_batch)])]))
-        fetcher._in_flight.add(0)
-        fetcher._records.clear()
-        needs_wake_up = yield from fetcher._proc_fetch_request(0, req)
-        self.assertEqual(needs_wake_up, False)
+    #     # error -> unknown
+    #     client.send.side_effect = asyncio.coroutine(
+    #         lambda n, r: FetchResponse(
+    #             [('test', [(0, -1, 9, raw_batch)])]))
+    #     fetcher._in_flight.add(0)
+    #     fetcher._records.clear()
+    #     needs_wake_up = yield from fetcher._proc_fetch_request(0, req)
+    #     self.assertEqual(needs_wake_up, False)
 
-        # error -> offset out of range with offset strategy
-        client.send.side_effect = asyncio.coroutine(
-            lambda n, r: FetchResponse(
-                [('test', [(0, 1, 9, raw_batch)])]))
-        fetcher._in_flight.add(0)
-        fetcher._records.clear()
-        with mock.patch.object(fetcher, "update_fetch_positions") as mocked:
-            mocked.side_effect = asyncio.coroutine(lambda o: None)
-            needs_wake_up = yield from fetcher._proc_fetch_request(0, req)
-            self.assertEqual(needs_wake_up, False)
-            self.assertEqual(state.is_fetchable(), False)
-            mocked.assert_called_with([tp])
+    #     # error -> offset out of range with offset strategy
+    #     client.send.side_effect = asyncio.coroutine(
+    #         lambda n, r: FetchResponse(
+    #             [('test', [(0, 1, 9, raw_batch)])]))
+    #     fetcher._in_flight.add(0)
+    #     fetcher._records.clear()
+    #     with mock.patch.object(fetcher, "update_fetch_positions") as mocked:
+    #         mocked.side_effect = asyncio.coroutine(lambda o: None)
+    #         needs_wake_up = yield from fetcher._proc_fetch_request(0, req)
+    #         self.assertEqual(needs_wake_up, False)
+    #         self.assertEqual(state.is_fetchable(), False)
+    #         mocked.assert_called_with([tp])
 
-        # error -> offset out of range with strategy errors out
-        state.seek(4)
-        client.send.side_effect = asyncio.coroutine(
-            lambda n, r: FetchResponse(
-                [('test', [(0, 1, 9, [(4, 10, raw_batch)])])]))
-        fetcher._in_flight.add(0)
-        fetcher._records.clear()
-        with mock.patch.object(fetcher, "update_fetch_positions") as mocked:
-            # the exception should not fail execution here
-            @asyncio.coroutine
-            def mock_async_raises(offests):
-                raise Exception()
-            mocked.side_effect = mock_async_raises
-            needs_wake_up = yield from fetcher._proc_fetch_request(0, req)
-            self.assertEqual(needs_wake_up, False)
-            self.assertEqual(state.is_fetchable(), False)
-            mocked.assert_called_with([tp])
+    #     # error -> offset out of range with strategy errors out
+    #     state.seek(4)
+    #     client.send.side_effect = asyncio.coroutine(
+    #         lambda n, r: FetchResponse(
+    #             [('test', [(0, 1, 9, [(4, 10, raw_batch)])])]))
+    #     fetcher._in_flight.add(0)
+    #     fetcher._records.clear()
+    #     with mock.patch.object(fetcher, "update_fetch_positions") as mocked:
+    #         # the exception should not fail execution here
+    #         @asyncio.coroutine
+    #         def mock_async_raises(offests):
+    #             raise Exception()
+    #         mocked.side_effect = mock_async_raises
+    #         needs_wake_up = yield from fetcher._proc_fetch_request(0, req)
+    #         self.assertEqual(needs_wake_up, False)
+    #         self.assertEqual(state.is_fetchable(), False)
+    #         mocked.assert_called_with([tp])
 
-        # error -> offset out of range without offset strategy
-        state.seek(4)
-        subscriptions._default_offset_reset_strategy = OffsetResetStrategy.NONE
-        client.send.side_effect = asyncio.coroutine(
-            lambda n, r: FetchResponse(
-                [('test', [(0, 1, 9, raw_batch)])]))
-        fetcher._in_flight.add(0)
-        fetcher._records.clear()
-        needs_wake_up = yield from fetcher._proc_fetch_request(0, req)
-        self.assertEqual(needs_wake_up, True)
-        with self.assertRaises(OffsetOutOfRangeError):
-            yield from fetcher.next_record([])
+    #     # error -> offset out of range without offset strategy
+    #     state.seek(4)
+    #     subscriptions._default_offset_reset_strategy = OffsetResetStrategy.NONE
+    #     client.send.side_effect = asyncio.coroutine(
+    #         lambda n, r: FetchResponse(
+    #             [('test', [(0, 1, 9, raw_batch)])]))
+    #     fetcher._in_flight.add(0)
+    #     fetcher._records.clear()
+    #     needs_wake_up = yield from fetcher._proc_fetch_request(0, req)
+    #     self.assertEqual(needs_wake_up, True)
+    #     with self.assertRaises(OffsetOutOfRangeError):
+    #         yield from fetcher.next_record([])
 
-        yield from fetcher.close()
+    #     yield from fetcher.close()
 
-    def _setup_error_after_data(self):
-        subscriptions = SubscriptionState('latest')
-        client = AIOKafkaClient(
-            loop=self.loop,
-            bootstrap_servers=[])
-        fetcher = Fetcher(client, subscriptions, loop=self.loop)
-        tp1 = TopicPartition('some_topic', 0)
-        tp2 = TopicPartition('some_topic', 1)
+    # def _setup_error_after_data(self):
+    #     subscriptions = SubscriptionState(loop=self.loop)
+    #     client = AIOKafkaClient(
+    #         loop=self.loop,
+    #         bootstrap_servers=[])
+    #     fetcher = Fetcher(client, subscriptions, loop=self.loop)
+    #     tp1 = TopicPartition('some_topic', 0)
+    #     tp2 = TopicPartition('some_topic', 1)
 
-        state = TopicPartitionState()
-        state.seek(0)
-        subscriptions.assignment[tp1] = state
-        state = TopicPartitionState()
-        state.seek(0)
-        subscriptions.assignment[tp2] = state
-        subscriptions.needs_partition_assignment = False
+    #     subscriptions.subscribe(set(["some_topic"]))
+    #     state = TopicPartitionState()
+    #     state.seek(0)
+    #     subscriptions.assignment[tp1] = state
+    #     state = TopicPartitionState()
+    #     state.seek(0)
+    #     subscriptions.assignment[tp2] = state
+    #     subscriptions.needs_partition_assignment = False
 
-        # Add some data
-        messages = [ConsumerRecord(
-            topic="some_topic", partition=1, offset=0, timestamp=0,
-            timestamp_type=0, key=None, value=b"some", checksum=None,
-            serialized_key_size=0, serialized_value_size=4)]
-        fetcher._records[tp2] = FetchResult(
-            tp2, subscriptions=subscriptions, loop=self.loop,
-            records=iter(messages), backoff=0)
-        # Add some error
-        fetcher._records[tp1] = FetchError(
-            loop=self.loop, error=OffsetOutOfRangeError({}), backoff=0)
-        return fetcher, tp1, tp2, messages
+    #     # Add some data
+    #     messages = [ConsumerRecord(
+    #         topic="some_topic", partition=1, offset=0, timestamp=0,
+    #         timestamp_type=0, key=None, value=b"some", checksum=None,
+    #         serialized_key_size=0, serialized_value_size=4)]
+    #     fetcher._records[tp2] = FetchResult(
+    #         tp2, subscriptions=subscriptions, loop=self.loop,
+    #         records=iter(messages), backoff=0)
+    #     # Add some error
+    #     fetcher._records[tp1] = FetchError(
+    #         loop=self.loop, error=OffsetOutOfRangeError({}), backoff=0)
+    #     return fetcher, tp1, tp2, messages
 
-    @run_until_complete
-    def test_fetched_records_error_after_data(self):
-        # Test error after some data. fetched_records should not discard data.
-        fetcher, tp1, tp2, messages = self._setup_error_after_data()
+    # @run_until_complete
+    # def test_fetched_records_error_after_data(self):
+    #     # Test error after some data. fetched_records should not discard data.
+    #     fetcher, tp1, tp2, messages = self._setup_error_after_data()
 
-        msg = yield from fetcher.fetched_records([])
-        self.assertEqual(msg, {tp2: messages})
+    #     msg = yield from fetcher.fetched_records([])
+    #     self.assertEqual(msg, {tp2: messages})
 
-        with self.assertRaises(OffsetOutOfRangeError):
-            msg = yield from fetcher.fetched_records([])
+    #     with self.assertRaises(OffsetOutOfRangeError):
+    #         msg = yield from fetcher.fetched_records([])
 
-        msg = yield from fetcher.fetched_records([])
-        self.assertEqual(msg, {})
+    #     msg = yield from fetcher.fetched_records([])
+    #     self.assertEqual(msg, {})
 
-    @run_until_complete
-    def test_next_record_error_after_data(self):
-        # Test error after some data. next_record should not discard data.
-        fetcher, tp1, tp2, messages = self._setup_error_after_data()
+    # @run_until_complete
+    # def test_next_record_error_after_data(self):
+    #     # Test error after some data. next_record should not discard data.
+    #     fetcher, tp1, tp2, messages = self._setup_error_after_data()
 
-        msg = yield from fetcher.next_record([])
-        self.assertEqual(msg, messages[0])
+    #     msg = yield from fetcher.next_record([])
+    #     self.assertEqual(msg, messages[0])
 
-        with self.assertRaises(OffsetOutOfRangeError):
-            msg = yield from fetcher.next_record([])
+    #     with self.assertRaises(OffsetOutOfRangeError):
+    #         msg = yield from fetcher.next_record([])
 
-        with self.assertRaises(asyncio.TimeoutError):
-            yield from asyncio.wait_for(
-                fetcher.next_record([]), timeout=0.1, loop=self.loop)
+    #     with self.assertRaises(asyncio.TimeoutError):
+    #         yield from asyncio.wait_for(
+    #             fetcher.next_record([]), timeout=0.1, loop=self.loop)
 
-    @run_until_complete
-    def test_compacted_topic_consumption(self):
-        # Compacted topics can have offsets skipped
-        client = AIOKafkaClient(
-            loop=self.loop,
-            bootstrap_servers=[])
-        client.ready = mock.MagicMock()
-        client.ready.side_effect = asyncio.coroutine(lambda a: True)
-        client.force_metadata_update = mock.MagicMock()
-        client.force_metadata_update.side_effect = asyncio.coroutine(
-            lambda: False)
-        client.send = mock.MagicMock()
+    # @run_until_complete
+    # def test_compacted_topic_consumption(self):
+    #     # Compacted topics can have offsets skipped
+    #     client = AIOKafkaClient(
+    #         loop=self.loop,
+    #         bootstrap_servers=[])
+    #     client.ready = mock.MagicMock()
+    #     client.ready.side_effect = asyncio.coroutine(lambda a: True)
+    #     client.force_metadata_update = mock.MagicMock()
+    #     client.force_metadata_update.side_effect = asyncio.coroutine(
+    #         lambda: False)
+    #     client.send = mock.MagicMock()
 
-        subscriptions = SubscriptionState('latest')
-        fetcher = Fetcher(client, subscriptions, loop=self.loop)
+    #     subscriptions = SubscriptionState('latest')
+    #     fetcher = Fetcher(client, subscriptions, loop=self.loop)
 
-        tp = TopicPartition('test', 0)
-        req = FetchRequest(
-            -1,  # replica_id
-            100, 100, [(tp.topic, [(tp.partition, 155, 100000)])])
+    #     tp = TopicPartition('test', 0)
+    #     req = FetchRequest(
+    #         -1,  # replica_id
+    #         100, 100, [(tp.topic, [(tp.partition, 155, 100000)])])
 
-        builder = LegacyRecordBatchBuilder(
-            magic=1, compression_type=0, batch_size=99999999)
-        builder.append(160, value=b"12345", key=b"1", timestamp=None)
-        builder.append(162, value=b"23456", key=b"2", timestamp=None)
-        builder.append(167, value=b"34567", key=b"3", timestamp=None)
-        batch = bytes(builder.build())
+    #     builder = LegacyRecordBatchBuilder(
+    #         magic=1, compression_type=0, batch_size=99999999)
+    #     builder.append(160, value=b"12345", key=b"1", timestamp=None)
+    #     builder.append(162, value=b"23456", key=b"2", timestamp=None)
+    #     builder.append(167, value=b"34567", key=b"3", timestamp=None)
+    #     batch = bytes(builder.build())
 
-        resp = FetchResponse(
-            [('test', [(
-                0, 0, 3000,  # partition, error_code, highwater_offset
-                batch  # Batch raw bytes
-            )])])
+    #     resp = FetchResponse(
+    #         [('test', [(
+    #             0, 0, 3000,  # partition, error_code, highwater_offset
+    #             batch  # Batch raw bytes
+    #         )])])
 
-        client.send.side_effect = asyncio.coroutine(lambda n, r: resp)
-        state = TopicPartitionState()
-        state.seek(155)
-        state.drop_pending_message_set = False
-        subscriptions.assignment[tp] = state
-        subscriptions.needs_partition_assignment = False
-        fetcher._in_flight.add(0)
+    #     client.send.side_effect = asyncio.coroutine(lambda n, r: resp)
+    #     state = TopicPartitionState()
+    #     state.seek(155)
+    #     state.drop_pending_message_set = False
+    #     subscriptions.assignment[tp] = state
+    #     subscriptions.needs_partition_assignment = False
+    #     fetcher._in_flight.add(0)
 
-        needs_wake_up = yield from fetcher._proc_fetch_request(0, req)
-        self.assertEqual(needs_wake_up, True)
-        buf = fetcher._records[tp]
-        # Test successful getone
-        first = buf.getone()
-        self.assertEqual(state.position, 161)
-        self.assertEqual(
-            (first.value, first.key, first.offset),
-            (b"12345", b"1", 160))
+    #     needs_wake_up = yield from fetcher._proc_fetch_request(0, req)
+    #     self.assertEqual(needs_wake_up, True)
+    #     buf = fetcher._records[tp]
+    #     # Test successful getone
+    #     first = buf.getone()
+    #     self.assertEqual(state.position, 161)
+    #     self.assertEqual(
+    #         (first.value, first.key, first.offset),
+    #         (b"12345", b"1", 160))
 
-        # Test successful getmany
-        second, third = buf.getall()
-        self.assertEqual(state.position, 168)
-        self.assertEqual(
-            (second.value, second.key, second.offset),
-            (b"23456", b"2", 162))
-        self.assertEqual(
-            (third.value, third.key, third.offset),
-            (b"34567", b"3", 167))
+    #     # Test successful getmany
+    #     second, third = buf.getall()
+    #     self.assertEqual(state.position, 168)
+    #     self.assertEqual(
+    #         (second.value, second.key, second.offset),
+    #         (b"23456", b"2", 162))
+    #     self.assertEqual(
+    #         (third.value, third.key, third.offset),
+    #         (b"34567", b"3", 167))
 
     @run_until_complete
     def test_fetcher_offsets_for_times(self):

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -7,7 +7,7 @@ from unittest import mock
 
 from kafka.consumer.subscription_state import (
     SubscriptionState, TopicPartitionState)
-from kafka.protocol.offset import OffsetResetStrategy, OffsetResponse
+from kafka.protocol.offset import OffsetResponse
 from aiokafka.record.legacy_records import LegacyRecordBatchBuilder
 
 from aiokafka.consumer.fetch import (
@@ -19,7 +19,7 @@ from aiokafka.errors import (
 from aiokafka.structs import TopicPartition, OffsetAndTimestamp
 from aiokafka.client import AIOKafkaClient
 from aiokafka.consumer.fetcher import (
-    Fetcher, FetchResult, FetchError, ConsumerRecord
+    Fetcher, FetchResult, FetchError, ConsumerRecord, OffsetResetStrategy
 )
 from ._testutil import run_until_complete
 

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -23,6 +23,20 @@ from aiokafka.consumer.subscription_state import SubscriptionState
 from ._testutil import run_until_complete
 
 
+def test_offset_reset_strategy():
+    assert OffsetResetStrategy.from_str("latest") == OffsetResetStrategy.LATEST
+    assert OffsetResetStrategy.from_str("earliest") == \
+        OffsetResetStrategy.EARLIEST
+    assert OffsetResetStrategy.from_str("none") == OffsetResetStrategy.NONE
+    assert OffsetResetStrategy.from_str("123") == OffsetResetStrategy.NONE
+
+    assert OffsetResetStrategy.to_str(OffsetResetStrategy.LATEST) == "latest"
+    assert OffsetResetStrategy.to_str(OffsetResetStrategy.EARLIEST) == \
+        "earliest"
+    assert OffsetResetStrategy.to_str(OffsetResetStrategy.NONE) == "none"
+    assert OffsetResetStrategy.to_str(100) == "timestamp(100)"
+
+
 @pytest.mark.usefixtures('setup_test_class_serverless')
 class TestFetcher(unittest.TestCase):
 

--- a/tests/test_pep492.py
+++ b/tests/test_pep492.py
@@ -1,7 +1,6 @@
 import asyncio
 from aiokafka.consumer import AIOKafkaConsumer
-from aiokafka.errors import ConsumerStoppedError
-from kafka.common import OffsetOutOfRangeError
+from aiokafka.errors import ConsumerStoppedError, NoOffsetForPartitionError
 from ._testutil import (
     KafkaIntegrationTestCase, run_until_complete, random_string)
 
@@ -73,7 +72,7 @@ class TestConsumerIteratorIntegration(KafkaIntegrationTestCase):
             auto_offset_reset="none")
         await consumer.start()
 
-        with self.assertRaises(OffsetOutOfRangeError):
+        with self.assertRaises(NoOffsetForPartitionError):
             async for m in consumer:
                 m  # pragma: no cover
 

--- a/tests/test_pep492.py
+++ b/tests/test_pep492.py
@@ -16,6 +16,7 @@ class TestConsumerIteratorIntegration(KafkaIntegrationTestCase):
             bootstrap_servers=self.hosts,
             auto_offset_reset='earliest')
         await consumer.start()
+        self.add_cleanup(consumer.stop)
 
         messages = []
         async for m in consumer:
@@ -27,7 +28,6 @@ class TestConsumerIteratorIntegration(KafkaIntegrationTestCase):
                 break  # noqa
 
         self.assert_message_count(messages, 20)
-        await consumer.stop()
 
     @run_until_complete
     async def test_exception_ignored_with_aiter(self):
@@ -42,6 +42,7 @@ class TestConsumerIteratorIntegration(KafkaIntegrationTestCase):
             auto_offset_reset='earliest',
             max_partition_fetch_bytes=4000)
         await consumer.start()
+        self.add_cleanup(consumer.stop)
 
         messages = []
         with self.assertLogs(
@@ -60,7 +61,6 @@ class TestConsumerIteratorIntegration(KafkaIntegrationTestCase):
                 in cm.output[0])
         self.assertEqual(messages[0].value, large_messages[0])
         self.assertEqual(messages[1].value, small_messages[0])
-        await consumer.stop()
 
     @run_until_complete
     async def test_exception_in_aiter(self):
@@ -71,6 +71,7 @@ class TestConsumerIteratorIntegration(KafkaIntegrationTestCase):
             bootstrap_servers=self.hosts,
             auto_offset_reset="none")
         await consumer.start()
+        self.add_cleanup(consumer.stop)
 
         with self.assertRaises(NoOffsetForPartitionError):
             async for m in consumer:
@@ -83,6 +84,7 @@ class TestConsumerIteratorIntegration(KafkaIntegrationTestCase):
             bootstrap_servers=self.hosts,
             auto_offset_reset="earliest")
         await consumer.start()
+        self.add_cleanup(consumer.stop)
 
         async def iterator():
             async for msg in consumer:  # pragma: no cover

--- a/tests/test_pep492.py
+++ b/tests/test_pep492.py
@@ -81,7 +81,7 @@ class TestConsumerIteratorIntegration(KafkaIntegrationTestCase):
         consumer = AIOKafkaConsumer(
             self.topic, loop=self.loop,
             bootstrap_servers=self.hosts,
-            auto_offset_reset="none")
+            auto_offset_reset="earliest")
         await consumer.start()
 
         async def iterator():

--- a/tests/test_pep492.py
+++ b/tests/test_pep492.py
@@ -70,7 +70,7 @@ class TestConsumerIteratorIntegration(KafkaIntegrationTestCase):
         consumer = AIOKafkaConsumer(
             self.topic, loop=self.loop,
             bootstrap_servers=self.hosts,
-            auto_offset_reset=None)
+            auto_offset_reset="none")
         await consumer.start()
 
         with self.assertRaises(OffsetOutOfRangeError):
@@ -82,7 +82,7 @@ class TestConsumerIteratorIntegration(KafkaIntegrationTestCase):
         consumer = AIOKafkaConsumer(
             self.topic, loop=self.loop,
             bootstrap_servers=self.hosts,
-            auto_offset_reset=None)
+            auto_offset_reset="none")
         await consumer.start()
 
         async def iterator():

--- a/tests/test_producer.py
+++ b/tests/test_producer.py
@@ -1,5 +1,6 @@
 import json
 import asyncio
+import pytest
 import time
 from unittest import mock
 
@@ -303,6 +304,7 @@ class TestKafkaProducerIntegration(KafkaIntegrationTestCase):
             yield from producer.send_batch(
                 batch, self.topic, partition=partition)
 
+    @pytest.mark.ssl
     @run_until_complete
     def test_producer_ssl(self):
         # Produce by SSL consume by PLAINTEXT

--- a/tests/test_subscription_state.py
+++ b/tests/test_subscription_state.py
@@ -122,6 +122,7 @@ def test_unsubscribe(subscription_state):
 
     # After unsubscribe you can change the type to say pattern.
     subscription_state.subscribe_pattern(re.compile("pattern"))
+    subscription_state.subscribe_from_pattern(set(["tp33"]))
 
     assert subscription_state.subscription is not None
 
@@ -133,6 +134,9 @@ def test_seek(subscription_state):
 
     assignment = subscription_state.subscription.assignment
     assert assignment.state_value(tp) is not None
-    assert assignment.state_value(tp).position is None
+    assert not assignment.state_value(tp).has_valid_position
+    assert assignment.state_value(tp)._position is None
 
     subscription_state.seek(tp, 1000)
+
+    assert assignment.state_value(tp).position == 1000

--- a/tests/test_subscription_state.py
+++ b/tests/test_subscription_state.py
@@ -1,0 +1,138 @@
+import pytest
+import re
+
+from aiokafka.consumer.subscription_state import SubscriptionState
+from aiokafka.errors import IllegalStateError
+from aiokafka.structs import TopicPartition
+from aiokafka.abc import ConsumerRebalanceListener
+
+
+@pytest.fixture
+def subscription_state(loop):
+    return SubscriptionState(loop=loop)
+
+
+class MockListener(ConsumerRebalanceListener):
+
+    def on_partitions_revoked(self, revoked):
+        pass
+
+    def on_partitions_assigned(self, assigned):
+        pass
+
+
+def test_subscribe_topic(subscription_state):
+    mock_listener = MockListener()
+    subscription_state.subscribe({"tp1", "tp2"}, listener=mock_listener)
+    assert subscription_state.subscription is not None
+    assert subscription_state.subscription.topics == {"tp1", "tp2"}
+    assert subscription_state.subscription.assignment is None
+    assert subscription_state.subscription.active is True
+    assert subscription_state.subscription.unsubscribe_future.done() is False
+
+    # After subscription to topic we can't change the subscription to pattern
+    # or user assignment
+    with pytest.raises(IllegalStateError):
+        subscription_state.subscribe_pattern(
+            pattern=re.compile("^tests-.*$"), listener=mock_listener)
+    with pytest.raises(IllegalStateError):
+        subscription_state.assign_from_user([TopicPartition("topic", 0)])
+
+    # Subsciption of the same type can be applied
+    old_subsciption = subscription_state.subscription
+    subscription_state.subscribe(
+        {"tp1", "tp2", "tp3"}, listener=mock_listener)
+
+    assert subscription_state.subscription is not None
+    assert subscription_state.subscription.topics == {"tp1", "tp2", "tp3"}
+
+    assert old_subsciption is not subscription_state.subscription
+    assert old_subsciption.active is False
+    assert old_subsciption.unsubscribe_future.done() is True
+
+
+def test_subscribe_pattern(subscription_state):
+    mock_listener = MockListener()
+    pattern = re.compile("^tests-.*$")
+    subscription_state.subscribe_pattern(
+        pattern=pattern, listener=mock_listener)
+
+    assert subscription_state.subscription is None
+    assert subscription_state.subscribed_pattern == pattern
+
+    # After subscription to a pattern we can't change the subscription until
+    # `unsubscribe` called
+    with pytest.raises(IllegalStateError):
+        subscription_state.subscribe(
+            topics={"tp1", "tp2", "tp3"}, listener=mock_listener)
+    with pytest.raises(IllegalStateError):
+        subscription_state.assign_from_user([TopicPartition("topic", 0)])
+
+
+def test_user_assignment(subscription_state):
+    topic_partitions = {
+        TopicPartition("topic1", 0),
+        TopicPartition("topic1", 1),
+        TopicPartition("topic2", 0)
+    }
+    subscription_state.assign_from_user(topic_partitions)
+    assert subscription_state.subscription is not None
+    assert subscription_state.subscription.topics == {"topic1", "topic2"}
+    assert subscription_state.subscription.assignment is not None
+    assert subscription_state.subscription.active is True
+    assert subscription_state.subscription.unsubscribe_future.done() is False
+    assignment = subscription_state.subscription.assignment
+    assert assignment.active is True
+    assert assignment.unassign_future.done() is False
+    assert assignment.tps == topic_partitions
+
+    # After manual assignment no other subscription is possible
+    mock_listener = MockListener()
+    with pytest.raises(IllegalStateError):
+        subscription_state.subscribe(
+            topics={"tp1", "tp2", "tp3"}, listener=mock_listener)
+    with pytest.raises(IllegalStateError):
+        subscription_state.subscribe_pattern(
+            pattern=re.compile("^tests-.*$"), listener=mock_listener)
+
+    # Assignment can be changed manually again thou
+    new_tps = {
+        TopicPartition("topic3", 0),
+        TopicPartition("topic3", 1),
+        TopicPartition("topic4", 0)
+    }
+    subscription_state.assign_from_user(new_tps)
+
+    assert subscription_state.subscription is not None
+    assert subscription_state.subscription.topics == {"topic3", "topic4"}
+    new_assignment = subscription_state.subscription.assignment
+    assert new_assignment.tps == new_tps
+
+    assert assignment is not new_assignment
+    assert assignment.active is False
+    assert assignment.unassign_future.done() is True
+
+
+def test_unsubscribe(subscription_state):
+    subscription_state.subscribe({"tp1", "tp2"})
+    assert subscription_state.subscription is not None
+
+    subscription_state.unsubscribe()
+    assert subscription_state.subscription is None
+
+    # After unsubscribe you can change the type to say pattern.
+    subscription_state.subscribe_pattern(re.compile("pattern"))
+
+    assert subscription_state.subscription is not None
+
+
+def test_seek(subscription_state):
+    tp = TopicPartition("topic1", 0)
+    tp2 = TopicPartition("topic2", 0)
+    subscription_state.assign_from_user({tp, tp2})
+
+    assignment = subscription_state.subscription.assignment
+    assert assignment.state_value(tp) is not None
+    assert assignment.state_value(tp).position is None
+
+    subscription_state.seek(tp, 1000)


### PR DESCRIPTION
This is a major work, that I was postponing for a long time. The issue was that `SubscriptionState` used in ``kafka-python`` is not suited for asyncio, as it is not aware of Futures and operates purely on flags. For example, lets look at this pseudo-code:
```python
async def update_fetch_position(self, partitions):
    pending_resets = []
    for tp in partitions:
        if not self._subscriptions.is_assigned(tp):
            continue
        if self._subscriptions.assignment[tp].awaiting_reset():
            pending_resets.append(ensure_future(self._do_partition_reset(tp)))

    if pending_resets:
        await asyncio.gather(pending_resets)

async def _do_partition_reset(self, tp):
    assert self._subscriptions.is_assigned(tp)

    tp_state = self._subscriptions.assignment[tp]
    reset_strategy = tp_state.reset_strategy

    # ...
```
The code could actually hit the assert in `_do_partition_reset` because created tasks are scheduled and can take some time to start executing. Ie the assignment can change before `_do_partition_reset` is executed.

In `kafka-python` this is never a problem because a thread can never be interrupted. We could emulate the same behaviour by adding locks at different places in the code, leading to all public API to become coroutines. That would break a lot, so instead this PR tries to solve those problems by refactoring `SubscriptionState` to contain some futures, etc.

 some points need addressing:
* [x] Refactor unit tests, that relied on mocking SubscriptionState
* [x] Add more tests for SubscriptionState
* [x] Fix coverage drop, it should be present.
* [x] Document API changes. (commit can raise CommitFailedError now)