### PR TITLE
docs: remove incorrect await

### DIFF
--- a/docs/consumer.rst
+++ b/docs/consumer.rst
@@ -144,7 +144,7 @@ bulk. The algorithm can be enhanced by taking advantage of:
 
 * :meth:`await consumer.getmany() <aiokafka.AIOKafkaConsumer.getmany>` to
   avoid multiple calls to get a batch of messages.
-* :meth:`await consumer.highwater(partition)
+* :meth:`consumer.highwater(partition)
   <aiokafka.AIOKafkaConsumer.highwater>` to understand if we have more
   unconsumed messages or this one is the last one in the partition.
 


### PR DESCRIPTION
<!-- Thank you for your contribution! 
Feel free to change the template if you feel confused.
-->
### Changes

`AIOKafkaConsumer.highwater` is not an async method:

https://github.com/aio-libs/aiokafka/blob/6360747c4305d1d096d5e55037d60a12c4c9ab15/aiokafka/consumer/consumer.py#L668

Remove an `await` before a call to `consumer.highwater` in an example in the docs.