### PR TITLE
Fix ClusterMetadata request_update()

### DIFF
--- a/aiokafka/cluster.py
+++ b/aiokafka/cluster.py
@@ -209,7 +209,7 @@ class ClusterMetadata:
                 f = self._future
                 self._future = None
         if f:
-            f.failure(exception)
+            f.set_exception(exception)
         self._last_refresh_ms = time.time() * 1000
 
     def update_metadata(self, metadata):
@@ -307,7 +307,7 @@ class ClusterMetadata:
         self._last_successful_refresh_ms = now
 
         if f:
-            f.success(self)
+            f.set_result(self)
         log.debug("Updated cluster metadata to %s", self)
 
         for listener in self._listeners:

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -21,7 +21,7 @@ def test_empty_broker_list():
     )
     assert len(cluster.brokers()) == 2
 
-@run_until_complete
 async def test_request_update(self):
     cluster = ClusterMetadata()
-    cluster.request_update()
+    updated_cluster = await cluster.request_update()
+    assert updated_cluster == cluster

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -1,3 +1,4 @@
+import unittest
 from aiokafka.cluster import ClusterMetadata
 from aiokafka.protocol.metadata import MetadataResponse
 from tests._testutil import run_until_complete
@@ -21,7 +22,9 @@ def test_empty_broker_list():
     )
     assert len(cluster.brokers()) == 2
 
-async def test_request_update(self):
-    cluster = ClusterMetadata()
-    updated_cluster = await cluster.request_update()
-    assert updated_cluster == cluster
+class TestClusterMetadata(unittest.TestCase):
+    @run_until_complete
+    async def test_request_update(self):
+        cluster = ClusterMetadata()
+        updated_cluster = await cluster.request_update()
+        assert updated_cluster == cluster

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -22,5 +22,11 @@ def test_empty_broker_list():
 
 def test_request_update():
     cluster = ClusterMetadata()
-    updated_cluster = cluster.request_update().result()
-    assert updated_cluster == cluster
+    updated_cluster = cluster.request_update()
+    cluster.update_metadata(
+        MetadataResponse[0](
+            [],  # empty brokers
+            [(17, "foo", []), (17, "bar", [])],  # topics w/ error
+        )
+    )
+    assert updated_cluster.result() == cluster

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -20,7 +20,7 @@ def test_empty_broker_list():
     )
     assert len(cluster.brokers()) == 2
 
-def test_request_update(self):
+def test_request_update():
     cluster = ClusterMetadata()
     updated_cluster = cluster.request_update().result()
     assert updated_cluster == cluster

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -1,3 +1,4 @@
+from aiokafka import errors
 from aiokafka.cluster import ClusterMetadata
 from aiokafka.protocol.metadata import MetadataResponse
 
@@ -20,13 +21,20 @@ def test_empty_broker_list():
     )
     assert len(cluster.brokers()) == 2
 
-def test_request_update():
+def test_request_update_expecting_success():
     cluster = ClusterMetadata()
     updated_cluster = cluster.request_update()
     cluster.update_metadata(
-        MetadataResponse[0](
+        MetadataResponse[0]([(0, "foo", 12), (1, "bar", 34)], []),
+    )
+    assert updated_cluster.result() == cluster
+
+def test_request_update_expecting_failure():
+    cluster = ClusterMetadata()
+    updated_cluster = cluster.request_update()
+    test_metadata = MetadataResponse[0](
             [],  # empty brokers
             [(17, "foo", []), (17, "bar", [])],  # topics w/ error
         )
-    )
-    assert updated_cluster.result() == cluster
+    cluster.update_metadata(test_metadata)
+    assert updated_cluster.exception() == errors.MetadataEmptyBrokerList(test_metadata)

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -1,4 +1,3 @@
-from aiokafka import errors
 from aiokafka.cluster import ClusterMetadata
 from aiokafka.protocol.metadata import MetadataResponse
 
@@ -37,4 +36,4 @@ def test_request_update_expecting_failure():
             [(17, "foo", []), (17, "bar", [])],  # topics w/ error
         )
     cluster.update_metadata(test_metadata)
-    assert updated_cluster.exception() == errors.MetadataEmptyBrokerList(test_metadata)
+    assert updated_cluster.exception() is not None

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -20,6 +20,7 @@ def test_empty_broker_list():
     )
     assert len(cluster.brokers()) == 2
 
+
 def test_request_update_expecting_success():
     cluster = ClusterMetadata()
     updated_cluster = cluster.request_update()
@@ -28,12 +29,13 @@ def test_request_update_expecting_success():
     )
     assert updated_cluster.result() == cluster
 
+
 def test_request_update_expecting_failure():
     cluster = ClusterMetadata()
     updated_cluster = cluster.request_update()
     test_metadata = MetadataResponse[0](
-            [],  # empty brokers
-            [(17, "foo", []), (17, "bar", [])],  # topics w/ error
-        )
+        [],  # empty brokers
+        [(17, "foo", []), (17, "bar", [])],  # topics w/ error
+    )
     cluster.update_metadata(test_metadata)
     assert updated_cluster.exception() is not None

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -1,5 +1,6 @@
 from aiokafka.cluster import ClusterMetadata
 from aiokafka.protocol.metadata import MetadataResponse
+from tests._testutil import run_until_complete
 
 
 def test_empty_broker_list():
@@ -19,3 +20,8 @@ def test_empty_broker_list():
         )
     )
     assert len(cluster.brokers()) == 2
+
+@run_until_complete
+async def test_request_update(self):
+    cluster = ClusterMetadata()
+    cluster.request_update()

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -1,9 +1,5 @@
-import unittest
-
-import pytest
 from aiokafka.cluster import ClusterMetadata
 from aiokafka.protocol.metadata import MetadataResponse
-from tests._testutil import run_until_complete
 
 
 def test_empty_broker_list():
@@ -24,10 +20,7 @@ def test_empty_broker_list():
     )
     assert len(cluster.brokers()) == 2
 
-@pytest.mark.usefixtures("setup_test_class_serverless")
-class TestClusterMetadata(unittest.TestCase):
-    @run_until_complete
-    async def test_request_update(self):
-        cluster = ClusterMetadata()
-        updated_cluster = await cluster.request_update()
-        assert updated_cluster == cluster
+def test_request_update(self):
+    cluster = ClusterMetadata()
+    updated_cluster = cluster.request_update().result()
+    assert updated_cluster == cluster

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -1,4 +1,6 @@
 import unittest
+
+import pytest
 from aiokafka.cluster import ClusterMetadata
 from aiokafka.protocol.metadata import MetadataResponse
 from tests._testutil import run_until_complete
@@ -22,6 +24,7 @@ def test_empty_broker_list():
     )
     assert len(cluster.brokers()) == 2
 
+@pytest.mark.usefixtures("setup_test_class_serverless")
 class TestClusterMetadata(unittest.TestCase):
     @run_until_complete
     async def test_request_update(self):


### PR DESCRIPTION
### Changes

Fixes https://github.com/aio-libs/aiokafka/issues/1055

- Call [Future#set_result(...)](https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.Future.set_result) instead of `Future#success(...)`
- Call [Future#set_exception(...)](https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.Future.set_exception) instead of `Future#failure(...)`.
- Added unit tests to demonstrate original error, and verify fix.

### Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
