### PR TITLE
#523: add consumer.last_poll_timestamp(partition)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 CHANGES
 -------
 
+523.feature
+^^^^^^^^^^^
+
+Add `consumer.last_poll_timestamp(partition)` which gives the ms timestamp of the last update of `highwater` and `lso`.
+
+
 0.5.2 (2019-03-10)
 ^^^^^^^^^^^^^^^^^^
 

--- a/aiokafka/consumer/consumer.py
+++ b/aiokafka/consumer/consumer.py
@@ -683,6 +683,25 @@ class AIOKafkaConsumer(object):
         assignment = self._subscription.subscription.assignment
         return assignment.state_value(partition).lso
 
+    def last_poll_timestamp(self, partition):
+        """ Returns the timestamp of the last poll of this partition (in ms).
+        It is the last time `highwater` and `last_stable_offset` were
+        udpated. However it does not mean that new messages were received.
+
+        As with ``highwater()`` will not be available until some messages are
+        consumed.
+
+        Arguments:
+            partition (TopicPartition): partition to check
+
+        Returns:
+            int or None: timestamp if available
+        """
+        assert self._subscription.is_assigned(partition), \
+            'Partition is not assigned'
+        assignment = self._subscription.subscription.assignment
+        return assignment.state_value(partition).timestamp
+
     def seek(self, partition, offset):
         """ Manually specify the fetch offset for a TopicPartition.
 

--- a/aiokafka/consumer/fetcher.py
+++ b/aiokafka/consumer/fetcher.py
@@ -2,6 +2,7 @@ import asyncio
 import collections
 import logging
 import random
+import time
 from itertools import chain
 
 from kafka.protocol.offset import OffsetRequest
@@ -673,6 +674,7 @@ class Fetcher:
             for partition, offset, _ in partitions:
                 fetch_offsets[TopicPartition(topic, partition)] = offset
 
+        now_ms = int(1000 * time.time())
         for topic, partitions in response.topics:
             for partition, error_code, highwater, *part_data in partitions:
                 tp = TopicPartition(topic, partition)
@@ -696,6 +698,7 @@ class Fetcher:
                         lso = None
                     tp_state.highwater = highwater
                     tp_state.lso = lso
+                    tp_state.timestamp = now_ms
 
                     # part_data also contains lso, aborted_transactions.
                     # message_set is last

--- a/aiokafka/consumer/subscription_state.py
+++ b/aiokafka/consumer/subscription_state.py
@@ -463,6 +463,7 @@ class TopicPartitionState(object):
 
         self.highwater = None  # Last fetched highwater mark
         self.lso = None  # Last fetched stable offset mark
+        self.timestamp = None  # timestamp of last poll
         self._position = None  # The current position of the topic
         self._position_fut = create_future(loop=loop)
 

--- a/docs/consumer.rst
+++ b/docs/consumer.rst
@@ -444,8 +444,10 @@ catch up). For example::
         for partition in consumer.assignment():
             highwater = consumer.highwater(partition)
             position = await consumer.position(partition)
-            lag = highwater - position
-            if lag > LAG_THRESHOLD:
+            position_lag = highwater - position
+            timestamp = consumer.last_poll_timestamp(partition)
+            time_lag = time.time() * 1000 - timestamp
+            if position_lag > POSITION_THRESHOLD or time_lag > TIME_THRESHOLD:
                 partitions.append(partition)
 
 .. note:: This interface differs from `pause()`/`resume()` interface of 

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -69,6 +69,7 @@ class TestConsumerIntegration(KafkaIntegrationTestCase):
             # check unsupported version
             consumer = await self.consumer_factory(api_version="0.8")
 
+        now = time.time()
         await self.send_messages(0, list(range(0, 100)))
         await self.send_messages(1, list(range(100, 200)))
         # Start a consumer_factory
@@ -101,6 +102,10 @@ class TestConsumerIntegration(KafkaIntegrationTestCase):
 
         h = consumer.highwater(p0)
         self.assertEqual(h, 100)
+        t = consumer.last_poll_timestamp(p0)
+        self.assertGreaterEqual(t, int(now * 1000))
+        now = time.time()
+        self.assertLessEqual(t, int(now * 1000))
 
         consumer.seek(p0, offset + 90)
         for i in range(10):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Add `consumer.last_poll_timestamp(partition)` which gives the ms timestamp of the last update of `highwater` and `lso`. This value is stored in `TopicPartitionState.timestamp` and updated with `highwater` and `lso`.

## Are there changes in behavior for the user?

It doesn't affect the current behavior, only adds a new method.

## Related issue number

https://github.com/aio-libs/aiokafka/issues/523
It will enable to know if a partition has been consumed recently, or is just waiting for another poll.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist: in `test_simple_consumer`, test that `last_poll_timestamp` is in the expected time range
- [x] Documentation reflects the changes: in "Consumption Flow Control" example
- [x] Add a new news fragment into the `CHANGES` folder