### PR TITLE
Retry once on StaleMetadata

### DIFF
--- a/aiokafka/client.py
+++ b/aiokafka/client.py
@@ -298,7 +298,10 @@ class AIOKafkaClient:
             nodeids.append('bootstrap')
         random.shuffle(nodeids)
         for node_id in nodeids:
-            conn = await self._get_conn(node_id)
+            try:
+                conn = await self._get_conn(node_id)
+            except StaleMetadata:
+                conn = None
 
             if conn is None:
                 continue

--- a/aiokafka/client.py
+++ b/aiokafka/client.py
@@ -395,10 +395,14 @@ class AIOKafkaClient:
                 reason == CloseReason.CONNECTION_TIMEOUT:
             self.force_metadata_update()
 
-    async def _get_conn(
-        self, node_id, *, group=ConnectionGroup.DEFAULT,
-        no_hint=False
-    ):
+    def _get_broker(self, node_id):
+        broker = self.cluster.broker_metadata(node_id)
+        if broker is None:
+            self.force_metadata_update()
+            return self.cluster.broker_metadata(node_id)
+        return broker
+
+    async def _get_conn(self, node_id, *, group=ConnectionGroup.DEFAULT, no_hint=False):
         "Get or create a connection to a broker using host and port"
         conn_id = (node_id, group)
         if conn_id in self._conns:
@@ -410,11 +414,7 @@ class AIOKafkaClient:
 
         try:
             if group == ConnectionGroup.DEFAULT:
-                broker = self.cluster.broker_metadata(node_id)
-                # XXX: earlier we only did an assert here, but it seems it's
-                # possible to get a leader that is for some reason not in
-                # metadata.
-                # I think requerying metadata should solve this problem
+                broker = self._get_broker(node_id)
                 if broker is None:
                     raise StaleMetadata(
                         'Broker id %s not in current metadata' % node_id)


### PR DESCRIPTION
We encoutered a loop of StaleMetadata error, and I found out that it's the `_metadata_update` calls that fails in the `_get_client` method.

### Changes

My idea to fix this is to at least retry once on the first occurency of the StaleMetadata case, then raise the StaleMetadata if it still None after a call to `force_metadata_update`.
In the mean time, also allow the `_metadata_update` method to handle a StaleMetadata case (it is itself using the `_get_conn` method) and consider the node_id to represent a None conn. None conn are later skiped by the `if not conn: continue` case thus allowing the `_metadata_update` algorithm to try to connect to the next node and refresh the cluster metadata from this node. 

(Still working on the Test and Document/CHANGES fragments, but I thought it could be discussed while i'm doing so).

### Checklist


- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
