### PR TITLE
Update isort to 5.6.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,15 +12,15 @@ setup:
 	pip install -Ue .
 
 format:
-	isort -rc $(FORMATTED_AREAS) setup.py
+	isort $(FORMATTED_AREAS) setup.py
 	black $(FORMATTED_AREAS) setup.py
 
 flake: lint
 lint:
 	black --check $(FORMATTED_AREAS) setup.py
-	@if ! isort -c -rc $(FORMATTED_AREAS) setup.py; then \
+	@if ! isort -c $(FORMATTED_AREAS) setup.py; then \
             echo "Import sort errors, run 'make format' to fix them!!!"; \
-            isort --diff -rc $(FORMATTED_AREAS) setup.py; \
+            isort --diff --color $(FORMATTED_AREAS) setup.py; \
             false; \
         fi
 	flake8 aiokafka tests setup.py

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -2,7 +2,7 @@
 flake8==3.8.3
 black==19.10b0
 mypy==0.782
-isort==4.3.21
+isort[colors]==5.6.4
 pytest==5.4.3
 pytest-cov==2.10.0
 pytest-asyncio==0.12.0

--- a/requirements-win-test.txt
+++ b/requirements-win-test.txt
@@ -2,7 +2,7 @@
 flake8==3.8.3
 black==19.10b0
 mypy==0.782
-isort==4.3.21
+isort[colors]==5.6.4
 pytest==5.4.3
 pytest-cov==2.10.0
 pytest-asyncio==0.12.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ multi_line_output=3
 force_grid_wrap=0
 combine_as_imports=True
 lines_after_imports=2
-known_standard_library=dataclasses
+extra_standard_library=dataclasses
 known_first_party=aiokafka,kafka
 known_third_party=pytest
 


### PR DESCRIPTION
### Changes

* Remove `-rc` option as it's no longer needed/supported
* Replace `known_standard_library` with `extra_standard_library`
* Colorize diff output

This should fix [the problem](https://github.com/aio-libs/aiokafka/runs/1309008038?check_suite_focus=true) with pyup MRs

### Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
