### PR TITLE
Fix package publishing build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
           python -m pip install --upgrade pip setuptools
           python -m pip install -r requirements-cython.txt
           # Make sure we install to have all c files to be shiped with bundle
-          python -m pip install -vv -Ue .  # We set -vv to see compiler exceptions/warnings
+          python -m pip install -vv -U .  # We set -vv to see compiler exceptions/warnings
       - name: Build source package
         run: python setup.py sdist
       - name: Upload source package


### PR DESCRIPTION
For some reason there was the `-e` (editable) flag passed when doing `pip install` in github workflows.

It caused a build error like this: https://github.com/aio-libs/aiokafka/actions/runs/5129292520/jobs/9226766667.

Probably the base CI distro upgraded, or python is bumped to 3.8, that's why it eventually broke.

Removing the flag solved the issue. At least, I was able to reproduce the bug locally using act, and after removing the flag it worked.