### PR TITLE
Return back mac x86_64 wheels

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,11 +37,11 @@ jobs:
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
-        
+
         # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         queries: +security-and-quality
 
-        
+
     # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
@@ -50,7 +50,7 @@ jobs:
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
 
-    #   If the Autobuild fails above, remove it and uncomment the following three lines. 
+    #   If the Autobuild fails above, remove it and uncomment the following three lines.
     #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
 
     # - run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,13 +35,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Available runner images:
-        # https://github.com/actions/runner-images#available-images
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        arch: [auto]
         include:
+          # Available runner images:
+          # https://github.com/actions/runner-images#available-images
+          - os: ubuntu-latest
+            arch: x86_64
           - os: ubuntu-latest
             arch: aarch64
+          - os: macos-13
+            arch: x86_64
+          - os: macos-latest
+            arch: arm64
+          - os: windows-latest
+            arch: amd64
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -116,6 +122,49 @@ jobs:
         shell: bash
 
   test-wheels-mac:
+    needs: [package-source, package-wheel]
+    runs-on: macos-13
+
+    strategy:
+      matrix:
+        python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        include:
+          - python: "3.8"
+            aiokafka_whl: dist/aiokafka-*-cp38-cp38-macosx_*_x86_64.whl
+          - python: "3.9"
+            aiokafka_whl: dist/aiokafka-*-cp39-cp39-macosx_*_x86_64.whl
+          - python: "3.10"
+            aiokafka_whl: dist/aiokafka-*-cp310-cp310-macosx_*_x86_64.whl
+          - python: "3.11"
+            aiokafka_whl: dist/aiokafka-*-cp311-cp311-macosx_*_x86_64.whl
+          - python: "3.12"
+            aiokafka_whl: dist/aiokafka-*-cp312-cp312-macosx_*_x86_64.whl
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download distributions
+        uses: actions/download-artifact@v2
+        with:
+          name: dist
+          path: dist/
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Install python dependencies
+        run: |
+          pip install --upgrade pip setuptools wheel
+          pip install -r requirements-ci.txt
+          pip install ${{ matrix.aiokafka_whl }}
+
+      - name: Run Unit Tests
+        run: |
+          # Remove source code to be sure we use wheel code
+          rm -rf aiokafka
+          make ci-test-unit
+
+  test-wheels-arm64-mac:
     needs: [package-source, package-wheel]
     runs-on: macos-latest
 
@@ -255,7 +304,12 @@ jobs:
   deploy:
 
     runs-on: ubuntu-latest
-    needs: [test-wheels-linux, test-wheels-aarch64-linux, test-wheels-mac, test-wheels-windows]
+    needs:
+      - test-wheels-linux
+      - test-wheels-aarch64-linux
+      - test-wheels-mac
+      - test-wheels-arm64-mac
+      - test-wheels-windows
 
     steps:
       - uses: actions/checkout@v2

--- a/aiokafka/producer/producer.py
+++ b/aiokafka/producer/producer.py
@@ -352,13 +352,13 @@ class AIOKafkaProducer:
         await self.client.bootstrap()
 
         if self._compression_type == "lz4":
-            assert (
-                self.client.api_version >= (0, 8, 2)  # fmt: skip
-            ), "LZ4 Requires >= Kafka 0.8.2 Brokers"
+            assert self.client.api_version >= (0, 8, 2), (
+                "LZ4 Requires >= Kafka 0.8.2 Brokers"
+            )  # fmt: skip
         elif self._compression_type == "zstd":
-            assert (
-                self.client.api_version >= (2, 1, 0)  # fmt: skip
-            ), "Zstd Requires >= Kafka 2.1.0 Brokers"
+            assert self.client.api_version >= (2, 1, 0), (
+                "Zstd Requires >= Kafka 2.1.0 Brokers"
+            )  # fmt: skip
 
         if self._txn_manager is not None and self.client.api_version < (0, 11):
             raise UnsupportedVersionError(
@@ -490,9 +490,9 @@ class AIOKafkaProducer:
             from being sent, but cancelling the :meth:`send` coroutine itself
             **will**.
         """
-        assert (
-            value is not None or self.client.api_version >= (0, 8, 1)  # fmt: skip
-        ), "Null messages require kafka >= 0.8.1"
+        assert value is not None or self.client.api_version >= (0, 8, 1), (
+            "Null messages require kafka >= 0.8.1"
+        )  # fmt: skip
         assert not (value is None and key is None), "Need at least one: key or value"
 
         # first make sure the metadata for the topic is available


### PR DESCRIPTION
<!-- Thank you for your contribution! 
Feel free to change the template if you feel confused.
-->
### Changes

In the latest release x86_64 wheels for mac were replaced with arm64. This PR returns them back to publish pipeline. Tested in [this pipeline](https://github.com/ods/aiokafka/actions/runs/9920386395).

Thanks @webknjaz for the hint