### PR TITLE
add test for sasl ssl

### DIFF
--- a/tests/_testutil.py
+++ b/tests/_testutil.py
@@ -392,12 +392,21 @@ class KafkaIntegrationTestCase(unittest.TestCase):
         # Make sure there are no duplicates
         self.assertEqual(len(set(messages)), num_messages)
 
-    def create_ssl_context(self):
+    def create_ssl_context(self, ca_cert_only: bool = False):
+        certfile = None
+        keyfile = None
+
+        if not ca_cert_only:
+            certfile = str(self.ssl_folder / "cl_client.pem")
+            keyfile = str(self.ssl_folder / "cl_client.key")
+
         context = create_ssl_context(
             cafile=str(self.ssl_folder / "ca-cert"),
-            certfile=str(self.ssl_folder / "cl_client.pem"),
-            keyfile=str(self.ssl_folder / "cl_client.key"),
-            password="abcdefgh")
+            certfile=certfile,
+            keyfile=keyfile,
+            password="abcdefgh",
+        )
+
         context.check_hostname = False
         return context
 


### PR DESCRIPTION
<!-- Thank you for your contribution! 
Feel free to change the template if you feel confused.
-->
### Changes

Hello! Thank you for great library! Just wanted to test if sasl_ssl auth method is working correctly while setting it up for my project. Realised that this scenario is missing in library's functional tests. So I've added it.

By the way, when tried to run tests on master there was a bunch of warnings like `RuntimeWarning: coroutine 'TestKafkaClientIntegration.test_failed_bootstrap' was never awaited` so many tests didnt actually run. When tried on top of the latest release tests run smoothly
<!-- Please give a short brief about these changes. -->

### Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.misc`: A ticket has been closed, but it is not of interest to users.
