### PR TITLE
Make sure generation and member id are correct after joining group

### DIFF
--- a/CHANGES/727.bugfix
+++ b/CHANGES/727.bugfix
@@ -1,0 +1,1 @@
+Make sure generation and member id are correct after (re)joining group.

--- a/aiokafka/__init__.py
+++ b/aiokafka/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.7.0'  # noqa
+__version__ = '0.7.1.dev0'  # noqa
 
 from .abc import ConsumerRebalanceListener
 from .client import AIOKafkaClient

--- a/aiokafka/__init__.py
+++ b/aiokafka/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.7.1.dev0'  # noqa
+__version__ = '0.7.1'  # noqa
 
 from .abc import ConsumerRebalanceListener
 from .client import AIOKafkaClient

--- a/aiokafka/consumer/group_coordinator.py
+++ b/aiokafka/consumer/group_coordinator.py
@@ -1371,7 +1371,7 @@ class CoordinatorGroupRebalance:
         if error_type is Errors.NoError:
             log.info("Successfully synced group %s with generation %s",
                      self.group_id, self._coordinator.generation)
-            # try making sure to get the right member_id/generation in case they changed
+            # make sure the right member_id/generation is set in case they changed
             # while the rejoin was taking place
             self._coordinator.generation = req_generation
             self._coordinator.member_id = req_member_id

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -13,6 +13,7 @@ from kafka.protocol.metadata import (
     MetadataResponse_v0 as MetadataResponse)
 from kafka.protocol.fetch import FetchRequest_v0
 
+from aiokafka import __version__
 from aiokafka.client import AIOKafkaClient, ConnectionGroup, CoordinationType
 from aiokafka.conn import AIOKafkaConnection, CloseReason
 from aiokafka.util import create_task, get_running_loop
@@ -35,7 +36,7 @@ class TestKafkaClientIntegration(KafkaIntegrationTestCase):
         client = AIOKafkaClient(bootstrap_servers=[
             '127.0.0.1:9092', '127.0.0.2:9092', '127.0.0.3:9092'])
         self.assertEqual(
-            '<AIOKafkaClient client_id=aiokafka-0.7.0>',
+            '<AIOKafkaClient client_id=aiokafka-{}>'.format(__version__),
             client.__repr__())
         self.assertEqual(
             sorted([('127.0.0.1', 9092, socket.AF_INET),


### PR DESCRIPTION
### Changes

Fixes #727

The purpose of this PR is to fix an issue where generation and member id get reset while a join was happening. This causes consumers to get into a state of never ending rebalancing. The issue is described here as well: https://github.com/aio-libs/aiokafka/issues/727

### Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [-] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
