### PR TITLE
Bump version of kafka-python to 1.4.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ class ve_build_ext(build_ext):
             raise BuildFailed()
 
 
-install_requires = ['kafka-python==1.4.3']
+install_requires = ['kafka-python==1.4.6']
 
 PY_VER = sys.version_info
 


### PR DESCRIPTION
Bumps version of kafka-python to 1.4.6 from 1.4.3