### PR TITLE
Make sure generation and member id are correct after joining group

### DIFF
--- a/CHANGES/727.bugfix
+++ b/CHANGES/727.bugfix
@@ -1,0 +1,1 @@
+Make sure generation and member id are correct after (re)joining group.

--- a/aiokafka/__init__.py
+++ b/aiokafka/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.7.0'  # noqa
+__version__ = '0.7.1.dev0'  # noqa
 
 from .abc import ConsumerRebalanceListener
 from .client import AIOKafkaClient

--- a/aiokafka/consumer/group_coordinator.py
+++ b/aiokafka/consumer/group_coordinator.py
@@ -1371,7 +1371,7 @@ class CoordinatorGroupRebalance:
         if error_type is Errors.NoError:
             log.info("Successfully synced group %s with generation %s",
                      self.group_id, self._coordinator.generation)
-            # try making sure to get the right member_id/generation in case they changed
+            # make sure the right member_id/generation is set in case they changed
             # while the rejoin was taking place
             self._coordinator.generation = req_generation
             self._coordinator.member_id = req_member_id


### PR DESCRIPTION
### Changes

Fixes #727

The purpose of this PR is to fix an issue where generation and member id get reset while a join was happening. This causes consumers to get into a state of never ending rebalancing. The issue is described here as well: https://github.com/aio-libs/aiokafka/issues/727

### Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [-] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
