### PR TITLE
Fix KeyError on solitary abort marker.

### DIFF
--- a/aiokafka/consumer/fetcher.py
+++ b/aiokafka/consumer/fetcher.py
@@ -220,7 +220,10 @@ class PartitionRecords:
 
                 if next_batch.is_control_batch:
                     if self._contains_abort_marker(next_batch):
-                        self._aborted_producers.remove(next_batch.producer_id)
+                        # Using `discard` instead of `remove`, because Kafka
+                        # may return an abort marker for an otherwise empty
+                        # topic-partition.
+                        self._aborted_producers.discard(next_batch.producer_id)
 
                 if next_batch.is_transactional and \
                         next_batch.producer_id in self._aborted_producers:

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -5,7 +5,9 @@ from unittest import mock
 
 from kafka.protocol.offset import OffsetResponse
 from aiokafka.record.legacy_records import LegacyRecordBatchBuilder
-from aiokafka.record.default_records import DefaultRecordBatchBuilder
+from aiokafka.record.default_records import (
+    # NB: test_solitary_abort_marker relies on implementation details
+    _DefaultRecordBatchBuilderPy as DefaultRecordBatchBuilder)
 from aiokafka.record.memory_records import MemoryRecords
 
 from aiokafka.protocol.fetch import (


### PR DESCRIPTION
<!-- Thank you for your contribution! 
Feel free to change the template if you feel confused.
-->
### Changes

Fixes #781 

<!-- Please give a short brief about these changes. -->

### Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
