### PR TITLE
Add connection open/close callbacks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 CHANGES
 -------
 
+552.feature
+^^^^^^^^^^^
+
+Add new callbacks for connection opened/close for consumer and producer 
+
 523.feature
 ^^^^^^^^^^^
 

--- a/aiokafka/consumer/consumer.py
+++ b/aiokafka/consumer/consumer.py
@@ -321,6 +321,21 @@ class AIOKafkaConsumer(object):
                 context['source_traceback'] = self._source_traceback
             self._loop.call_exception_handler(context)
 
+    def set_on_connection_closed_callback(self, on_connection_closed_callback):
+        """Set a callback function to invoke when a connection to Kafka is closed
+        Arguments:
+            on_connection_closed_callback: a callback function to call
+        """
+        self._client.set_on_connection_closed_callback(on_connection_closed_callback)
+
+    def set_on_connection_opened_callback(self, on_connection_opened_callback):
+        """Set a callback function to invoke when a connection to Kafka is opened
+        Arguments:
+            on_connection_opened_callback: a callback function to call
+        """
+        self._client.set_on_connection_opened_callback(on_connection_opened_callback)
+
+
     async def start(self):
         """ Connect to Kafka cluster. This will:
 

--- a/aiokafka/producer/producer.py
+++ b/aiokafka/producer/producer.py
@@ -549,6 +549,20 @@ class AIOKafkaProducer(object):
         fut = self._txn_manager.add_offsets_to_txn(formatted_offsets, group_id)
         await asyncio.shield(fut, loop=self._loop)
 
+    def set_on_connection_closed_callback(self, on_connection_closed_callback):
+        """Set a callback function to invoke when a connection to Kafka is closed
+        Arguments:
+            on_connection_closed_callback: a callback function to call
+        """
+        self.client.set_on_connection_closed_callback(on_connection_closed_callback)
+
+    def set_on_connection_opened_callback(self, on_connection_opened_callback):
+        """Set a callback function to invoke when a connection to Kafka is opened
+        Arguments:
+            on_connection_opened_callback: a callback function to call
+        """
+        self.client.set_on_connection_opened_callback(on_connection_opened_callback)
+
 
 class TransactionContext:
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Add new callbacks for connection opened/close for consumer and producer

## Are there changes in behavior for the user?

User may add callbacks if they want to be notified for changes in connection status (and take action accordingly)

## Related issue number

No

## Checklist

- [x ] I think the code is well written
- [ x] Unit tests for the changes exist
- [ x] Documentation reflects the changes
- [ x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
