### PR TITLE
Use MetadataRequest_V1 if possible during client bootstrap

### DIFF
--- a/aiokafka/client.py
+++ b/aiokafka/client.py
@@ -166,8 +166,12 @@ class AIOKafkaClient:
     @asyncio.coroutine
     def bootstrap(self):
         """Try to to bootstrap initial cluster metadata"""
-        # using request v0 for bootstap (bcs api version is not detected yet)
-        metadata_request = MetadataRequest[0]([])
+        # using request v0 for bootstap if not sure v1 is available
+        if self.api_version == "auto" or self.api_version < (0, 10):
+            metadata_request = MetadataRequest[0]([])
+        else:
+            metadata_request = MetadataRequest[1]([])
+
         for host, port, _ in self.hosts:
             log.debug("Attempting to bootstrap via node at %s:%s", host, port)
 


### PR DESCRIPTION
This is a naive fix for the problem of client bootstrap trying to fetch all topic metadata.
It only changes current behaviour if a version is manually supplied to the client.

v1 of the protocol changes the semantics of [] to mean "don't fetch any topic metadata at all", v0 [] means "get all topic metadata".

Is this good enough as a temporary solution?

Fixes #440