### PR TITLE
Update docker python lib to 6.1.2

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -6,7 +6,7 @@ isort[colors]==5.10.0
 pytest==7.1.2
 pytest-cov==3.0.0
 pytest-asyncio==0.18.3
-docker==6.0.1
+docker==6.1.2
 chardet==4.0.0  # Until fixed requests is released
 lz4==3.1.3
 xxhash==2.0.2


### PR DESCRIPTION
Fixes "TypeError: request() got an unexpected keyword argument 'chunked'" error