### PR TITLE
  Ignore debug package generation on bdist_rpm command

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ import os
 import re
 import platform
 import sys
+from distutils.command.bdist_rpm import bdist_rpm as _bdist_rpm
 from distutils.command.build_ext import build_ext
 from distutils.errors import (CCompilerError, DistutilsExecError,
                               DistutilsPlatformError)
@@ -67,10 +68,14 @@ extensions = [
 if USE_CYTHON:
     extensions = cythonize(extensions)
 
+class bdist_rpm(_bdist_rpm):
+    def _make_spec_file(self):
+        orig = super()._make_spec_file()
+        orig.insert(0, '%define debug_package %{nil}')
+        return orig
 
 class BuildFailed(Exception):
     pass
-
 
 class ve_build_ext(build_ext):
     # This class allows C extension building to fail.
@@ -151,7 +156,7 @@ args = dict(
     extras_require=extras_require,
     include_package_data=True,
     ext_modules=extensions,
-    cmdclass=dict(build_ext=ve_build_ext)
+    cmdclass=dict(build_ext=ve_build_ext, bdist_rpm=bdist_rpm)
 )
 
 try:


### PR DESCRIPTION
because the command fails on the debug file information gathering step

https://github.com/aio-libs/aiokafka/issues/599
