### PR TITLE
Add some missing test, that was in a different PR for some reason.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ ci-test-unit:
 	py.test -s --log-level DEBUG --cov aiokafka --cov-report html $(FLAGS) tests
 
 ci-test-all:
-	py.test -s --log-level DEBUG --cov aiokafka --cov-report html --docker-image $(DOCKER_IMAGE) $(FLAGS) tests
+	py.test -s -v --log-level DEBUG --cov aiokafka --cov-report html --docker-image $(DOCKER_IMAGE) $(FLAGS) tests
 
 coverage.xml: .coverage
 	coverage xml

--- a/tests/_testutil.py
+++ b/tests/_testutil.py
@@ -190,7 +190,7 @@ class ACLManager:
         return options
 
     def cleanup(self):
-        for acl_params in self._active_acls:
+        for acl_params in self._active_acls[:]:
             self.remove_acl(**acl_params)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -198,7 +198,7 @@ if sys.platform != 'win32':
             detach=True)
 
         try:
-            if not wait_kafka(kafka_host, kafka_port, timeout=10):
+            if not wait_kafka(kafka_host, kafka_port):
                 exit_code, output = container.exec_run(
                     ["supervisorctl", "tail", "kafka"])
                 print("Kafka failed to start. \n--- STDOUT:")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,15 +72,6 @@ def kafka_config(kafka_server, request):
     return manager
 
 
-@pytest.yield_fixture(autouse=True)
-def clean_acl(acl_manager):
-    # This is used to have a better report on ResourceWarnings. Without it
-    # all warnings will be filled in the end of last test-case.
-    acl_manager.list_acl()
-    yield
-    acl_manager.cleanup()
-
-
 if sys.platform != 'win32':
 
     @pytest.fixture(scope='class')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,8 +40,10 @@ def pytest_addoption(parser):
 
 def pytest_configure(config):
     """Disable the loggers."""
-    logger = logging.getLogger("asyncio")
-    logger.setLevel(logging.INFO)
+    # Debug logs clobber output on CI
+    for name in ["urllib3", "asyncio"]:
+        logger = logging.getLogger(name)
+        logger.setLevel(logging.INFO)
 
 
 @pytest.fixture(scope='session')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import asyncio
 import gc
 import docker as libdocker
+import logging
 import pytest
 import socket
 import uuid
@@ -37,6 +38,12 @@ def pytest_addoption(parser):
                      help='Do not pull new docker image before test run')
 
 
+def pytest_configure(config):
+    """Disable the loggers."""
+    logger = logging.getLogger("asyncio")
+    logger.setLevel(logging.INFO)
+
+
 @pytest.fixture(scope='session')
 def docker(request):
     image = request.config.getoption('--docker-image')
@@ -69,6 +76,7 @@ def kafka_config(kafka_server, request):
 def clean_acl(acl_manager):
     # This is used to have a better report on ResourceWarnings. Without it
     # all warnings will be filled in the end of last test-case.
+    acl_manager.list_acl()
     yield
     acl_manager.cleanup()
 

--- a/tests/test_sasl.py
+++ b/tests/test_sasl.py
@@ -1,3 +1,5 @@
+import pytest
+
 from ._testutil import (
     KafkaIntegrationTestCase, run_until_complete, kafka_versions
 )
@@ -10,7 +12,6 @@ from aiokafka.errors import (
     TransactionalIdAuthorizationFailed, UnknownTopicOrPartitionError
 )
 from aiokafka.structs import TopicPartition
-import pytest
 
 
 @pytest.mark.usefixtures('setup_test_class')
@@ -20,6 +21,16 @@ class TestKafkaSASL(KafkaIntegrationTestCase):
     # See https://docs.confluent.io/current/kafka/authorization.html
     # for a good list of what Operation can be mapped to what Resource and
     # when is it checked
+
+    def setUp(self):
+        super().setUp()
+        self.acl_manager.list_acl()
+
+    def tearDown(self):
+        # This is used to have a better report on ResourceWarnings. Without it
+        # all warnings will be filled in the end of last test-case.
+        super().tearDown()
+        self.acl_manager.cleanup()
 
     @property
     def sasl_hosts(self):

--- a/tests/test_sasl.py
+++ b/tests/test_sasl.py
@@ -24,7 +24,8 @@ class TestKafkaSASL(KafkaIntegrationTestCase):
 
     def setUp(self):
         super().setUp()
-        self.acl_manager.list_acl()
+        if tuple(map(int, self.kafka_version.split("."))) >= (0, 10):
+            self.acl_manager.list_acl()
 
     def tearDown(self):
         # This is used to have a better report on ResourceWarnings. Without it
@@ -242,42 +243,24 @@ class TestKafkaSASL(KafkaIntegrationTestCase):
 
     @kafka_versions('>=0.11.0')
     @run_until_complete
-    async def test_sasl_deny_autocreate(self):
-        # Before 1.0.0 Kafka if topic does not exist it will not report
-        # Topic authorization errors, so we need to create topic beforehand
-        # See https://kafka.apache.org/documentation/#upgrade_100_notable
-        tmp_producer = await self.producer_factory()
-        error_class = TopicAuthorizationFailedError
-        if tmp_producer.client.api_version < (1, 0):
-            error_class = UnknownTopicOrPartitionError
-        del tmp_producer
-
-        self.acl_manager.add_acl(
-            allow_principal="test", operation="All", cluster=True)
+    async def test_sasl_deny_autocreate_cluster(self):
         self.acl_manager.add_acl(
             deny_principal="test", operation="CREATE", cluster=True)
+        self.acl_manager.add_acl(
+            allow_principal="test", operation="DESCRIBE", topic=self.topic)
+        self.acl_manager.add_acl(
+            allow_principal="test", operation="WRITE", topic=self.topic)
 
         producer = await self.producer_factory(request_timeout_ms=5000)
-        with self.assertRaises(UnknownTopicOrPartitionError):
+        with self.assertRaises(TopicAuthorizationFailedError):
             await producer.send_and_wait(self.topic, value=b"Super sasl msg")
 
-        with self.assertRaises(UnknownTopicOrPartitionError):
+        with self.assertRaises(TopicAuthorizationFailedError):
             await self.consumer_factory(request_timeout_ms=5000)
 
-        with self.assertRaises(UnknownTopicOrPartitionError):
+        with self.assertRaises(TopicAuthorizationFailedError):
             await self.consumer_factory(
                 request_timeout_ms=5000, group_id=None)
-
-        self.acl_manager.add_acl(
-            allow_principal="test", operation="All", topic=self.topic)
-        self.acl_manager.add_acl(
-            deny_principal="test", operation="CREATE", topic=self.topic)
-
-        with self.assertRaises(error_class):
-            await producer.send_and_wait(self.topic, value=b"Super sasl msg")
-
-        with self.assertRaises(error_class):
-            await self.consumer_factory(request_timeout_ms=5000)
 
     ##########################################################################
     # Group Resource


### PR DESCRIPTION
Revert the kafka broker start timeout in tests to 60s