### PR TITLE
Support async with in the consumer

### DIFF
--- a/aiokafka/consumer/consumer.py
+++ b/aiokafka/consumer/consumer.py
@@ -747,7 +747,7 @@ class AIOKafkaConsumer(object):
             assert partitions, 'No partitions are currently assigned'
         else:
             not_assigned = (
-                set(partitions) - self._subscription.assigned_partitions()
+                    set(partitions) - self._subscription.assigned_partitions()
             )
             if not_assigned:
                 raise IllegalStateError(
@@ -791,7 +791,7 @@ class AIOKafkaConsumer(object):
             assert partitions, 'No partitions are currently assigned'
         else:
             not_assigned = (
-                set(partitions) - self._subscription.assigned_partitions()
+                    set(partitions) - self._subscription.assigned_partitions()
             )
             if not_assigned:
                 raise IllegalStateError(
@@ -836,7 +836,7 @@ class AIOKafkaConsumer(object):
             assert partitions, 'No partitions are currently assigned'
         else:
             not_assigned = (
-                set(partitions) - self._subscription.assigned_partitions()
+                    set(partitions) - self._subscription.assigned_partitions()
             )
             if not_assigned:
                 raise IllegalStateError(
@@ -887,7 +887,7 @@ class AIOKafkaConsumer(object):
         if self._client.api_version <= (0, 10, 0):
             raise UnsupportedVersionError(
                 "offsets_for_times API not supported for cluster version {}"
-                .format(self._client.api_version))
+                    .format(self._client.api_version))
         for tp, ts in timestamps.items():
             timestamps[tp] = int(ts)
             if ts < 0:
@@ -927,7 +927,7 @@ class AIOKafkaConsumer(object):
         if self._client.api_version <= (0, 10, 0):
             raise UnsupportedVersionError(
                 "offsets_for_times API not supported for cluster version {}"
-                .format(self._client.api_version))
+                    .format(self._client.api_version))
         offsets = yield from self._fetcher.beginning_offsets(
             partitions, self._request_timeout_ms)
         return offsets
@@ -963,7 +963,7 @@ class AIOKafkaConsumer(object):
         if self._client.api_version <= (0, 10, 0):
             raise UnsupportedVersionError(
                 "offsets_for_times API not supported for cluster version {}"
-                .format(self._client.api_version))
+                    .format(self._client.api_version))
         offsets = yield from self._fetcher.end_offsets(
             partitions, self._request_timeout_ms)
         return offsets
@@ -1199,12 +1199,13 @@ class AIOKafkaConsumer(object):
     if PY_35:
         async def __aenter__(self):
             await self.start()
-        
+
         async def __aexit__(self, exc_type, exc, tb):
             if (not exc_type) or (not exc) or (not tb):
-                log.debug("Exception in async-with block", exc_info=(exc_type, exc, tb))
+                log.debug("Exception in async-with block",
+                          exc_info=(exc_type, exc, tb))
             await self.stop()
-       
+
         def __aiter__(self):
             if self._closed:
                 raise ConsumerStoppedError()

--- a/aiokafka/consumer/consumer.py
+++ b/aiokafka/consumer/consumer.py
@@ -1197,6 +1197,14 @@ class AIOKafkaConsumer(object):
             self._subscription.resume(partition)
 
     if PY_35:
+        async def __aenter__(self):
+            await self.start()
+        
+        async def __aexit__(self, exc_type, exc, tb):
+            if (not exc_type) or (not exc) or (not tb):
+                log.debug("Exception in async-with block", exc_info=(exc_type, exc, tb))
+            await self.stop()
+       
         def __aiter__(self):
             if self._closed:
                 raise ConsumerStoppedError()

--- a/docs/consumer.rst
+++ b/docs/consumer.rst
@@ -23,6 +23,13 @@ from a Kafka cluster. Most simple usage would be::
     finally:
         await consumer.stop()
 
+In modern version of Python (>=3.5), the consumer supports `async with`::
+
+    async with AIOKafkaConsumer(...) as consumer:
+        # do work
+
+which will automatically call `start` and `stop` on enter and exit of the context.
+
 .. note:: ``msg.value`` and ``msg.key`` are raw bytes, use **key_deserializer**
   and **value_deserializer** configuration if you need to decode them. 
 

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -14,7 +14,7 @@ from aiokafka.consumer import fetcher
 from aiokafka.producer import AIOKafkaProducer
 from aiokafka.record import MemoryRecords
 from aiokafka.client import AIOKafkaClient
-from aiokafka.util import ensure_future, PY_341
+from aiokafka.util import ensure_future, PY_341, PY_35
 from aiokafka.structs import (
     OffsetAndTimestamp, TopicPartition, OffsetAndMetadata
 )
@@ -154,6 +154,16 @@ class TestConsumerIntegration(KafkaIntegrationTestCase):
                 del consumer
                 yield from asyncio.sleep(0, loop=self.loop)
                 gc.collect()
+
+    @pytest.mark.skipif(not PY_35, reason="Not supported on older Python's")
+    @run_until_complete
+    async def test_async_with(self):
+        async with AIOKafkaConsumer(loop=self.loop,
+                                    group_id=None,
+                                    bootstrap_servers=self.hosts) \
+                as _:
+            pass
+
 
     @run_until_complete
     def test_get_by_partition(self):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Adds `async with` -- PEP 492 -- support in the consumer 

## Are there changes in behavior for the user?

Not really, just support for 

`async with AIOKafkaConsumer(....) as foo: pass`

## Related issue number

None

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
