### PR TITLE
Fix type annotation for `AIOKafkaAdminClient.create_partitions`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Unreleased
 Bugfixes:
 
 * Fix serialization for batch (issue #886, pr #887 by @ydjin0602)
+* Fix type annotation for `AIOKafkaAdminClient.create_partitions` (pr #978 by @alm0ra)
 
 
 0.10.0 (2023-12-15)

--- a/aiokafka/admin/client.py
+++ b/aiokafka/admin/client.py
@@ -27,6 +27,7 @@ from aiokafka.protocol.api import Request, Response
 from aiokafka.protocol.commit import GroupCoordinatorRequest, OffsetFetchRequest
 from aiokafka.protocol.metadata import MetadataRequest
 from aiokafka.structs import OffsetAndMetadata, TopicPartition
+from aiokafka.admin import NewPartitions
 
 from .config_resource import ConfigResource, ConfigResourceType
 from .new_topic import NewTopic
@@ -395,7 +396,7 @@ class AIOKafkaAdminClient:
         return broker_resources, topic_resources
 
     @staticmethod
-    def _convert_topic_partitions(topic_partitions: Dict[str, TopicPartition]):
+    def _convert_topic_partitions(topic_partitions: Dict[str, NewPartitions]):
         return [
             (topic_name, (new_part.total_count, new_part.new_assignments))
             for topic_name, new_part in topic_partitions.items()
@@ -403,7 +404,7 @@ class AIOKafkaAdminClient:
 
     async def create_partitions(
         self,
-        topic_partitions: Dict[str, TopicPartition],
+        topic_partitions: Dict[str, NewPartitions],
         timeout_ms: Optional[int] = None,
         validate_only: bool = False,
     ) -> Response:

--- a/aiokafka/admin/client.py
+++ b/aiokafka/admin/client.py
@@ -27,7 +27,7 @@ from aiokafka.protocol.api import Request, Response
 from aiokafka.protocol.commit import GroupCoordinatorRequest, OffsetFetchRequest
 from aiokafka.protocol.metadata import MetadataRequest
 from aiokafka.structs import OffsetAndMetadata, TopicPartition
-from aiokafka.admin import NewPartitions
+from .new_partitions import NewPartitions
 
 from .config_resource import ConfigResource, ConfigResourceType
 from .new_topic import NewTopic

--- a/aiokafka/admin/client.py
+++ b/aiokafka/admin/client.py
@@ -27,9 +27,9 @@ from aiokafka.protocol.api import Request, Response
 from aiokafka.protocol.commit import GroupCoordinatorRequest, OffsetFetchRequest
 from aiokafka.protocol.metadata import MetadataRequest
 from aiokafka.structs import OffsetAndMetadata, TopicPartition
-from .new_partitions import NewPartitions
 
 from .config_resource import ConfigResource, ConfigResourceType
+from .new_partitions import NewPartitions
 from .new_topic import NewTopic
 from .records_to_delete import RecordsToDelete
 


### PR DESCRIPTION
Fixes #977 

### Changes

Fixes wrong typo in create_partitions() for the admin client

### Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
