### PR TITLE
Fix initialization without running loop (issue #689)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ Exclude `.so` from source distribution
 
 689.bugfix
 Add `dataclasses` backport package to dependencies for Python 3.6
+Fix initialization without running loop
 
 693.doc
 Update docs and examples to not use deprecated practices like passing loop explicitly

--- a/aiokafka/client.py
+++ b/aiokafka/client.py
@@ -149,7 +149,13 @@ class AIOKafkaClient:
 
         self._md_update_fut = None
         self._md_update_waiter = loop.create_future()
-        self._get_conn_lock = asyncio.Lock()
+        self._get_conn_lock_value = None
+
+    @property
+    def _get_conn_lock(self):
+        if self._get_conn_lock_value is None:
+            self._get_conn_lock_value = asyncio.Lock()
+        return self._get_conn_lock_value
 
     def __repr__(self):
         return '<AIOKafkaClient client_id=%s>' % self._client_id

--- a/aiokafka/conn.py
+++ b/aiokafka/conn.py
@@ -436,7 +436,7 @@ class AIOKafkaConnection:
 
         if not expect_response:
             return self._writer.drain()
-        fut = create_future()
+        fut = self._loop.create_future()
         self._requests.append((correlation_id, request.RESPONSE_TYPE, fut))
         return asyncio.wait_for(fut, self._request_timeout)
 
@@ -458,7 +458,7 @@ class AIOKafkaConnection:
         if not expect_response:
             return self._writer.drain()
 
-        fut = create_future()
+        fut = self._loop.create_future()
         self._requests.append((None, None, fut))
         return asyncio.wait_for(fut, self._request_timeout)
 

--- a/aiokafka/consumer/consumer.py
+++ b/aiokafka/consumer/consumer.py
@@ -302,7 +302,7 @@ class AIOKafkaConsumer(object):
         self._max_poll_interval_ms = max_poll_interval_ms
 
         self._check_crcs = check_crcs
-        self._subscription = SubscriptionState()
+        self._subscription = SubscriptionState(loop=loop)
         self._fetcher = None
         self._coordinator = None
         self._loop = loop

--- a/aiokafka/consumer/fetcher.py
+++ b/aiokafka/consumer/fetcher.py
@@ -368,6 +368,7 @@ class Fetcher:
             auto_offset_reset='latest',
             isolation_level="read_uncommitted"):
         self._client = client
+        self._loop = client._loop
         self._key_deserializer = key_deserializer
         self._value_deserializer = value_deserializer
         self._fetch_min_bytes = fetch_min_bytes
@@ -440,7 +441,7 @@ class Fetcher:
         # Creating a fetch waiter is usually not that frequent of an operation,
         # (get methods will return all data first, before a waiter is created)
 
-        fut = create_future()
+        fut = self._loop.create_future()
         self._fetch_waiters.add(fut)
         fut.add_done_callback(
             lambda f, waiters=self._fetch_waiters: waiters.remove(f))

--- a/tests/_testutil.py
+++ b/tests/_testutil.py
@@ -12,6 +12,7 @@ import shutil
 import sys
 import os
 
+from concurrent import futures
 from contextlib import contextmanager
 from functools import wraps
 
@@ -40,6 +41,18 @@ def run_until_complete(fun):
         ret = loop.run_until_complete(
             asyncio.wait_for(fun(test, *args, **kw), timeout))
         return ret
+    return wrapper
+
+
+def run_in_thread(fun):
+
+    @wraps(fun)
+    def wrapper(test, *args, **kw):
+        timeout = getattr(test, "TEST_TIMEOUT", 120)
+        with futures.ThreadPoolExecutor() as executor:
+            fut = executor.submit(fun, test, *args, **kw)
+            fut.result(timeout=timeout)
+
     return wrapper
 
 

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -27,7 +27,7 @@ from aiokafka.errors import (
 
 from ._testutil import (
     KafkaIntegrationTestCase, StubRebalanceListener,
-    run_until_complete, random_string, kafka_versions)
+    run_until_complete, run_in_thread, random_string, kafka_versions)
 
 
 class TestConsumerIntegration(KafkaIntegrationTestCase):
@@ -116,6 +116,7 @@ class TestConsumerIntegration(KafkaIntegrationTestCase):
         # will ignore, no exception expected
         await consumer.stop()
 
+    @run_in_thread
     def test_create_consumer_no_running_loop(self):
         loop = asyncio.new_event_loop()
         consumer = AIOKafkaConsumer(

--- a/tests/test_producer.py
+++ b/tests/test_producer.py
@@ -9,7 +9,7 @@ from unittest import mock
 from kafka.cluster import ClusterMetadata
 
 from ._testutil import (
-    KafkaIntegrationTestCase, run_until_complete, kafka_versions
+    KafkaIntegrationTestCase, run_until_complete, run_in_thread, kafka_versions
 )
 
 from aiokafka.protocol.produce import ProduceResponse
@@ -133,6 +133,7 @@ class TestKafkaProducerIntegration(KafkaIntegrationTestCase):
         with self.assertRaises(ProducerClosed):
             await producer.send(self.topic, b'value', key=b'KEY')
 
+    @run_in_thread
     def test_create_producer_no_running_loop(self):
         loop = asyncio.new_event_loop()
         producer = AIOKafkaProducer(bootstrap_servers=self.hosts, loop=loop)

--- a/tests/test_producer.py
+++ b/tests/test_producer.py
@@ -133,6 +133,20 @@ class TestKafkaProducerIntegration(KafkaIntegrationTestCase):
         with self.assertRaises(ProducerClosed):
             await producer.send(self.topic, b'value', key=b'KEY')
 
+    def test_create_producer_no_running_loop(self):
+        loop = asyncio.new_event_loop()
+        producer = AIOKafkaProducer(bootstrap_servers=self.hosts, loop=loop)
+        loop.run_until_complete(producer.start())
+        try:
+            future = loop.run_until_complete(
+                producer.send(self.topic, b'hello, Kafka!', partition=0))
+            resp = loop.run_until_complete(future)
+            self.assertEqual(resp.topic, self.topic)
+            self.assertTrue(resp.partition in (0, 1))
+            self.assertEqual(resp.offset, 0)
+        finally:
+            loop.run_until_complete(producer.stop())
+
     @run_until_complete
     async def test_producer_context_manager(self):
         producer = AIOKafkaProducer(

--- a/tests/test_subscription_state.py
+++ b/tests/test_subscription_state.py
@@ -11,7 +11,7 @@ pytestmark = pytest.mark.asyncio
 
 
 @pytest.fixture
-def subscription_state():
+async def subscription_state():
     return SubscriptionState()
 
 


### PR DESCRIPTION
### Changes

Return (temporary?) back an ability to instantiate `AIOKafkaConsumer` and `AIOKafkaProducer` without running loop by passing it explicitly. Fixes #689

<!-- Please give a short brief about these changes. -->

### Checklist

- [ ] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
