### PR TITLE
Remove typing_extensions from run time requirements

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ Improved Documentation:
 
 Misc:
 * Use SPDX license expression for project metadata.
+* Remove typing_extensions from run time requirements (pr #1109)
 
 
 0.12.0 (2024-10-26)

--- a/aiokafka/codec.py
+++ b/aiokafka/codec.py
@@ -1,9 +1,12 @@
+from __future__ import annotations
+
 import gzip
 import io
 import struct
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
-from typing_extensions import Buffer
+if TYPE_CHECKING:
+    from typing_extensions import Buffer
 
 _XERIAL_V1_HEADER = (-126, b"S", b"N", b"A", b"P", b"P", b"Y", 0, 1, 1)
 _XERIAL_V1_FORMAT = "bccccccBii"

--- a/aiokafka/helpers.py
+++ b/aiokafka/helpers.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import logging
 from os import PathLike
 from ssl import Purpose, SSLContext, create_default_context
-from typing import Callable, Union
+from typing import TYPE_CHECKING, Callable, Union
 
-from typing_extensions import Buffer
+if TYPE_CHECKING:
+    from typing_extensions import Buffer
 
 log = logging.getLogger(__name__)
 

--- a/aiokafka/protocol/message.py
+++ b/aiokafka/protocol/message.py
@@ -1,10 +1,13 @@
+from __future__ import annotations
+
 import io
 import time
 from binascii import crc32
 from collections.abc import Iterable
-from typing import Literal, Optional, Union, cast, overload
+from typing import TYPE_CHECKING, Literal, Optional, Union, cast, overload
 
-from typing_extensions import Self
+if TYPE_CHECKING:
+    from typing_extensions import Self
 
 from aiokafka.codec import (
     gzip_decode,

--- a/aiokafka/protocol/struct.py
+++ b/aiokafka/protocol/struct.py
@@ -1,7 +1,10 @@
-from io import BytesIO
-from typing import Any, ClassVar, Union
+from __future__ import annotations
 
-from typing_extensions import Self
+from io import BytesIO
+from typing import TYPE_CHECKING, Any, ClassVar, Union
+
+if TYPE_CHECKING:
+    from typing_extensions import Self
 
 from .types import Schema
 

--- a/aiokafka/protocol/types.py
+++ b/aiokafka/protocol/types.py
@@ -1,8 +1,11 @@
+from __future__ import annotations
+
 import struct
 from collections.abc import Sequence
 from io import BytesIO
 from struct import error
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     Optional,
@@ -12,7 +15,8 @@ from typing import (
     overload,
 )
 
-from typing_extensions import Buffer, TypeAlias
+if TYPE_CHECKING:
+    from typing_extensions import Buffer, TypeAlias
 
 from .abstract import AbstractType
 

--- a/aiokafka/record/_crecords/default_records.pyi
+++ b/aiokafka/record/_crecords/default_records.pyi
@@ -1,6 +1,7 @@
-from typing import ClassVar, final
+from typing import TYPE_CHECKING, ClassVar, final
 
-from typing_extensions import Literal, Self
+if TYPE_CHECKING:
+    from typing_extensions import Literal, Self
 
 from aiokafka.record._protocols import (
     DefaultRecordBatchBuilderProtocol,

--- a/aiokafka/record/_crecords/legacy_records.pyi
+++ b/aiokafka/record/_crecords/legacy_records.pyi
@@ -1,7 +1,10 @@
-from collections.abc import Generator
-from typing import Any, ClassVar, final
+from __future__ import annotations
 
-from typing_extensions import Buffer, Literal, Never
+from collections.abc import Generator
+from typing import TYPE_CHECKING, Any, ClassVar, final
+
+if TYPE_CHECKING:
+    from typing_extensions import Buffer, Literal, Never
 
 from aiokafka.record._protocols import (
     LegacyRecordBatchBuilderProtocol,

--- a/aiokafka/record/_protocols.py
+++ b/aiokafka/record/_protocols.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Iterator
 from typing import (
+    TYPE_CHECKING,
     Any,
     ClassVar,
     Optional,
@@ -10,7 +11,8 @@ from typing import (
     runtime_checkable,
 )
 
-from typing_extensions import Literal, Never
+if TYPE_CHECKING:
+    from typing_extensions import Literal, Never
 
 from ._types import (
     CodecGzipT,

--- a/aiokafka/record/_types.py
+++ b/aiokafka/record/_types.py
@@ -1,6 +1,9 @@
-from typing import Union
+from __future__ import annotations
 
-from typing_extensions import Literal
+from typing import TYPE_CHECKING, Union
+
+if TYPE_CHECKING:
+    from typing_extensions import Literal
 
 CodecNoneT = Literal[0x00]
 CodecGzipT = Literal[0x01]

--- a/aiokafka/record/control_record.py
+++ b/aiokafka/record/control_record.py
@@ -1,7 +1,11 @@
+from __future__ import annotations
+
 import struct
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
-from typing_extensions import Self
+if TYPE_CHECKING:
+    from typing_extensions import Self
 
 _SCHEMA = struct.Struct(">HH")
 

--- a/aiokafka/record/default_records.py
+++ b/aiokafka/record/default_records.py
@@ -54,13 +54,16 @@
 # * Timestamp Type (3)
 # * Compression Type (0-2)
 
+from __future__ import annotations
+
 import struct
 import time
 from collections.abc import Sized
 from dataclasses import dataclass
-from typing import Any, Callable, Optional, Union, final
+from typing import TYPE_CHECKING, Any, Callable, Optional, Union, final
 
-from typing_extensions import Self, TypeIs, assert_never
+if TYPE_CHECKING:
+    from typing_extensions import Self, TypeIs, assert_never
 
 import aiokafka.codec as codecs
 from aiokafka.codec import (

--- a/aiokafka/record/legacy_records.py
+++ b/aiokafka/record/legacy_records.py
@@ -5,9 +5,10 @@ import time
 from binascii import crc32
 from collections.abc import Generator
 from dataclasses import dataclass
-from typing import Any, Optional, Union, final
+from typing import TYPE_CHECKING, Any, Optional, Union, final
 
-from typing_extensions import Literal, Never, TypeIs, assert_never
+if TYPE_CHECKING:
+    from typing_extensions import Literal, Never, TypeIs, assert_never
 
 import aiokafka.codec as codecs
 from aiokafka.codec import (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dynamic = ["version"]
 dependencies = [
     "async-timeout",
     "packaging",
-    "typing_extensions >=4.10.0",
+
 ]
 
 [project.optional-dependencies]

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -11,3 +11,4 @@ Pygments==2.18.0
 gssapi==1.9.0
 async-timeout==4.0.3
 cramjam==2.9.0
+typing_extensions>=4.10.0


### PR DESCRIPTION
<!-- Thank you for your contribution! 
Feel free to change the template if you feel confused.
-->
### Changes

Remove typing_extensions from run time requirements = less dependencies to install for users of aiokafka.

<!-- Please give a short brief about these changes. -->

### Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
