### PR TITLE
Added delay to retry connection

### DIFF
--- a/aiokafka/client.py
+++ b/aiokafka/client.py
@@ -475,6 +475,7 @@ class AIOKafkaClient:
             if group == ConnectionGroup.DEFAULT:
                 # Connection failures imply that our metadata is stale, so
                 # let's refresh
+                await asyncio.sleep(self._retry_backoff)
                 self.force_metadata_update()
             return None
         else:


### PR DESCRIPTION
When a consumer connection breaks, aiokafka goes into a loop trying to reconnect every 1ms, generating a mountain of logs. This PR introduces a delay between connection attempts with the configured `retry_backoff_ms` parameter.

Addresses issues #496 and #830.