### PR TITLE
Fix manual commit documentation page is misleading

### DIFF
--- a/docs/examples/manual_commit.rst
+++ b/docs/examples/manual_commit.rst
@@ -1,12 +1,12 @@
 Manual commit
 =============
 
-When processing more sensitive data ``enable_auto_commit=False`` mode of
-Consumer can lead to data loss in cases of critical failure. To avoid it we
-can commit offsets manually after they were processed. Note, that this is a
-tradeoff from *at most once* to *at least once* delivery, to achieve
-*exactly once* you will need to save offsets in the destination database and
-validate those yourself.
+When processing sensitive data, setting ``enable_auto_commit=True`` for the
+Consumer can lead to data loss in the event of a critical failure. To avoid
+this, set ``enable_auto_commit=False`` and commit offsets manually only after
+messages have been processed. Note, that this is a tradeoff from *at most once*
+to *at least once* delivery, to achieve *exactly once* you will need to save
+offsets in the destination database and validate those yourself.
 
 More on message delivery: https://kafka.apache.org/documentation.html#semantics
 

--- a/docs/examples/manual_commit.rst
+++ b/docs/examples/manual_commit.rst
@@ -1,7 +1,7 @@
 Manual commit
 =============
 
-When processing sensitive data, setting ``enable_auto_commit=True`` for the
+When processing sensitive data, using ``enable_auto_commit=True`` (default) for the
 Consumer can lead to data loss in the event of a critical failure. To avoid
 this, set ``enable_auto_commit=False`` and commit offsets manually only after
 messages have been processed. Note, that this is a tradeoff from *at most once*


### PR DESCRIPTION
<!-- Thank you for your contribution! 
Feel free to change the template if you feel confused.
-->
### Changes

Fixes #1070

Updates the documentation for Manual commit page