### PR TITLE
Timeout on broker metadata sending failure

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,9 @@
 CHANGES
 -------
 
+576.bugfix
+Added handling `asyncio.TimeoutError` on metadata request to broker and metadata update.
+
 558.feature
 Upgrade to kafka-python version 1.4.7, which fixes a number of issues with client performance and concurrency.
 

--- a/aiokafka/client.py
+++ b/aiokafka/client.py
@@ -202,7 +202,7 @@ class AIOKafkaClient:
 
             try:
                 metadata = await bootstrap_conn.send(metadata_request)
-            except KafkaError as err:
+            except (KafkaError, asyncio.TimeoutError) as err:
                 log.warning('Unable to request metadata from "%s:%s": %s',
                             host, port, err)
                 bootstrap_conn.close()
@@ -292,7 +292,7 @@ class AIOKafkaClient:
 
             try:
                 metadata = await conn.send(metadata_request)
-            except KafkaError as err:
+            except (KafkaError, asyncio.TimeoutError) as err:
                 log.error(
                     'Unable to request metadata from node with id %s: %s',
                     node_id, err)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Add support for `asyncio.TimeoutError` on requesting metadata during bootstrap and metadata update.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

No changes

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

Issue #576

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
