### PR TITLE
Updated BrokerMetadata#nodeId type from `int` to `int | str`.

### DIFF
--- a/aiokafka/structs.py
+++ b/aiokafka/structs.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Generic, List, NamedTuple, Optional, Sequence, Tuple, TypeVar, Union
+from typing import Generic, NamedTuple, Optional, Sequence, TypeVar
 
 from aiokafka.errors import KafkaError
 
@@ -27,7 +28,7 @@ class TopicPartition(NamedTuple):
 class BrokerMetadata(NamedTuple):
     """A Kafka broker metadata used by admin tools"""
 
-    nodeId: Union[int, str]
+    nodeId: int | str  # FIXME consider updating implementation
     "The Kafka broker id"
 
     host: str

--- a/aiokafka/structs.py
+++ b/aiokafka/structs.py
@@ -1,6 +1,6 @@
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Generic, NamedTuple, Optional, TypeVar
+from typing import Generic, List, NamedTuple, Optional, Sequence, Tuple, TypeVar, Union
 
 from aiokafka.errors import KafkaError
 
@@ -27,7 +27,7 @@ class TopicPartition(NamedTuple):
 class BrokerMetadata(NamedTuple):
     """A Kafka broker metadata used by admin tools"""
 
-    nodeId: int
+    nodeId: Union[int, str]
     "The Kafka broker id"
 
     host: str

--- a/aiokafka/structs.py
+++ b/aiokafka/structs.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Generic, NamedTuple, Optional, Sequence, TypeVar
+from typing import Generic, NamedTuple, Optional, TypeVar
 
 from aiokafka.errors import KafkaError
 

--- a/aiokafka/structs.py
+++ b/aiokafka/structs.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Generic, NamedTuple, Optional, TypeVar
@@ -28,7 +29,8 @@ class TopicPartition(NamedTuple):
 class BrokerMetadata(NamedTuple):
     """A Kafka broker metadata used by admin tools"""
 
-    nodeId: int | str  # FIXME consider updating implementation (https://github.com/aio-libs/aiokafka/issues/1050)
+    # FIXME: consider updating implementation (https://github.com/aio-libs/aiokafka/issues/1050)
+    nodeId: int | str
     "The Kafka broker id"
 
     host: str

--- a/aiokafka/structs.py
+++ b/aiokafka/structs.py
@@ -28,7 +28,7 @@ class TopicPartition(NamedTuple):
 class BrokerMetadata(NamedTuple):
     """A Kafka broker metadata used by admin tools"""
 
-    nodeId: int | str  # FIXME consider updating implementation
+    nodeId: int | str  # FIXME consider updating implementation (https://github.com/aio-libs/aiokafka/issues/1050)
     "The Kafka broker id"
 
     host: str


### PR DESCRIPTION
### Changes

Fixes https://github.com/aio-libs/aiokafka/issues/1050

Preferred (less invasive) fix to issue above, changes the type of `aiokafka.structs.BrokerMetadata#nodeId` from `int` to `int | str`. No functionality change.

Use this or https://github.com/aio-libs/aiokafka/pull/1052, but not both.

### Checklist

The check list mentions a `CHANGES` folder, but I do not see one, am I supposed to create one for each PR?
