### PR TITLE
Fix warnings with Python 3.9

### DIFF
--- a/aiokafka/producer/producer.py
+++ b/aiokafka/producer/producer.py
@@ -13,7 +13,7 @@ from aiokafka.errors import (
 from aiokafka.record.legacy_records import LegacyRecordBatchBuilder
 from aiokafka.structs import TopicPartition
 from aiokafka.util import (
-    INTEGER_MAX_VALUE, commit_structure_validate, get_running_loop
+    INTEGER_MAX_VALUE, commit_structure_validate, create_task, get_running_loop
 )
 
 from .message_accumulator import MessageAccumulator
@@ -316,7 +316,7 @@ class AIOKafkaProducer(object):
         # If the sender task is down there is no way for accumulator to flush
         if self._sender is not None and self._sender.sender_task is not None:
             await asyncio.wait([
-                self._message_accumulator.close(),
+                create_task(self._message_accumulator.close()),
                 self._sender.sender_task],
                 return_when=asyncio.FIRST_COMPLETED)
 


### PR DESCRIPTION
### Changes

Python 3.9 issue warnings when coroutine is passed to `asyncio.wait()`, so we have to explicitly create task from coroutine or use future instead.
