### PR TITLE
Vishal/support client.rack 2

### DIFF
--- a/aiokafka/consumer/consumer.py
+++ b/aiokafka/consumer/consumer.py
@@ -260,6 +260,7 @@ class AIOKafkaConsumer:
         exclude_internal_topics=True,
         connections_max_idle_ms=540000,
         isolation_level="read_uncommitted",
+        rack_id="",
         sasl_mechanism="PLAIN",
         sasl_plain_password=None,
         sasl_plain_username=None,
@@ -324,6 +325,7 @@ class AIOKafkaConsumer:
         self._max_poll_records = max_poll_records
         self._consumer_timeout = consumer_timeout_ms / 1000
         self._isolation_level = isolation_level
+        self._rack_id = rack_id
         self._rebalance_timeout_ms = rebalance_timeout_ms
         self._max_poll_interval_ms = max_poll_interval_ms
 
@@ -397,6 +399,7 @@ class AIOKafkaConsumer:
             retry_backoff_ms=self._retry_backoff_ms,
             auto_offset_reset=self._auto_offset_reset,
             isolation_level=self._isolation_level,
+            rack_id=self._rack_id,
         )
 
         if self._group_id is not None:

--- a/aiokafka/consumer/fetcher.py
+++ b/aiokafka/consumer/fetcher.py
@@ -372,8 +372,14 @@ class Fetcher:
             OffsetOutOfRange errors: 'earliest' will move to the oldest
             available message, 'latest' will move to the most recent. Any
             ofther value will raise the exception. Default: 'latest'.
+        session_id (int): The fetch session ID.
+        session_epoch (int): The fetch session epoch, which is used for
+            ordering requests in a session.
         isolation_level (str): Controls how to read messages written
             transactionally. See consumer description.
+        forgotten_topics_data ([str, [int]]): In an incremental fetch
+            request, the partitions to remove.
+        rack_id (str): Rack ID of the consumer making this request.
     """
 
     def __init__(
@@ -393,6 +399,10 @@ class Fetcher:
         retry_backoff_ms=100,
         auto_offset_reset="latest",
         isolation_level="read_uncommitted",
+        session_id=0,
+        session_epoch=-1,
+        forgotten_topics_data=None,
+        rack_id="",
     ):
         self._client = client
         self._loop = client._loop
@@ -416,6 +426,10 @@ class Fetcher:
         else:
             raise ValueError(f"Incorrect isolation level {isolation_level}")
 
+        self._session_id = session_id
+        self._session_epoch = session_epoch
+        self._forgotten_topics_data = forgotten_topics_data or []
+        self._rack_id = rack_id
         self._records = collections.OrderedDict()
         self._in_flight = set()
         self._pending_tasks = set()
@@ -427,8 +441,8 @@ class Fetcher:
         # waiters directly
         self._subscriptions.register_fetch_waiters(self._fetch_waiters)
 
-        if client.api_version >= (0, 11):
-            req_version = 4
+        if client.api_version >= (2, 4, 0):
+            req_version = 11
         elif client.api_version >= (0, 10, 1):
             req_version = 3
         elif client.api_version >= (0, 10):
@@ -645,7 +659,43 @@ class Fetcher:
                     (tp.partition, position, self._max_partition_fetch_bytes)
                 )
             klass = self._fetch_request_class
-            if klass.API_VERSION > 3:
+            if klass.API_VERSION > 10:
+                topics = collections.defaultdict(list)
+                for k, v in by_topics.items():
+                    for partition_info in v:
+                        topics[k].append(
+                            (
+                                partition_info[0],
+                                -1,
+                                partition_info[1],
+                                -1,
+                                partition_info[2],
+                            )
+                        )
+
+                req = klass(
+                    -1,  # replica_id
+                    self._fetch_max_wait_ms,
+                    self._fetch_min_bytes,
+                    self._fetch_max_bytes,
+                    self._isolation_level,
+                    self._session_id,
+                    self._session_epoch,
+                    list(topics.items()),
+                    self._forgotten_topics_data,
+                    self._rack_id,
+                )
+            elif klass.API_VERSION > 6:
+                req = klass(
+                    -1,  # replica_id
+                    self._fetch_max_wait_ms,
+                    self._fetch_min_bytes,
+                    self._fetch_max_bytes,
+                    self._isolation_level,
+                    list(by_topics.items()),
+                    self._forgotten_topics_data,
+                )
+            elif klass.API_VERSION > 3:
                 req = klass(
                     -1,  # replica_id
                     self._fetch_max_wait_ms,
@@ -706,8 +756,12 @@ class Fetcher:
 
         fetch_offsets = {}
         for topic, partitions in request.topics:
-            for partition, offset, _ in partitions:
-                fetch_offsets[TopicPartition(topic, partition)] = offset
+            if self._client.api_version >= (2, 4, 0):
+                for partition, _, offset, _, _ in partitions:
+                    fetch_offsets[TopicPartition(topic, partition)] = offset
+            else:
+                for partition, offset, _ in partitions:
+                    fetch_offsets[TopicPartition(topic, partition)] = offset
 
         now_ms = int(1000 * time.time())
         for topic, partitions in response.topics:


### PR DESCRIPTION
<!-- Thank you for your contribution! 
Feel free to change the template if you feel confused.
-->
### Changes

- Introduce a new `rack_id` parameter on AIOKafkaConsumer and store it on the instance.
- Propagate `rack_id` (alongside new session metadata fields `session_id`, `session_epoch` and `forgotten_topics_data`) into the internal `Fetcher`.
- Revise fetch-request version logic:
   - For kafka 2.4.0+ clients, bump to FetchRequest V11 and include the consumer's `rack_id` in the payload
   - Fall back to the existing protocal branches (V7 and V4) for older API versions
- All changes are opt-in and fully backward-compatible


Fixes #1016 

<!-- Please give a short brief about these changes. -->

### Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
