### PR TITLE
Transactional producer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,19 +81,21 @@ Running tests
 
 Docker is required to run tests. See https://docs.docker.com/engine/installation for installation notes. Also note, that `lz4` compression libraries for python will require `python-dev` package,
 or python source header files for compilation on Linux.
+NOTE: You will also need a valid java installation. It's required for the ``keytool`` utility, used to
+generate ssh keys for some tests.
 
 Setting up tests requirements (assuming you're within virtualenv on ubuntu 14.04+)::
 
     sudo apt-get install -y libsnappy-dev
     make setup
 
-Running tests::
+Running tests with coverage::
 
     make cov
 
-To run tests with a specific version of Kafka (default one is 0.10.1.0) use KAFKA_VERSION variable::
+To run tests with a specific version of Kafka (default one is 1.0.2) use KAFKA_VERSION variable::
 
-    make cov KAFKA_VERSION=0.10.0.0
+    make cov KAFKA_VERSION=0.10.2.1
 
 Test running cheatsheat:
 

--- a/aiokafka/consumer/consumer.py
+++ b/aiokafka/consumer/consumer.py
@@ -972,7 +972,8 @@ class AIOKafkaConsumer(object):
             data_task = ensure_future(coro, loop=self._loop)
             yield from asyncio.wait(
                 [data_task, coordination_error_fut],
-                return_when=asyncio.FIRST_COMPLETED)
+                return_when=asyncio.FIRST_COMPLETED,
+                loop=self._loop)
 
             # Check for errors in coordination and raise if any
             if coordination_error_fut.done():

--- a/aiokafka/producer/producer.py
+++ b/aiokafka/producer/producer.py
@@ -234,6 +234,7 @@ class AIOKafkaProducer(object):
             loop=loop)
         self._sender_task = None
         self._in_flight = set()
+        self._muted_partitions = set()
         self._loop = loop
         self._retry_backoff = retry_backoff_ms / 1000
         self._linger_time = linger_ms / 1000
@@ -405,7 +406,8 @@ class AIOKafkaProducer(object):
 
                 batches, unknown_leaders_exist = \
                     self._message_accumulator.drain_by_nodes(
-                        ignore_nodes=self._in_flight)
+                        ignore_nodes=self._in_flight,
+                        muted_partitions=self._muted_partitions)
 
                 # create produce task for every batch
                 for node_id, batches in batches.items():
@@ -413,6 +415,8 @@ class AIOKafkaProducer(object):
                         self._send_produce_req(node_id, batches),
                         loop=self._loop)
                     self._in_flight.add(node_id)
+                    for tp in batches:
+                        self._muted_partitions.add(tp)
                     tasks.add(task)
 
                 if unknown_leaders_exist:
@@ -552,7 +556,7 @@ class AIOKafkaProducer(object):
                                 partition_info
                         tp = TopicPartition(topic, partition)
                         error = Errors.for_code(error_code)
-                        batch = batches.pop(tp, None)
+                        batch = batches.get(tp)
                         if batch is None:
                             continue
 
@@ -586,6 +590,8 @@ class AIOKafkaProducer(object):
             yield from asyncio.sleep(sleep_time, loop=self._loop)
 
         self._in_flight.remove(node_id)
+        for tp in batches:
+            self._muted_partitions.remove(tp)
 
     def _can_retry(self, error, batch):
         # If indempotence is enabled we never expire batches, but retry until
@@ -660,7 +666,11 @@ class AIOKafkaProducer(object):
             asyncio.Future: object that will be set when the batch is
                 delivered.
         """
+        # first make sure the metadata for the topic is available
+        yield from self.client._wait_on_metadata(topic)
+        # We only validate we have the partition in the metadata here
         partition = self._partition(topic, partition, None, None, None, None)
+
         tp = TopicPartition(topic, partition)
         log.debug("Sending batch to %s", tp)
         future = yield from self._message_accumulator.add_batch(

--- a/aiokafka/producer/producer.py
+++ b/aiokafka/producer/producer.py
@@ -296,11 +296,17 @@ class AIOKafkaProducer(object):
             return
         self._closed = True
 
-        yield from self._message_accumulator.close()
+        # If the sender task is down there is no way for accumulator to flush
+        if self._sender_task is not None:
+            yield from asyncio.wait([
+                self._message_accumulator.close(),
+                self._sender_task],
+                return_when=asyncio.FIRST_COMPLETED,
+                loop=self._loop)
 
-        if self._sender_task:
-            self._sender_task.cancel()
-            yield from self._sender_task
+            if not self._sender_task.done():
+                self._sender_task.cancel()
+                yield from self._sender_task
 
         yield from self.client.close()
         log.debug("The Kafka producer has closed.")
@@ -366,9 +372,11 @@ class AIOKafkaProducer(object):
         tp = TopicPartition(topic, partition)
         log.debug("Sending (key=%s value=%s) to %s", key, value, tp)
 
-        fut = yield from self._message_accumulator.add_message(
-            tp, key_bytes, value_bytes, self._request_timeout_ms / 1000,
-            timestamp_ms=timestamp_ms)
+        fut = yield from self._wait_for_reponse_or_error(
+            self._message_accumulator.add_message(
+                tp, key_bytes, value_bytes, self._request_timeout_ms / 1000,
+                timestamp_ms=timestamp_ms)
+        )
         return fut
 
     @asyncio.coroutine
@@ -377,7 +385,7 @@ class AIOKafkaProducer(object):
         """Publish a message to a topic and wait the result"""
         future = yield from self.send(
             topic, value, key, partition, timestamp_ms)
-        return (yield from future)
+        return (yield from self._wait_for_reponse_or_error(future))
 
     @asyncio.coroutine
     def _sender_routine(self):
@@ -450,6 +458,7 @@ class AIOKafkaProducer(object):
                 yield from task
         except Exception:  # pragma: no cover
             log.error("Unexpected error in sender routine", exc_info=True)
+            raise
 
     @asyncio.coroutine
     def _maybe_wait_for_pid(self):
@@ -673,6 +682,23 @@ class AIOKafkaProducer(object):
 
         tp = TopicPartition(topic, partition)
         log.debug("Sending batch to %s", tp)
-        future = yield from self._message_accumulator.add_batch(
-            batch, tp, self._request_timeout_ms / 1000)
+        future = yield from self._wait_for_reponse_or_error(
+            self._message_accumulator.add_batch(
+                batch, tp, self._request_timeout_ms / 1000)
+        )
         return future
+
+    @asyncio.coroutine
+    def _wait_for_reponse_or_error(self, coro):
+        routine_task = self._sender_task
+        data_task = ensure_future(coro, loop=self._loop)
+        yield from asyncio.wait(
+            [data_task, routine_task],
+            return_when=asyncio.FIRST_COMPLETED,
+            loop=self._loop)
+
+        # Check for errors in sender and raise if any
+        if routine_task.done():
+            routine_task.result()  # Raises set exception if any
+
+        return (yield from data_task)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,8 +18,7 @@ The client is designed to function much like the official Java client, with a sp
 
 **aiokafka** can be used with 0.9+ Kafka brokers and supports fully coordinated
 consumer groups -- i.e., dynamic partition assignment to multiple consumers in
-the same group. For now new features of Kafka 11+ are yet to be implemented,
-including Transactional Producer.
+the same group.
 
 
 Getting started

--- a/tests/test_producer.py
+++ b/tests/test_producer.py
@@ -599,3 +599,97 @@ class TestKafkaProducerIntegration(KafkaIntegrationTestCase):
 
         with self.assertRaises(asyncio.TimeoutError):
             yield from asyncio.wait_for(consumer.getone(), timeout=0.5)
+
+    @run_until_complete
+    def test_producer_invalid_leader_retry_metadata(self):
+        # See related issue #362. The metadata can have a new node in leader
+        # set while we still don't have metadata for that node.
+
+        producer = AIOKafkaProducer(
+            loop=self.loop, bootstrap_servers=self.hosts, linger_ms=1000)
+        yield from producer.start()
+        self.add_cleanup(producer.stop)
+
+        # Make sure we have fresh metadata for partitions
+        yield from producer.partitions_for(self.topic)
+        # Alter metadata to convince the producer, that leader or partition 0
+        # is a different node
+        topic_meta = producer._metadata._partitions[self.topic]
+        topic_meta[0] = topic_meta[0]._replace(leader=topic_meta[0].leader + 1)
+
+        meta = yield from producer.send_and_wait(self.topic, b'hello, Kafka!')
+        self.assertTrue(meta)
+
+    @run_until_complete
+    def test_producer_leader_change_preserves_order(self):
+        # Before 0.5.0 we did not lock partition until a response came from
+        # the server, but locked the node itself.
+        # For example: Say the sender sent a request to node 1 and before an
+        # failure answer came we updated metadata and leader become node 0.
+        # This way we may send the next batch to node 0 without waiting for
+        # node 1 batch to be reenqueued, resulting in out-of-order batches
+
+        producer = AIOKafkaProducer(
+            loop=self.loop, bootstrap_servers=self.hosts, linger_ms=1000)
+        yield from producer.start()
+        self.add_cleanup(producer.stop)
+
+        # Alter metadata to convince the producer, that leader or partition 0
+        # is a different node
+        yield from producer.partitions_for(self.topic)
+        topic_meta = producer._metadata._partitions[self.topic]
+        real_leader = topic_meta[0].leader
+        topic_meta[0] = topic_meta[0]._replace(leader=real_leader + 1)
+
+        # Make sure the first request for produce takes more time
+        original_send = producer.client.send
+
+        @asyncio.coroutine
+        def mocked_send(node_id, request, *args, **kw):
+            if node_id != real_leader and \
+                    request.API_KEY == ProduceResponse[0].API_KEY:
+                yield from asyncio.sleep(2, loop=self.loop)
+
+            result = yield from original_send(node_id, request, *args, **kw)
+            return result
+        producer.client.send = mocked_send
+
+        # Send Batch 1. This will end up waiting for some time on fake leader
+        batch = producer.create_batch()
+        meta = batch.append(key=b"key", value=b"1", timestamp=None)
+        batch.close()
+        fut = yield from producer.send_batch(
+            batch, self.topic, partition=0)
+
+        # Make sure we sent the request
+        yield from asyncio.sleep(0.1, loop=self.loop)
+        # Update metadata to return leader to real one
+        yield from producer.client.force_metadata_update()
+
+        # Send Batch 2, that if it's bugged will go straight to the real node
+        batch2 = producer.create_batch()
+        meta2 = batch2.append(key=b"key", value=b"2", timestamp=None)
+        batch2.close()
+        fut2 = yield from producer.send_batch(
+            batch2, self.topic, partition=0)
+
+        batch_meta = yield from fut
+        batch_meta2 = yield from fut2
+
+        # Check the order of messages
+        consumer = AIOKafkaConsumer(
+            self.topic, loop=self.loop,
+            bootstrap_servers=self.hosts,
+            auto_offset_reset="earliest")
+        yield from consumer.start()
+        self.add_cleanup(consumer.stop)
+        msg = yield from consumer.getone()
+        self.assertEqual(msg.offset, batch_meta.offset)
+        self.assertEqual(msg.timestamp, meta.timestamp)
+        self.assertEqual(msg.value, b"1")
+        self.assertEqual(msg.key, b"key")
+        msg2 = yield from consumer.getone()
+        self.assertEqual(msg2.offset, batch_meta2.offset)
+        self.assertEqual(msg2.timestamp, meta2.timestamp)
+        self.assertEqual(msg2.value, b"2")
+        self.assertEqual(msg2.key, b"key")


### PR DESCRIPTION
Checklist:

* [ ] Write basic test cases for transactional producer behaviour:
  * [ ] Test 2 producers fencing one another by using the same transactional_id
  * [ ] Test that a restarted producer will get the same PID if it's using the same transactional_id
  * [ ] Ensure we raise OutOfOrderSequence if we lose some messages. This can be done by bumping the sequence manually.
  * [ ] Ensure the transaction will materialise only after we commit in READ_COMMITTED and straight away if READ_UNCOMMITTED
  * [ ] Ensure the consumer will not yield control messages to the user
* [ ] Add support for Transaction Coordinator in InitPID request. The InitProducerIdRequest should be only routed to Coordination node. We will need a mechanism similar to Consumer's coordinator lookup.
* [ ] Add **begin_transaction** API that will create a new transaction and mark all subsequent sends with it. 
* [ ] After **begin_transaction** we need to add each partition to the transaction as new sends are done. Use AddPartitionsToTxn.
* [ ] Add **send_offsets_to_transaction** API that will be able to add a new commit to the current transaction. Calling this method not within a transaction is prohibited. There can be only 1 transaction per Producer at a time.
* [ ] Add **end_transaction** API that will flush all pending messages in the Producer and commit transaction.
* [ ] Add **init_transactions** API that will abort previous transactions on the same transactional_id.
* [ ] Add as ``async with`` API simplification. **init_transactions** will be called at first entry, **begin_transaction** on `__enter__` and  **end_transction** on exit. Commit should still remain explicit. 
```python
producer = AIOKafkaProducer(..., transactional_id="my-id")
producer.start()
async with producer.transaction() as t:
    for i in range(10):
        producer.send("topic", b"Super Data")
    producer.send_offsets_to_transaction({TopicPartition("topic-0", 0): 1})
```
* [ ] Add last_stable_offset API to consumer
