### PR TITLE
Added type annotation to public classes.

### DIFF
--- a/aiokafka/abc.py
+++ b/aiokafka/abc.py
@@ -1,5 +1,7 @@
 import abc
 
+from aiokafka.structs import TopicPartition
+
 
 class ConsumerRebalanceListener(abc.ABC):
     """
@@ -45,7 +47,7 @@ class ConsumerRebalanceListener(abc.ABC):
     """
 
     @abc.abstractmethod
-    def on_partitions_revoked(self, revoked):
+    def on_partitions_revoked(self, revoked: list[TopicPartition]) -> None:
         """
         A coroutine or function the user can implement to provide cleanup or
         custom state save on the start of a rebalance operation.
@@ -65,7 +67,7 @@ class ConsumerRebalanceListener(abc.ABC):
         """
 
     @abc.abstractmethod
-    def on_partitions_assigned(self, assigned):
+    def on_partitions_assigned(self, assigned: list[TopicPartition]) -> None:
         """
         A coroutine or function the user can implement to provide load of
         custom consumer state or cache warmup on completion of a successful
@@ -103,7 +105,7 @@ class AbstractTokenProvider(abc.ABC):
     """
 
     @abc.abstractmethod
-    async def token(self):
+    async def token(self) -> None:
         """
         An async callback returning a :class:`str` ID/Access Token to be sent to
         the Kafka client. In case where a synchronous callback is needed,
@@ -122,7 +124,7 @@ class AbstractTokenProvider(abc.ABC):
                     # The actual synchronous token callback.
         """
 
-    def extensions(self):
+    def extensions(self) -> dict[str, str]:
         """
         This is an OPTIONAL method that may be implemented.
 

--- a/aiokafka/conn.py
+++ b/aiokafka/conn.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import base64
 import collections
@@ -16,6 +18,7 @@ import uuid
 import warnings
 import weakref
 from enum import IntEnum
+from typing import Literal
 
 import async_timeout
 
@@ -893,7 +896,7 @@ def get_ip_port_afi(host_and_port_str):
         return host, port, af
 
 
-def collect_hosts(hosts, randomize=True):
+def collect_hosts(hosts: str | list[str], randomize: bool=True) -> list[tuple[str, int, Literal[0] | Literal[2] | Literal[10]]]:
     """
     Collects a comma-separated set of hosts (host:port) and optionally
     randomize the returned list.

--- a/aiokafka/producer/message_accumulator.py
+++ b/aiokafka/producer/message_accumulator.py
@@ -3,6 +3,7 @@ import collections
 import copy
 import time
 from collections.abc import Sequence
+from typing import Generic, TypeVar
 
 from aiokafka.errors import (
     KafkaTimeoutError,
@@ -16,7 +17,11 @@ from aiokafka.structs import RecordMetadata
 from aiokafka.util import create_future, get_running_loop
 
 
-class BatchBuilder:
+KT = TypeVar("KT", contravariant=True)
+VT = TypeVar("VT", contravariant=True)
+
+
+class BatchBuilder(Generic[KT, VT]):
     def __init__(
         self,
         magic,

--- a/aiokafka/structs.py
+++ b/aiokafka/structs.py
@@ -27,7 +27,7 @@ class TopicPartition(NamedTuple):
 class BrokerMetadata(NamedTuple):
     """A Kafka broker metadata used by admin tools"""
 
-    nodeId: int
+    nodeId: int | str
     "The Kafka broker id"
 
     host: str
@@ -117,8 +117,8 @@ class RecordMetadata(NamedTuple):
     ""
 
 
-KT = TypeVar("KT")
-VT = TypeVar("VT")
+KT = TypeVar("KT", covariant=True)
+VT = TypeVar("VT", covariant=True)
 
 
 @dataclass


### PR DESCRIPTION
### Changes
Adds type annotation to public classes, and `py.typed` so that client code can type check against this library.

Fixes https://github.com/aio-libs/aiokafka/issues/980 (kind of)

Note that the issue in question seems to be more ambitious in that it aims to provide type information to the entire library:
1. Allowing bugs to be discovered
2. Allowing developers consuming this library to have better type information to work with. 

This PR only aims to solve the latter.

## Details about this PR:
- Using Python 3.10+ typing, which is available in 3.9 via `from __future__ import annotations`
	- `x | None` instead of `Optional[x]`
	- `x | y` instead of `Union[x, y]`
	- `list[x]`/`set[x]`/`dict[x, y]` instead of `typing.List[x]`/`typing.Set[x]`/`typing.Dict[x, y]`
- For the most part, all I'm doing is explicitly annotate methods as documented in docstring
- There are special cases though where the docstring had to be updated, e.g.,:
	- docstring says `list`, but varargs/default value is `tuple`
	- docstring doesn't say optional, but default value is `None`

Note that this is introducing a breaking change that may affect a small minority of users. The key/value serializer/deserializer functions no longer optional (with the identity function defined as the default parameter). This is so that the generic parameters `KT`/`VT` can be inferred.

This means that:
- The (de)serialization behavior is identical at runtime
- As long as clients do not explicitly set `None` as their key/value serializer/deserializer function, there should be no change.

However, if a client is explicitly passing in `None`, e.g., with `AIOKafkaConsumer`:
```python
# OK, most people probably do this anyway, this is from the README
consumer = AIOKafkaConsumer(
    'my_topic', 'my_other_topic',
    bootstrap_servers='localhost:9092',
    group_id='my-group'
)

# Not OK, key_deserializer/value_deserializer cannot be None
consumer = AIOKafkaConsumer(
    'my_topic', 'my_other_topic',
    bootstrap_servers='localhost:9092',
    group_id='my-group',
    key_deserializer=None,
    value_deserializer=None
)
```

Or with `AIOKafkaProducer`:
```python
# OK, most people probably do this anyway, this is from the README
AIOKafkaProducer(
    bootstrap_servers='localhost:9092'
)

# Not OK, key_deserializer/value_deserializer cannot be None
AIOKafkaProducer(
    bootstrap_servers='localhost:9092'
    key_serializer=None,
    value_serializer=None
)
```

The type checker will reject it.
<img width="929" alt="image" src="https://github.com/user-attachments/assets/198bc85d-a730-4c6a-8c88-403f0fd5d98c">

You can ignore the type checker though, and the application should work the same as before, as this PR does not change any runtime logic.

### Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
