### PR TITLE
912.bugfix allow checksum to be `None` on `ConsumerRecord`

### DIFF
--- a/aiokafka/structs.py
+++ b/aiokafka/structs.py
@@ -81,7 +81,7 @@ class ConsumerRecord(Generic[KT, VT]):
     value: Optional[VT]
     "The value"
 
-    checksum: int
+    checksum: Optional[int]
     "Deprecated"
 
     serialized_key_size: int


### PR DESCRIPTION
<!-- Thank you for your contribution! 
Feel free to change the template if you feel confused.
-->
### Changes

When using serialization frameworks like pydantic, I can not attach a consumer record because checksum can be None.  Since it is marked as deprecated, it seems reasonable to mark it as optional here.

### Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
