### PR TITLE
Handle node failure properly in sender

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,9 @@ Bugfixes:
 
 * Make KafkaStorageError retriable after metadata refresh like in other
   implementations (pr #1115 by @omerhadari)
+* Ensure the transaction coordinator is refreshed after broker fail‑over,
+  so transactional producers resume once a new coordinator is elected.
+  (pr #1135 by @vmaurin)
 
 
 Misc:


### PR DESCRIPTION
Various sender activities require the sender to talk to a dedicated coordinator node, for a related group or for transaction management.

When trying to reach this node, an error could happen because of the broker being unavailable or unreachable. In this case, we must mark the coordinator dead, so instead of retrying over and over to the same node, we will first try to find an active coordinator.

fixes #1134

<!-- Thank you for your contribution! 
Feel free to change the template if you feel confused.
-->
### Changes

Fixes #1134

<!-- Please give a short brief about these changes. -->

### Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
