### PR TITLE
Fix documentation for benchmark

### DIFF
--- a/benchmark/README
+++ b/benchmark/README
@@ -1,7 +1,7 @@
 The batch compose and read benchmarks in this section are written using
 ``perf`` library, created by Viktor Stinner. For more information on how to get
 reliable results of test runs please consult
-http://perf.readthedocs.io/en/latest/run_benchmark.html.
+http://pyperf.readthedocs.io/en/latest/run_benchmark.html.
 
 The `simple_` benchmarks can be just run, consult command line argument on how
 to run those.


### PR DESCRIPTION
The documentation has a broken link to the pyperf package.

<!-- Thank you for your contribution! -->

## What do these changes do?

Fixes broken link in the Benchmark documentation.

## Are there changes in behavior for the user?

No

## Related issue number

No

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
