### PR TITLE
Implement KIP-204 : DeleteRecords API

### DIFF
--- a/CHANGES/969.feature
+++ b/CHANGES/969.feature
@@ -1,0 +1,1 @@
+Implement DeleteRecords API (KIP-204) (pr #969 by @vmaurin)

--- a/aiokafka/admin/__init__.py
+++ b/aiokafka/admin/__init__.py
@@ -1,5 +1,6 @@
 from .client import AIOKafkaAdminClient
 from .new_partitions import NewPartitions
 from .new_topic import NewTopic
+from .records_to_delete import RecordsToDelete
 
-__all__ = ["AIOKafkaAdminClient", "NewPartitions", "NewTopic"]
+__all__ = ["AIOKafkaAdminClient", "NewPartitions", "NewTopic", "RecordsToDelete"]

--- a/aiokafka/admin/client.py
+++ b/aiokafka/admin/client.py
@@ -626,12 +626,7 @@ class AIOKafkaAdminClient:
         """
         version = self._matching_api_version(DeleteRecordsRequest)
 
-        if self._version_info[MetadataRequest[0].API_KEY] < (0, 10):
-            metadata_request = MetadataRequest[0]([])
-        else:
-            metadata_request = MetadataRequest[1](None)
-
-        metadata = await self._send_request(metadata_request)
+        metadata = await self._get_cluster_metadata()
 
         self._client.cluster.update_metadata(metadata)
 

--- a/aiokafka/admin/client.py
+++ b/aiokafka/admin/client.py
@@ -646,8 +646,7 @@ class AIOKafkaAdminClient:
         for leader, delete_request in requests.items():
             request = req_cls(
                 self._convert_records_to_delete(delete_request),
-                timeout_ms or self._request_timeout_ms,
-                {},
+                timeout_ms or self._request_timeout_ms
             )
             response = await self._client.send(leader, request)
             for topic, partitions in response.topics:
@@ -665,8 +664,7 @@ class AIOKafkaAdminClient:
         return [
             (
                 topic,
-                [(partition, rec.before_offset, {}) for partition, rec in records],
-                {},
+                [(partition, rec.before_offset) for partition, rec in records]
             )
             for topic, records in records_to_delete.items()
         ]

--- a/aiokafka/admin/client.py
+++ b/aiokafka/admin/client.py
@@ -646,7 +646,7 @@ class AIOKafkaAdminClient:
         for leader, delete_request in requests.items():
             request = req_cls(
                 self._convert_records_to_delete(delete_request),
-                timeout_ms or self._request_timeout_ms
+                timeout_ms or self._request_timeout_ms,
             )
             response = await self._client.send(leader, request)
             for topic, partitions in response.topics:
@@ -662,9 +662,6 @@ class AIOKafkaAdminClient:
         records_to_delete: Dict[str, List[Tuple[int, RecordsToDelete]]],
     ):
         return [
-            (
-                topic,
-                [(partition, rec.before_offset) for partition, rec in records]
-            )
+            (topic, [(partition, rec.before_offset) for partition, rec in records])
             for topic, records in records_to_delete.items()
         ]

--- a/aiokafka/admin/client.py
+++ b/aiokafka/admin/client.py
@@ -6,12 +6,18 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from aiokafka import __version__
 from aiokafka.client import AIOKafkaClient
-from aiokafka.errors import IncompatibleBrokerVersion, for_code
+from aiokafka.errors import (
+    IncompatibleBrokerVersion,
+    LeaderNotAvailableError,
+    NotLeaderForPartitionError,
+    for_code,
+)
 from aiokafka.protocol.admin import (
     AlterConfigsRequest,
     ApiVersionRequest_v0,
     CreatePartitionsRequest,
     CreateTopicsRequest,
+    DeleteRecordsRequest,
     DeleteTopicsRequest,
     DescribeConfigsRequest,
     DescribeGroupsRequest,
@@ -24,6 +30,7 @@ from aiokafka.structs import OffsetAndMetadata, TopicPartition
 
 from .config_resource import ConfigResource, ConfigResourceType
 from .new_topic import NewTopic
+from .records_to_delete import RecordsToDelete
 
 log = logging.getLogger(__name__)
 
@@ -605,3 +612,66 @@ class AIOKafkaAdminClient:
                 offset_plus_meta = OffsetAndMetadata(offset, metadata)
                 response_dict[tp] = offset_plus_meta
         return response_dict
+
+    async def delete_records(
+        self,
+        records_to_delete: Dict[TopicPartition, RecordsToDelete],
+        timeout_ms: Optional[int] = None,
+    ) -> Dict[TopicPartition, int]:
+        """Delete records from partitions.
+
+        :param records_to_delete: A map of RecordsToDelete for each TopicPartition
+        :param timeout_ms: Milliseconds to wait for the deletion to complete.
+        :return: Appropriate version of DeleteRecordsResponse class.
+        """
+        version = self._matching_api_version(DeleteRecordsRequest)
+
+        if self._version_info[MetadataRequest[0].API_KEY] < (0, 10):
+            metadata_request = MetadataRequest[0]([])
+        else:
+            metadata_request = MetadataRequest[1](None)
+
+        metadata = await self._send_request(metadata_request)
+
+        self._client.cluster.update_metadata(metadata)
+
+        requests = defaultdict(lambda: defaultdict(list))
+        responses = {}
+
+        for tp, records in records_to_delete.items():
+            leader = self._client.cluster.leader_for_partition(tp)
+            if leader is None:
+                raise NotLeaderForPartitionError()
+            elif leader == -1:
+                raise LeaderNotAvailableError()
+            requests[leader][tp.topic].append((tp.partition, records))
+
+        req_cls = DeleteRecordsRequest[version]
+
+        for leader, delete_request in requests.items():
+            request = req_cls(
+                self._convert_records_to_delete(delete_request),
+                timeout_ms or self._request_timeout_ms,
+                {},
+            )
+            response = await self._client.send(leader, request)
+            for topic, partitions in response.topics:
+                for partition_index, low_watermark, error_code in partitions:
+                    if error_code:
+                        err = for_code(error_code)
+                        raise err
+                    responses[TopicPartition(topic, partition_index)] = low_watermark
+        return responses
+
+    @staticmethod
+    def _convert_records_to_delete(
+        records_to_delete: Dict[str, List[Tuple[int, RecordsToDelete]]],
+    ):
+        return [
+            (
+                topic,
+                [(partition, rec.before_offset, {}) for partition, rec in records],
+                {},
+            )
+            for topic, records in records_to_delete.items()
+        ]

--- a/aiokafka/admin/records_to_delete.py
+++ b/aiokafka/admin/records_to_delete.py
@@ -1,0 +1,12 @@
+class RecordsToDelete:
+    """A class for deleting records on existing topics.
+    Arguments:
+        before_offset (int):
+            delete all the records before the given offset
+    """
+
+    def __init__(
+        self,
+        before_offset,
+    ):
+        self.before_offset = before_offset

--- a/aiokafka/cluster.py
+++ b/aiokafka/cluster.py
@@ -254,6 +254,7 @@ class ClusterMetadata:
             error_type = Errors.for_code(error_code)
             if error_type is Errors.NoError:
                 _new_partitions[topic] = {}
+                # Starting with v5, MetadataResponse contains more than 5 fields
                 for p_error, partition, leader, replicas, isr, *_ in partitions:
                     _new_partitions[topic][partition] = PartitionMetadata(
                         topic=topic,

--- a/aiokafka/cluster.py
+++ b/aiokafka/cluster.py
@@ -254,7 +254,7 @@ class ClusterMetadata:
             error_type = Errors.for_code(error_code)
             if error_type is Errors.NoError:
                 _new_partitions[topic] = {}
-                for p_error, partition, leader, replicas, isr in partitions:
+                for p_error, partition, leader, replicas, isr, *_ in partitions:
                     _new_partitions[topic][partition] = PartitionMetadata(
                         topic=topic,
                         partition=partition,

--- a/aiokafka/protocol/admin.py
+++ b/aiokafka/protocol/admin.py
@@ -1389,11 +1389,13 @@ class DeleteRecordsRequest_v2(Request):
 DeleteRecordsRequest = [
     DeleteRecordsRequest_v0,
     DeleteRecordsRequest_v1,
-    DeleteRecordsRequest_v2,
+    # FIXME: We have some problems with `TaggedFields`
+    # DeleteRecordsRequest_v2,
 ]
 
 DeleteRecordsResponse = [
     DeleteRecordsResponse_v0,
     DeleteRecordsResponse_v1,
-    DeleteRecordsResponse_v2,
+    # FIXME: We have some problems with `TaggedFields`
+    # DeleteRecordsResponse_v2,
 ]

--- a/aiokafka/protocol/admin.py
+++ b/aiokafka/protocol/admin.py
@@ -1276,3 +1276,124 @@ class ListPartitionReassignmentsRequest_v0(Request):
 ListPartitionReassignmentsRequest = [ListPartitionReassignmentsRequest_v0]
 
 ListPartitionReassignmentsResponse = [ListPartitionReassignmentsResponse_v0]
+
+
+class DeleteRecordsResponse_v0(Response):
+    API_KEY = 21
+    API_VERSION = 0
+    SCHEMA = Schema(
+        ("throttle_time_ms", Int32),
+        (
+            "topics",
+            Array(
+                ("name", String("utf-8")),
+                (
+                    "partitions",
+                    Array(
+                        ("partition_index", Int32),
+                        ("low_watermark", Int64),
+                        ("error_code", Int16),
+                    ),
+                ),
+            ),
+        ),
+    )
+
+
+class DeleteRecordsResponse_v1(Response):
+    API_KEY = 21
+    API_VERSION = 1
+    SCHEMA = DeleteRecordsResponse_v0.SCHEMA
+
+
+class DeleteRecordsResponse_v2(Response):
+    API_KEY = 21
+    API_VERSION = 2
+    SCHEMA = Schema(
+        ("throttle_time_ms", Int32),
+        (
+            "topics",
+            CompactArray(
+                ("name", CompactString("utf-8")),
+                (
+                    "partitions",
+                    CompactArray(
+                        ("partition_index", Int32),
+                        ("low_watermark", Int64),
+                        ("error_code", Int16),
+                        ("tags", TaggedFields),
+                    ),
+                ),
+                ("tags", TaggedFields),
+            ),
+        ),
+        ("tags", TaggedFields),
+    )
+
+
+class DeleteRecordsRequest_v0(Request):
+    API_KEY = 21
+    API_VERSION = 0
+    RESPONSE_TYPE = DeleteRecordsResponse_v0
+    SCHEMA = Schema(
+        (
+            "topics",
+            Array(
+                ("name", String("utf-8")),
+                (
+                    "partitions",
+                    Array(
+                        ("partition_index", Int32),
+                        ("offset", Int64),
+                    ),
+                ),
+            ),
+        ),
+        ("timeout_ms", Int32),
+    )
+
+
+class DeleteRecordsRequest_v1(Request):
+    API_KEY = 21
+    API_VERSION = 1
+    RESPONSE_TYPE = DeleteRecordsResponse_v1
+    SCHEMA = DeleteRecordsRequest_v0.SCHEMA
+
+
+class DeleteRecordsRequest_v2(Request):
+    API_KEY = 21
+    API_VERSION = 2
+    FLEXIBLE_VERSION = True
+    RESPONSE_TYPE = DeleteRecordsResponse_v2
+    SCHEMA = Schema(
+        (
+            "topics",
+            CompactArray(
+                ("name", CompactString("utf-8")),
+                (
+                    "partitions",
+                    CompactArray(
+                        ("partition_index", Int32),
+                        ("offset", Int64),
+                        ("tags", TaggedFields),
+                    ),
+                ),
+                ("tags", TaggedFields),
+            ),
+        ),
+        ("timeout_ms", Int32),
+        ("tags", TaggedFields),
+    )
+
+
+DeleteRecordsRequest = [
+    DeleteRecordsRequest_v0,
+    DeleteRecordsRequest_v1,
+    DeleteRecordsRequest_v2,
+]
+
+DeleteRecordsResponse = [
+    DeleteRecordsResponse_v0,
+    DeleteRecordsResponse_v1,
+    DeleteRecordsResponse_v2,
+]

--- a/aiokafka/protocol/types.py
+++ b/aiokafka/protocol/types.py
@@ -313,6 +313,7 @@ class CompactString(String):
         return UnsignedVarInt32.encode(len(value) + 1) + value
 
 
+# FIXME: TaggedFields doesn't seem to work properly so they should be avoided
 class TaggedFields(AbstractType):
     @classmethod
     def decode(cls, data):


### PR DESCRIPTION
When doing stream processing, it is convinient to use "transient" topic :
* retention time is infinite
* records get deleted when consumed

The java kafka streams client is using the deleteRecords of the admin client to perform this operation. It is lacking in aiokafka

The KIP reference https://cwiki.apache.org/confluence/display/KAFKA/KIP-204+%3A+Adding+records+deletion+operation+to+the+new+Admin+Client+API

refs #967

<!-- Thank you for your contribution! 
Feel free to change the template if you feel confused.
-->
### Changes

Fixes #967 

<!-- Please give a short brief about these changes. -->

### Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
