### PR TITLE
Fix formatting of pip install commmand in docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -89,7 +89,7 @@ Read more in :ref:`Producer client <producer-usage>` section.
 Installation
 ------------
 
-.. code::
+.. code:: bash
 
     pip install aiokafka
 
@@ -100,6 +100,8 @@ Optional LZ4 install
 ++++++++++++++++++++
 
 To enable LZ4 compression/decompression, install **aiokafka** with :code:`lz4` extra option:
+
+.. code:: bash
 
     pip install 'aiokafka[lz4]'
 


### PR DESCRIPTION
### Changes

Fixes documentation formatting of pip install commands.

### Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
