### PR TITLE
Remove duplicate error log during rebalance

### DIFF
--- a/aiokafka/consumer/group_coordinator.py
+++ b/aiokafka/consumer/group_coordinator.py
@@ -1133,14 +1133,6 @@ class GroupCoordinator(BaseCoordinator):
                         self.request_rejoin()
                     else:
                         self.reset_generation()
-                    # need to re-join group
-                    error = error_type(self.group_id)
-                    log.error(
-                        "OffsetCommit failed for group %s due to group"
-                        " error (%s), will rejoin",
-                        self.group_id,
-                        error,
-                    )
                     errored[tp] = error
 
                 else:


### PR DESCRIPTION
This log message is emitted twice.
