### PR TITLE
Set language_level to version 3.

### DIFF
--- a/aiokafka/record/_crecords/consts.pxi
+++ b/aiokafka/record/_crecords/consts.pxi
@@ -1,3 +1,4 @@
+#cython: language_level=3
 # Attribute parsing flags
 DEF _ATTR_CODEC_MASK = 0x07
 DEF _ATTR_CODEC_NONE = 0x00

--- a/aiokafka/record/_crecords/cutil.pxd
+++ b/aiokafka/record/_crecords/cutil.pxd
@@ -1,3 +1,4 @@
+#cython: language_level=3
 from libc.stdint cimport int64_t, uint64_t, uint32_t
 from libc.limits cimport UINT_MAX
 from cpython cimport (

--- a/aiokafka/record/_crecords/cutil.pyx
+++ b/aiokafka/record/_crecords/cutil.pyx
@@ -1,3 +1,4 @@
+#cython: language_level=3
 from aiokafka.errors import CorruptRecordException
 
 # VarInt implementation

--- a/aiokafka/record/_crecords/default_records.pxd
+++ b/aiokafka/record/_crecords/default_records.pxd
@@ -1,3 +1,4 @@
+#cython: language_level=3
 from libc.stdint cimport int64_t, uint32_t, int32_t, int16_t
 
 

--- a/aiokafka/record/_crecords/default_records.pyx
+++ b/aiokafka/record/_crecords/default_records.pyx
@@ -1,3 +1,4 @@
+#cython: language_level=3
 # See:
 # https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/\
 #    apache/kafka/common/record/DefaultRecordBatch.java

--- a/aiokafka/record/_crecords/hton.pxd
+++ b/aiokafka/record/_crecords/hton.pxd
@@ -1,3 +1,4 @@
+#cython: language_level=3
 # Module taken as is from https://github.com/MagicStack/asyncpg project.
 
 # Copyright (C) 2016-present the asyncpg authors and contributors

--- a/aiokafka/record/_crecords/legacy_records.pxd
+++ b/aiokafka/record/_crecords/legacy_records.pxd
@@ -1,3 +1,4 @@
+#cython: language_level=3
 from libc.stdint cimport int64_t, uint32_t
 
 

--- a/aiokafka/record/_crecords/memory_records.pyx
+++ b/aiokafka/record/_crecords/memory_records.pyx
@@ -1,3 +1,4 @@
+#cython: language_level=3
 # This class takes advantage of the fact that all formats v0, v1 and v2 of
 # messages storage has the same byte offsets for Length and Magic fields.
 # Lets look closely at what leading bytes all versions have:


### PR DESCRIPTION
Fixes:
```
FutureWarning: Cython directive 'language_level' not set, using 2 for now (Py2). This will change in a later release!
```