### PR TITLE
Catch request timeout in coordinator

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,9 @@
 CHANGES
 -------
 
+584.bugfix
+Handle `RequestTimedOutError` in `coordinator._do_commit_offsets()` method to explicitly mark coordinator as dead.
+
 576.bugfix
 Added handling `asyncio.TimeoutError` on metadata request to broker and metadata update.
 

--- a/aiokafka/consumer/group_coordinator.py
+++ b/aiokafka/consumer/group_coordinator.py
@@ -1013,7 +1013,8 @@ class GroupCoordinator(BaseCoordinator):
                         error_type.__name__)
                     errored[tp] = error_type()
                 elif error_type in (Errors.GroupCoordinatorNotAvailableError,
-                                    Errors.NotCoordinatorForGroupError):
+                                    Errors.NotCoordinatorForGroupError,
+                                    Errors.RequestTimedOutError):
                     log.info(
                         "OffsetCommit failed for group %s due to a"
                         " coordinator error (%s), will find new coordinator"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
Propose to fix this issue https://github.com/aio-libs/aiokafka/issues/584 

<!-- Please give a short brief about these changes. -->
These changes add handling `kafka.RequestTimedOutError` exception in `coordinator._do_commit_offsets()` method and `coordinator.coordinator_dead()` is called explicitly in result.
## Are there changes in behavior for the user?
It seems no.
<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
https://github.com/aio-libs/aiokafka/issues/584 
## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
