### PR TITLE
Update consumer.rst documentation for correct ordering of consumer su…

### DIFF
--- a/docs/consumer.rst
+++ b/docs/consumer.rst
@@ -399,8 +399,8 @@ new topic matching a *subscribed regex* is created. For example::
         bootstrap_servers='localhost:9092',
         metadata_max_age_ms=30000,  # This controls the polling interval
     )
-    await consumer.start()
     consumer.subscribe(pattern="^MyGreatTopic-.*$")
+    await consumer.start()
 
     async for msg in consumer:  # Will detect metadata changes
         print("Consumed msg %s %s %s" % (msg.topic, msg.partition, msg.value))


### PR DESCRIPTION
…bscription by pattern

<!-- Thank you for your contribution! 
Feel free to change the template if you feel confused.
-->
### Changes

Fixes documentation for consumer subscription by regex pattern.

<!-- Please give a short brief about these changes. -->


Whenever I invoked, as the documentation specifies:
```python
await consumer.start()
consumer.subscribe(pattern="^MyGreatTopic-.*$")
```

I always get errors indicating the following:
```python
Traceback (most recent call last):
  File "/home/REDACTED/PycharmProjects/REDACTED", line REDACTED, in REDACTED
    await consumer.start()
  File "/home/REDACTED/PycharmProjects/REDACTED", line REDACTED, in REDACTED
    await consumer.seek_to_end()
  File "/home/REDACTED/PycharmProjects/REDACTED/venv/lib/python3.8/site-packages/aiokafka/consumer/consumer.py", line 824, in seek_to_end
    assert partitions, 'No partitions are currently assigned'
AssertionError: No partitions are currently assigned
```

When I run the following, my application works fine:
```python
consumer.subscribe(pattern="^MyGreatTopic-.*$")
await consumer.start()
```

Or is there something I'm misunderstanding in the documentation?

### Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
