### PR TITLE
KIP-368: Allow SASL Connections to Periodically Re-Authenticate

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,13 @@ Changelog
 0.13.0 (????-??-??)
 ===================
 
+New features:
+
+* Allow SASL Connections to Periodically Re-Authenticate (`KIP-368`_) (pr #1105 by @kprzybyla)
+
+.. _KIP-368: https://cwiki.apache.org/confluence/display/KAFKA/KIP-368%3A+Allow+SASL+Connections+to+Periodically+Re-Authenticate
+
+
 Improved Documentation:
 
 * Fix incomplete documentation for `AIOKafkaConsumer.offset_for_times``

--- a/docker/scripts/start-kafka.sh
+++ b/docker/scripts/start-kafka.sh
@@ -1,12 +1,12 @@
-#!/bin/sh
+#!/bin/bash
 
-OPTIONS=""
+OPTIONS=()
 PATH="$HOME/bin:$PATH"
 
 # Configure the default number of log partitions per topic
 if [ ! -z "$NUM_PARTITIONS" ]; then
     echo "default number of partition: $NUM_PARTITIONS"
-    OPTIONS="$OPTIONS --override num.partitions=$NUM_PARTITIONS"
+    OPTIONS+=("--override" "num.partitions=$NUM_PARTITIONS")
 fi
 
 # Set the external host and port
@@ -16,36 +16,36 @@ echo "advertised port: $ADVERTISED_PORT"
 LISTENERS="PLAINTEXT://:$ADVERTISED_PORT"
 ADVERTISED_LISTENERS="PLAINTEXT://$ADVERTISED_HOST:$ADVERTISED_PORT"
 
-if [ ! -z "$ADVERTISED_SSL_PORT" ]; then
+if [[ ! -z "$ADVERTISED_SSL_PORT" ]]; then
     echo "advertised ssl port: $ADVERTISED_SSL_PORT"
 
     # SSL options
-    OPTIONS="$OPTIONS --override ssl.protocol=TLS"
-    OPTIONS="$OPTIONS --override ssl.enabled.protocols=TLSv1.2,TLSv1.1,TLSv1"
-    OPTIONS="$OPTIONS --override ssl.keystore.type=JKS"
-    OPTIONS="$OPTIONS --override ssl.keystore.location=/ssl_cert/br_server.keystore.jks"
-    OPTIONS="$OPTIONS --override ssl.keystore.password=abcdefgh"
-    OPTIONS="$OPTIONS --override ssl.key.password=abcdefgh"
-    OPTIONS="$OPTIONS --override ssl.truststore.type=JKS"
-    OPTIONS="$OPTIONS --override ssl.truststore.location=/ssl_cert/br_server.truststore.jks"
-    OPTIONS="$OPTIONS --override ssl.truststore.password=abcdefgh"
-    OPTIONS="$OPTIONS --override ssl.client.auth=required"
-    OPTIONS="$OPTIONS --override security.inter.broker.protocol=SSL"
-    OPTIONS="$OPTIONS --override ssl.endpoint.identification.algorithm="
+    OPTIONS+=("--override" "ssl.protocol=TLS")
+    OPTIONS+=("--override" "ssl.enabled.protocols=TLSv1.2,TLSv1.1,TLSv1")
+    OPTIONS+=("--override" "ssl.keystore.type=JKS")
+    OPTIONS+=("--override" "ssl.keystore.location=/ssl_cert/br_server.keystore.jks")
+    OPTIONS+=("--override" "ssl.keystore.password=abcdefgh")
+    OPTIONS+=("--override" "ssl.key.password=abcdefgh")
+    OPTIONS+=("--override" "ssl.truststore.type=JKS")
+    OPTIONS+=("--override" "ssl.truststore.location=/ssl_cert/br_server.truststore.jks")
+    OPTIONS+=("--override" "ssl.truststore.password=abcdefgh")
+    OPTIONS+=("--override" "ssl.client.auth=required")
+    OPTIONS+=("--override" "security.inter.broker.protocol=SSL")
+    OPTIONS+=("--override" "ssl.endpoint.identification.algorithm=")
 
     LISTENERS="$LISTENERS,SSL://:$ADVERTISED_SSL_PORT"
     ADVERTISED_LISTENERS="$ADVERTISED_LISTENERS,SSL://$ADVERTISED_HOST:$ADVERTISED_SSL_PORT"
 fi
 
-if [ ! -z "$SASL_MECHANISMS" ]; then
+if [[ ! -z "$SASL_MECHANISMS" ]]; then
     echo "sasl mechanisms: $SASL_MECHANISMS"
     echo "advertised sasl plaintext port: $ADVERTISED_SASL_PLAINTEXT_PORT"
     echo "advertised sasl ssl port: $ADVERTISED_SASL_SSL_PORT"
 
-    OPTIONS="$OPTIONS --override sasl.enabled.mechanisms=$SASL_MECHANISMS"
-    OPTIONS="$OPTIONS --override sasl.kerberos.service.name=kafka"
-    OPTIONS="$OPTIONS --override authorizer.class.name=kafka.security.auth.SimpleAclAuthorizer"
-    OPTIONS="$OPTIONS --override allow.everyone.if.no.acl.found=true"
+    OPTIONS+=("--override" "sasl.enabled.mechanisms=$SASL_MECHANISMS")
+    OPTIONS+=("--override" "sasl.kerberos.service.name=kafka")
+    OPTIONS+=("--override" "authorizer.class.name=kafka.security.auth.SimpleAclAuthorizer")
+    OPTIONS+=("--override" "allow.everyone.if.no.acl.found=true")
     export KAFKA_OPTS="-Djava.security.auth.login.config=/etc/kafka/$SASL_JAAS_FILE"
 
     LISTENERS="$LISTENERS,SASL_PLAINTEXT://:$ADVERTISED_SASL_PLAINTEXT_PORT"
@@ -56,13 +56,13 @@ if [ ! -z "$SASL_MECHANISMS" ]; then
 fi
 
 # Enable auto creation of topics
-OPTIONS="$OPTIONS --override auto.create.topics.enable=true"
-OPTIONS="$OPTIONS --override listeners=$LISTENERS"
-OPTIONS="$OPTIONS --override advertised.listeners=$ADVERTISED_LISTENERS"
-OPTIONS="$OPTIONS --override super.users=User:admin"
+OPTIONS+=("--override" "auto.create.topics.enable=true")
+OPTIONS+=("--override" "listeners=$LISTENERS")
+OPTIONS+=("--override" "advertised.listeners=$ADVERTISED_LISTENERS")
+OPTIONS+=("--override" "super.users=User:admin")
 
 
 # Run Kafka
 echo "$KAFKA_HOME/bin/kafka-server-start.sh $KAFKA_HOME/config/server.properties $OPTIONS"
 
-exec $KAFKA_HOME/bin/kafka-server-start.sh $KAFKA_HOME/config/server.properties $OPTIONS
+exec $KAFKA_HOME/bin/kafka-server-start.sh $KAFKA_HOME/config/server.properties "${OPTIONS[@]}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ asyncio_mode = "auto"
 addopts = ["--strict-config", "--strict-markers"]
 markers = [
     "ssl: Tests that require SSL certificates to run",
+    "oauthbearer: Tests that require SASL OAUTHBEARER mechanism to run",
 ]
 filterwarnings = [
     "error",

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -11,3 +11,4 @@ Pygments==2.18.0
 gssapi==1.9.0
 async-timeout==4.0.3
 cramjam==2.9.0
+pyjwt==2.10.1


### PR DESCRIPTION
### Changes

Fixes #1080
Fixes #1015

I recently discovered that `aiokafka` does not implement `KIP-368`, which is essential for the `OAUTHBEARER` authorization, for example, when using `AWS MSK`. This was not so obvious to find out for me as someone who does not know Kafka internals and just wants to use a certain authorization method, because according to the `KIP-368`, the server will just break the connection to any client for which the token has expired. So, from the client side, this looks like the Kafka server is terminating the connection for no reason. This was especially mindboggling because the [Amazon MSK library](https://github.com/aws/aws-msk-iam-sasl-signer-python) "hardcodes" the [session timeout to be 15 minutes](https://github.com/aws/aws-msk-iam-sasl-signer-python/blob/a1bbf3c19eaff152051188bf2344e14727eacb2c/aws_msk_iam_sasl_signer/MSKAuthTokenProvider.py#L18), while the token is actually granted with a 1-hour expiration time, and this did not help to make the 1-hour error interval noticeable.

Also, Amazon MSK library describes in their ["Get Started"](https://github.com/aws/aws-msk-iam-sasl-signer-python?tab=readme-ov-file#get-started) how to use it with the `kafka-python` library, but this library does not implement `KIP-368` either (see https://github.com/dpkp/kafka-python/issues/2205), which leads me to believe that not that many people is aware how problematic this is when you are trying to built something reliable. This also happens to be the case for the `confluent-kafka-python` (see https://github.com/confluentinc/confluent-kafka-python/issues/1485), which is also used in the Amazon MSK example.

Anyway, after I figured out what was happening, I created a quick and dirty patch for `aiokafka` with a workaround that closed connections that were about to expire, and this got rid of all connection drops from the Kafka server that I was experiencing previously. This "patched" version is now used in our production in the company I worked for, and it works flawlessly, but due to certain implementation shortcuts, it generates unharmful but still annoying errors. So, after it was proven that this solved the issue we were battling for a long time, I decided to contribute a polished solution so that nobody else has to go through the same frustration I went through to get this working reliably.

The `OAUTHBEARER` SASL mechanism was also painful to configure in the Kafka server since it is implemented differently than other SASL mechanisms. Setting up `OAUTHBEARER` with other SASL mechanisms is impossible, at least I did not find a way to make it work. Because of this, a separate Docker container runs specifically for `OAUTHBEARER` tests.

Also, for anyone reading this who will use AWS MSK, please remember to set a static value for `AWS_ROLE_SESSION_NAME` (different for each client), otherwise, the re-authentication will fail since by default, the session name will contain the current timestamp at the end, and the session name must stay the same for a given client.

Java reference implementation of the same feature: https://github.com/apache/kafka/pull/5582

### Checklist

- [X] I think the code is well written
- [X] Unit tests for the changes exist
- [X] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder