### PR TITLE
fix AIOKafkaProducer contextmanager

### DIFF
--- a/aiokafka/producer/producer.py
+++ b/aiokafka/producer/producer.py
@@ -557,6 +557,7 @@ class AIOKafkaProducer(object):
 
     async def __aenter__(self):
         await self.start()
+        return self
 
     async def __aexit__(self, exc_type, exc, tb):
         await self.stop()


### PR DESCRIPTION
### Changes

`AIOKafkaProducer` currently doesn't work as a context manager:

```python
async with AIOKafkaProducer(loop=asyncio.get_event_loop(), **kafka_params()) as producer:
        await producer.send_and_wait(KAFKA_TOPIC, b'message data')
```

It fails with `AttributeError: 'NoneType' object has no attribute 'send_and_wait'`.

<!-- Please give a short brief about these changes. -->

### Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
