### PR TITLE
Add support for client.rack

### DIFF
--- a/aiokafka/consumer/consumer.py
+++ b/aiokafka/consumer/consumer.py
@@ -67,7 +67,7 @@ class AIOKafkaConsumer:
         group_instance_id (str or None): name of the group instance ID used for
             static membership (KIP-345)
         client_rack (str or None): rack ID of this client for rack-aware
-            assignment (KIP-881). Default: None
+            assignment. Default: None
         key_deserializer (Callable): Any callable that takes a
             raw message key and returns a deserialized key.
         value_deserializer (Callable, Optional): Any callable that takes a

--- a/aiokafka/consumer/consumer.py
+++ b/aiokafka/consumer/consumer.py
@@ -66,6 +66,8 @@ class AIOKafkaConsumer:
             Default: None
         group_instance_id (str or None): name of the group instance ID used for
             static membership (KIP-345)
+        client_rack (str or None): rack ID of this client for rack-aware
+            assignment (KIP-881). Default: None
         key_deserializer (Callable): Any callable that takes a
             raw message key and returns a deserialized key.
         value_deserializer (Callable, Optional): Any callable that takes a
@@ -234,6 +236,7 @@ class AIOKafkaConsumer:
         client_id="aiokafka-" + __version__,
         group_id=None,
         group_instance_id=None,
+        client_rack=None,
         key_deserializer=None,
         value_deserializer=None,
         fetch_max_wait_ms=500,
@@ -306,6 +309,7 @@ class AIOKafkaConsumer:
 
         self._group_id = group_id
         self._group_instance_id = group_instance_id
+        self._client_rack = client_rack
         self._heartbeat_interval_ms = heartbeat_interval_ms
         self._session_timeout_ms = session_timeout_ms
         self._retry_backoff_ms = retry_backoff_ms
@@ -406,6 +410,7 @@ class AIOKafkaConsumer:
                 self._subscription,
                 group_id=self._group_id,
                 group_instance_id=self._group_instance_id,
+                client_rack=self._client_rack,
                 heartbeat_interval_ms=self._heartbeat_interval_ms,
                 session_timeout_ms=self._session_timeout_ms,
                 retry_backoff_ms=self._retry_backoff_ms,

--- a/aiokafka/protocol/group.py
+++ b/aiokafka/protocol/group.py
@@ -119,11 +119,33 @@ class JoinGroupRequest_v5(Request):
     UNKNOWN_MEMBER_ID = ""
 
 
+# JoinGroupRequest version 8: adds rack_id for client.rack support (KIP-881)
+class JoinGroupRequest_v8(Request):
+    API_KEY = 11
+    API_VERSION = 8
+    RESPONSE_TYPE = JoinGroupResponse_v5
+    SCHEMA = Schema(
+        ("group", String("utf-8")),
+        ("session_timeout", Int32),
+        ("rebalance_timeout", Int32),
+        ("member_id", String("utf-8")),
+        ("group_instance_id", String("utf-8")),
+        ("protocol_type", String("utf-8")),
+        (
+            "group_protocols",
+            Array(("protocol_name", String("utf-8")), ("protocol_metadata", Bytes)),
+        ),
+        ("rack_id", String("utf-8")),
+    )
+    UNKNOWN_MEMBER_ID = JoinGroupRequest_v5.UNKNOWN_MEMBER_ID
+
+
 JoinGroupRequest = [
     JoinGroupRequest_v0,
     JoinGroupRequest_v1,
     JoinGroupRequest_v2,
     JoinGroupRequest_v5,
+    JoinGroupRequest_v8,
 ]
 JoinGroupResponse = [
     JoinGroupResponse_v0,

--- a/docs/consumer.rst
+++ b/docs/consumer.rst
@@ -40,6 +40,12 @@ transparently adapts as topic partitions it fetches migrate within the
 cluster. It also interacts with the broker to allow groups of consumers to load
 balance consumption using :ref:`Consumer Groups <consumer-groups>`.
 
+.. note::
+   `client_rack` parameter can be provided to
+   :class:`.AIOKafkaConsumer` to enable rack-aware assignment when
+   connecting to Kafka brokers 2.4.0 or later. This advertises the client's
+   rack ID to the broker for improved partition placement.
+
 
 .. _offset_and_position:
 

--- a/tests/test_consumer_client_rack.py
+++ b/tests/test_consumer_client_rack.py
@@ -1,0 +1,16 @@
+from aiokafka.consumer.consumer import AIOKafkaConsumer
+
+
+def test_consumer_stores_client_rack():
+    # When initialized with client_rack, it should store the attribute
+    rack = "rack-test"
+    consumer = AIOKafkaConsumer(client_rack=rack)
+    assert hasattr(consumer, "_client_rack"), "Consumer missing _client_rack attribute"
+    assert consumer._client_rack == rack
+
+
+def test_consumer_default_client_rack_none():
+    # If not provided, default should be None
+    consumer = AIOKafkaConsumer()
+    assert hasattr(consumer, "_client_rack"), "Consumer missing _client_rack attribute"
+    assert consumer._client_rack is None

--- a/tests/test_protocol_group_rack_support.py
+++ b/tests/test_protocol_group_rack_support.py
@@ -1,0 +1,53 @@
+from aiokafka.protocol.group import JoinGroupRequest, JoinGroupRequest_v8
+
+
+def test_join_group_request_v8_in_list():
+    # Ensure version 8 is present in the request versions
+    versions = [req.API_VERSION for req in JoinGroupRequest]
+    assert 8 in versions, "JoinGroupRequest version 8 missing"
+
+
+def test_join_group_request_v8_schema_names():
+    # The last field in the schema should be 'rack_id'
+    names = JoinGroupRequest_v8.SCHEMA.names
+    assert (
+        "rack_id" in names
+    ), f"Expected last schema field to be 'rack_id', got {names[-1]}"
+
+
+def test_to_object_includes_rack_id():
+    # Instantiate a v8 join request with dummy data
+    group = "test-group"
+    session = 1234
+    rebalance = 5678
+    member = "member-1"
+    instance = "instance-x"
+    protocol_type = "consumer"
+    protocols = [("proto1", b"meta1"), ("proto2", b"meta2")]
+    rack_id = "rack-A"
+    req = JoinGroupRequest_v8(
+        group,
+        session,
+        rebalance,
+        member,
+        instance,
+        protocol_type,
+        protocols,
+        rack_id,
+    )
+    obj = req.to_object()
+    # Verify rack_id is included and correct
+    assert obj.get("rack_id") == rack_id
+    # Verify other fields round-trip
+    assert obj.get("group") == group
+    assert obj.get("session_timeout") == session
+    assert obj.get("rebalance_timeout") == rebalance
+    assert obj.get("member_id") == member
+    assert obj.get("group_instance_id") == instance
+    assert obj.get("protocol_type") == protocol_type
+    # Protocols should be list of dicts with these keys
+    protos = obj.get("group_protocols")
+    assert isinstance(protos, list) and len(protos) == 2
+    for i, entry in enumerate(protos):
+        assert entry["protocol_name"] == protocols[i][0]
+        assert entry["protocol_metadata"] == protocols[i][1]


### PR DESCRIPTION
### Changes
Protocol update (`aiokafka/protocol/group.py`)
- Introduced a new JoinGroupRequest_v8 (API_VERSION = 8) that appends a "rack_id" string field.
- Extended the JoinGroupRequest list to include v8.

Consumer API (`aiokafka/consumer/consumer.py`)
- Added client_rack=None to AIOKafkaConsumer.__init__, stored as self._client_rack.
- Documented the new client_rack parameter in the docstring.
- Passed client_rack=self._client_rack into the GroupCoordinator on start() when group_id is set.

Coordinator logic (`aiokafka/consumer/group_coordinator.py`)
- Updated GroupCoordinator.__init__ to accept and store client_rack.
- In the rebalance’s perform_group_join(), split the old “else” branch into two:
  - Kafka < 2.4.0 uses the existing static-membership protocol (v5)
  - Kafka ≥ 2.4.0 now uses the new v8 request and injects the configured rack ID (or empty string)

With these changes, consumers connecting to Kafka 2.4+ will advertise their client.rack, enabling rack-aware assignment. 

Fixes #1016

<!-- Please give a short brief about these changes. -->

### Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
