### PR TITLE
Use SPDX license identifier

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -109,7 +109,7 @@ jobs:
 
       - name: Install python dependencies
         run: |
-          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install --upgrade pip setuptools
           python -m pip install -r requirements-win-test.txt
           python -m pip install ${{ matrix.aiokafka_whl }}
         shell: bash
@@ -154,7 +154,7 @@ jobs:
 
       - name: Install python dependencies
         run: |
-          pip install --upgrade pip setuptools wheel
+          pip install --upgrade pip setuptools
           pip install -r requirements-ci.txt
           pip install ${{ matrix.aiokafka_whl }}
 
@@ -197,7 +197,7 @@ jobs:
 
       - name: Install python dependencies
         run: |
-          pip install --upgrade pip setuptools wheel
+          pip install --upgrade pip setuptools
           pip install -r requirements-ci.txt
           pip install ${{ matrix.aiokafka_whl }}
 
@@ -244,7 +244,7 @@ jobs:
           sudo apt-get install -y libkrb5-dev
       - name: Install python dependencies
         run: |
-          pip install --upgrade pip setuptools wheel
+          pip install --upgrade pip setuptools
           pip install -r requirements-ci.txt
           pip install ${{ matrix.aiokafka_whl }}
 
@@ -294,7 +294,7 @@ jobs:
               yum install -y epel-release && \
               yum-config-manager --enable epel && \
               yum install -y krb5-devel && \
-              pip install --upgrade pip setuptools wheel && \
+              pip install --upgrade pip setuptools && \
               pip install -r requirements-ci.txt && \
               pip install ${{ matrix.aiokafka_whl }} && \
               rm -rf aiokafka && \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
 
     - name: Install python dependencies
       run: |
-        pip install --upgrade pip setuptools wheel
+        pip install --upgrade pip setuptools
         pip install -r requirements-ci.txt
         pip install -vv -Ue .  # We set -vv to see compiler exceptions/warnings
 
@@ -101,7 +101,7 @@ jobs:
 
     - name: Install python dependencies
       run: |
-        pip install --upgrade pip setuptools wheel
+        pip install --upgrade pip setuptools
         pip install -r requirements-win-test.txt
         pip install -vv -Ue .  # We set -vv to see compiler exceptions/warnings
 
@@ -169,7 +169,7 @@ jobs:
 
     - name: Install python dependencies
       run: |
-        pip install --upgrade pip setuptools wheel
+        pip install --upgrade pip setuptools
         pip install -r requirements-ci.txt
         pip install -vv -Ue .  # We set -vv to see compiler exceptions/warnings
 
@@ -295,7 +295,7 @@ jobs:
 
     - name: Install python dependencies
       run: |
-        pip install --upgrade pip setuptools wheel
+        pip install --upgrade pip setuptools
         pip install -r requirements-ci.txt
         pip install -vv -Ue .  # We set -vv to see compiler exceptions/warnings
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,9 @@ Improved Documentation:
   (pr #1068 by @jzvandenoever)
 * Fix Java Client API reference (pr #1069 by @emmanuel-ferdman)
 
+Misc:
+* Use SPDX license expression for project metadata.
+
 
 0.12.0 (2024-10-26)
 ===================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,17 +1,16 @@
 [build-system]
-requires = ["setuptools >=61", "wheel", "Cython >=3.0.5"]
+requires = ["setuptools >=77", "Cython >=3.0.5"]
 
 [project]
 name = "aiokafka"
 description = "Kafka integration with asyncio"
 readme = "README.rst"
 requires-python = ">=3.9"
-license = { file = "LICENSE" }
+license = "Apache-2.0"
 authors = [
     { name = "Andrew Svetlov", email = "andrew.svetlov@gmail.com" },
 ]
 classifiers = [
-    "License :: OSI Approved :: Apache Software License",
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
### Changes
Use the SPDX license identifier as recommended by [PEP 639](https://peps.python.org/pep-0639/).
https://spdx.org/licenses/Apache-2.0.html