### PR TITLE
Fix consumer fetcher for python3.9

### DIFF
--- a/CHANGES/python3.9-fix.bugfix
+++ b/CHANGES/python3.9-fix.bugfix
@@ -1,0 +1,1 @@
+Fix consumer fetcher for python3.9

--- a/aiokafka/consumer/fetcher.py
+++ b/aiokafka/consumer/fetcher.py
@@ -530,7 +530,9 @@ class Fetcher:
                     other_futs.append(fut)
 
                 done_set, _ = await asyncio.wait(
-                    chain(self._pending_tasks, other_futs, resume_futures),
+                    set(
+                        chain(self._pending_tasks, other_futs, resume_futures)
+                    ),
                     timeout=timeout,
                     return_when=asyncio.FIRST_COMPLETED)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! 
Feel free to change the template if you feel confused.
-->
### Changes

Fixes #<!-- Provide issue number if exists -->
- Fix consumer fetcher for python3.9

<!-- Please give a short brief about these changes. -->
From python3.9 the `asyncio.wait` function iterates over futures two times.
The consumer fetcher gives an iterator to this function, so the second iteration is empty, that causes the error `Set of Futures is empty`.

python3.9 asyncio code:

```python
    if any(coroutines.iscoroutine(f) for f in set(fs)):
        warnings.warn("The explicit passing of coroutine objects to "
                      "asyncio.wait() is deprecated since Python 3.8, and "
                      "scheduled for removal in Python 3.11.",
                      DeprecationWarning, stacklevel=2)

    fs = {ensure_future(f, loop=loop) for f in set(fs)}

```

### Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
