### PR TITLE
Fix unintended cancellation of fetcher task

### DIFF
--- a/aiokafka/consumer/fetcher.py
+++ b/aiokafka/consumer/fetcher.py
@@ -512,10 +512,8 @@ class Fetcher:
                         # cancellation
                         if not task.done():
                             task.cancel()
-                        try:
+                        with contextlib.suppress(asyncio.CancelledError):
                             await task
-                        except asyncio.CancelledError:
-                            pass
                     self._pending_tasks.clear()
                     self._records.clear()
 

--- a/aiokafka/consumer/fetcher.py
+++ b/aiokafka/consumer/fetcher.py
@@ -512,7 +512,10 @@ class Fetcher:
                         # cancellation
                         if not task.done():
                             task.cancel()
-                        await task
+                        try:
+                            await task
+                        except asyncio.CancelledError:
+                            pass
                     self._pending_tasks.clear()
                     self._records.clear()
 


### PR DESCRIPTION
### Changes

Fixes #983

It's not entirely clear to me why the change from `asyncio.wait_for` to `util.wait_for` caused a behavior change here, but this code was always broken in the case where `task.cancel()` was called.

### Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
