### PR TITLE
Changed BrokerMetadata#nodeId to str, and convert all values to str before setting

### DIFF
--- a/aiokafka/client.py
+++ b/aiokafka/client.py
@@ -693,7 +693,7 @@ class AIOKafkaClient:
             err = error_type()
             raise err
         self.cluster.add_coordinator(
-            resp.coordinator_id,
+            str(resp.coordinator_id),
             resp.host,
             resp.port,
             rack=None,

--- a/aiokafka/structs.py
+++ b/aiokafka/structs.py
@@ -26,7 +26,7 @@ class TopicPartition(NamedTuple):
 class BrokerMetadata(NamedTuple):
     """A Kafka broker metadata used by admin tools"""
 
-    nodeId: int
+    nodeId: str
     "The Kafka broker id"
 
     host: str


### PR DESCRIPTION
### Changes

Fixes https://github.com/aio-libs/aiokafka/issues/1050

Alternative (more invasive) fix to issue above, changes the type of `aiokafka.structs.BrokerMetadata#nodeId` from `int` to `str`. Where we are currently using an integer here, convert ti string first.

Use this or https://github.com/aio-libs/aiokafka/pull/1051, but not both.
