### PR TITLE
change request metadata error to warning

### DIFF
--- a/aiokafka/client.py
+++ b/aiokafka/client.py
@@ -332,7 +332,7 @@ class AIOKafkaClient:
             try:
                 metadata = await conn.send(metadata_request)
             except (KafkaError, asyncio.TimeoutError) as err:
-                log.error(
+                log.warning(
                     "Unable to request metadata from node with id %s: %r", node_id, err
                 )
                 continue


### PR DESCRIPTION
### Changes

Make log of "Unable to request metadata from node" warning instead of error as it's handled. This is the same as in line 246 in the same file.
This change will allow to better monitor errors from this lib and distinguish them from warnings.


### Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
