### PR TITLE
Fix Appveyor builds, simplify Windows builds

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,21 +1,20 @@
 environment:
   PYTHONASYNCIODEBUG: "1"
-  KAFKA_VERSION: "0.10.2.1"
-  SCALA_VERSION: "2.11"
+  KAFKA_VERSION: "2.8.1"
+  SCALA_VERSION: "2.13"
   matrix:
-    - PYTHON: "C:\\Python36"
-      SNAPPY_WHEEL: "tools\\python_snappy-0.5.4-cp36-cp36m-win32.whl"
-    - PYTHON: "C:\\Python36-x64"
-      SNAPPY_WHEEL: "tools\\python_snappy-0.5.4-cp36-cp36m-win_amd64.whl"
+    - PYTHON: "C:\\Python39"
+    - PYTHON: "C:\\Python39-x64"
+    - PYTHON: "C:\\Python38"
+    - PYTHON: "C:\\Python38-x64"
     - PYTHON: "C:\\Python37"
-      SNAPPY_WHEEL: "tools\\python_snappy-0.5.4-cp37-cp37m-win32.whl"
     - PYTHON: "C:\\Python37-x64"
-      SNAPPY_WHEEL: "tools\\python_snappy-0.5.4-cp37-cp37m-win_amd64.whl"
+    - PYTHON: "C:\\Python36"
+    - PYTHON: "C:\\Python36-x64"
 
-image: Visual Studio 2017
+image: Visual Studio 2022
 
 install:
-- "%PYTHON%\\python.exe -m pip install %SNAPPY_WHEEL%"
 - "%PYTHON%\\python.exe -m pip install -r requirements-win-test.txt"
 - "%PYTHON%\\python.exe setup.py develop"
 
@@ -23,9 +22,9 @@ build: off
 
 test_script:
 - "%PYTHON%\\python.exe -c \"import sys; print(sys.version)\""
-- "%PYTHON%\\python.exe -m pytest -sv --no-print-logs --cov=aiokafka --cov-report=xml --junit-xml=results.xml --docker-image=aiolibs/kafka:%SCALA_VERSION%_%KAFKA_VERSION% tests"
+- "%PYTHON%\\python.exe -m pytest -sv --cov=aiokafka --cov-report=xml --junit-xml=results.xml --docker-image=aiolibs/kafka:%SCALA_VERSION%_%KAFKA_VERSION% tests"
 - "set AIOKAFKA_NO_EXTENSIONS=x"
-- "%PYTHON%\\python.exe -m pytest -sv --no-print-logs --cov=aiokafka --cov-report=xml:coverage-no-extension.xml --junit-xml=results-no-extension.xml --docker-image=aiolibs/kafka:%SCALA_VERSION%_%KAFKA_VERSION% tests"
+- "%PYTHON%\\python.exe -m pytest -sv --cov=aiokafka --cov-report=xml:coverage-no-extension.xml --junit-xml=results-no-extension.xml --docker-image=aiolibs/kafka:%SCALA_VERSION%_%KAFKA_VERSION% tests"
 
 on_finish:
 - ps: >-

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,15 +74,6 @@ jobs:
     strategy:
       matrix:
         python: [3.6, 3.7, 3.8, 3.9]
-        include:
-          - python: 3.6
-            snappy_whl: tools/python_snappy-0.5.4-cp36-cp36m-win_amd64.whl
-          - python: 3.7
-            snappy_whl: tools/python_snappy-0.5.4-cp37-cp37m-win_amd64.whl
-          - python: 3.8
-            snappy_whl: tools/python_snappy-0.5.4-cp38-cp38-win_amd64.whl
-          - python: 3.9
-            snappy_whl: tools/python_snappy-0.5.4-cp39-cp39-win_amd64.whl
 
     steps:
     - uses: actions/checkout@v2
@@ -111,7 +102,6 @@ jobs:
     - name: Install python dependencies
       run: |
         pip install --upgrade pip setuptools wheel
-        pip install ${{ matrix.snappy_whl }}
         pip install -r requirements-win-test.txt
         pip install -vv -Ue .  # We set -vv to see compiler exceptions/warnings
 


### PR DESCRIPTION
### Changes

Appveyor builds should now be passing: https://ci.appveyor.com/project/multani/aiokafka/history

* Appveyor builds don't work since several months due to the unsupported `--no-print-logs` pytest option.

* Appveyor builds were using outdated/old Kakfa & Python versions

* Windows builds were pre-installing the python-snappy wheel ... [for another version to be installed from `requirements-win-test.txt`](https://github.com/aio-libs/aiokafka/blob/654fcbf6ac9d4ec8edc6c26bd1500383113fc14d/requirements-win-test.txt#L12) just after.


About Appveyor: since [GitHub Actions is already building on Windows](https://github.com/aio-libs/aiokafka/blob/654fcbf6ac9d4ec8edc6c26bd1500383113fc14d/.github/workflows/tests.yml#L70-L146), Appveyor could be simply completely removed.

In this case, it would be cool to also quickly have a look in the project settings on GitHub to remove references to Appveyor (hooks, etc.)

### Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`