### PR TITLE
Modify cluster metadata

### DIFF
--- a/aiokafka/cluster.py
+++ b/aiokafka/cluster.py
@@ -193,7 +193,7 @@ class ClusterMetadata:
             set: {topic (str), ...}
         """
         if exclude_internal_topics:
-            return self._topics - self.internal_topics
+            return self.external_topics 
         else:
             return self._topics
 
@@ -286,6 +286,7 @@ class ClusterMetadata:
             self._broker_partitions = _new_broker_partitions
             self.unauthorized_topics = _new_unauthorized_topics
             self.internal_topics = _new_internal_topics
+            self.external_topics = self._topics - self.internal_topics
             f = None
             if self._future:
                 f = self._future

--- a/aiokafka/cluster.py
+++ b/aiokafka/cluster.py
@@ -43,6 +43,7 @@ class ClusterMetadata:
     def __init__(self, **configs):
         self._brokers = {}  # node_id -> BrokerMetadata
         self._partitions = {}  # topic -> partition -> PartitionMetadata
+        self._topics = set()
         # node_id -> {TopicPartition...}
         self._broker_partitions = collections.defaultdict(set)
         self._groups = {}  # group_name -> node_id
@@ -191,11 +192,10 @@ class ClusterMetadata:
         Returns:
             set: {topic (str), ...}
         """
-        topics = set(self._partitions.keys())
         if exclude_internal_topics:
-            return topics - self.internal_topics
+            return self._topics - self.internal_topics
         else:
-            return topics
+            return self._topics
 
     def failed_update(self, exception):
         """Update cluster state given a failed MetadataRequest."""
@@ -282,6 +282,7 @@ class ClusterMetadata:
             self._brokers = _new_brokers
             self.controller = _new_controller
             self._partitions = _new_partitions
+            self._topics = set(self._partitions.keys())
             self._broker_partitions = _new_broker_partitions
             self.unauthorized_topics = _new_unauthorized_topics
             self.internal_topics = _new_internal_topics

--- a/aiokafka/cluster.py
+++ b/aiokafka/cluster.py
@@ -56,6 +56,7 @@ class ClusterMetadata:
         self.need_all_topic_metadata = False
         self.unauthorized_topics = set()
         self.internal_topics = set()
+        self.external_topics = set()
         self.controller = None
 
         self.config = copy.copy(self.DEFAULT_CONFIG)
@@ -193,7 +194,7 @@ class ClusterMetadata:
             set: {topic (str), ...}
         """
         if exclude_internal_topics:
-            return self.external_topics 
+            return self.external_topics
         else:
             return self._topics
 


### PR DESCRIPTION
<!-- Thank you for your contribution! 
Feel free to change the template if you feel confused.
-->
### Changes

Fixes #943 

<!-- Please give a short brief about these changes. -->

### Peformance
I reported #943 and re-measured the performance in the same environment after this improvement. Here is the summary of both before and after.
- before
```
$ ./run-benchmarks.sh
Running Tests for Kafka-Python
Starting benchmark for Kafka-Python producer.
Kafka-Python producer Results:
Number of Runs: 5, Number of messages: 100000, Message Size: 100 bytes.
Average Time for 100000 messages: 7.028003358840943 seconds.
Messages / sec: 14228.792289093612
MB / sec : 1.3569633759587871
===================
Running Tests for AIOKafka
/root/workspace/news/kafka-client-benchmarks/aiokafka-benchmark.py:40: DeprecationWarning: The loop argument is deprecated since 0.7.1, and scheduled for removal in 0.9.0
  producer = AIOKafkaProducer(loop=loop, **producer_config)
Starting benchmark for AIOKafka Producer.
AIOKafka Producer Results:                   
Number of Runs: 5, Number of messages: 100000, Message Size: 100 bytes.
Average Time for 100000 messages: 54.26867785453796 seconds.
Messages / sec: 1842.6835506853604
MB / sec : 0.17573199755529026
===================
```
- after
```
$ ./run-benchmarks.sh
Running Tests for Kafka-Python
Starting benchmark for Kafka-Python producer.
Kafka-Python producer Results:
Number of Runs: 5, Number of messages: 100000, Message Size: 100 bytes.
Average Time for 100000 messages: 5.166848373413086 seconds.
Messages / sec: 19354.15804237015
MB / sec : 1.8457563440675877
===================
Running Tests for AIOKafka
/root/workspace/news/kafka-client-benchmarks/aiokafka-benchmark.py:40: DeprecationWarning: The loop argument is deprecated since 0.7.1, and scheduled for removal in 0.9.0
  producer = AIOKafkaProducer(loop=loop, **producer_config)
kafka parition size: 6056
Starting benchmark for AIOKafka Producer.
AIOKafka Producer Results:
Number of Runs: 5, Number of messages: 100000, Message Size: 100 bytes.
Average Time for 100000 messages: 3.341134214401245 seconds.
Messages / sec: 29929.95599188185
MB / sec : 2.854343032062707
===================
```

As for aiokafka producer, the performance is improved significantly.
Messages / sec:  1842 -> 29929
MB / sec : 0.1757 -> 2.854

### Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist (I do not modify any interface)
- [x] Documentation reflects the changes (same as above)
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
