### PR TITLE
Simplify flexible versions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,11 @@ New features:
   configured, the consumer will fetch from a same-rack follower instead of the
   partition leader, reducing cross-AZ traffic and tail latency.
   (prs #1159 and #1160 by @GlebShipilov)
+* Simplify flexible versions in schema.
+  Defining an API request or response schemas that should support
+  flexible versions (KIP-482) is now achieved by setting `FLEXIBLE_VERSION` to True.
+  Tagged fields could be expressed with ("name", tag) instead of just a name.
+  (pr #1139 by @vmaurin)
 
 Bugfixes:
 

--- a/aiokafka/conn.py
+++ b/aiokafka/conn.py
@@ -428,10 +428,11 @@ class AIOKafkaConnection:
             ) from err
 
         log.debug(
-            "Request to %s:%d %d: %s",
+            "Request to %s:%d %d: %s, %s",
             self._host,
             self._port,
             correlation_id,
+            header,
             request_struct,
         )
 
@@ -565,10 +566,11 @@ class AIOKafkaConnection:
             if not fut.done():
                 response = resp_type.decode(resp)
                 log.debug(
-                    "Response from %s:%d %d: %s",
+                    "Response from %s:%d %d: %s, %s",
                     self._host,
                     self._port,
                     correlation_id,
+                    response_header,
                     response,
                 )
                 fut.set_result(response)

--- a/aiokafka/protocol/abstract.py
+++ b/aiokafka/protocol/abstract.py
@@ -8,11 +8,11 @@ T = TypeVar("T")
 class AbstractType(Generic[T], metaclass=abc.ABCMeta):
     @classmethod
     @abc.abstractmethod
-    def encode(cls, value: T) -> bytes: ...
+    def encode(cls, value: T, flexible: bool) -> bytes: ...
 
     @classmethod
     @abc.abstractmethod
-    def decode(cls, data: BytesIO) -> T: ...
+    def decode(cls, data: BytesIO, flexible: bool) -> T: ...
 
     @classmethod
     def repr(cls, value: T) -> str:

--- a/aiokafka/protocol/admin.py
+++ b/aiokafka/protocol/admin.py
@@ -8,8 +8,6 @@ from .types import (
     Array,
     Boolean,
     Bytes,
-    CompactArray,
-    CompactString,
     Float64,
     Int8,
     Int16,
@@ -17,7 +15,6 @@ from .types import (
     Int64,
     Schema,
     String,
-    TaggedFields,
 )
 
 
@@ -1453,53 +1450,48 @@ class DescribeClientQuotasRequest(Request[DescribeClientQuotasRequestStruct]):
 class AlterPartitionReassignmentsResponse_v0(Response):
     API_KEY = 45
     API_VERSION = 0
+    FLEXIBLE_VERSION = True
     SCHEMA = Schema(
         ("throttle_time_ms", Int32),
         ("error_code", Int16),
-        ("error_message", CompactString("utf-8")),
+        ("error_message", String("utf-8")),
         (
             "responses",
-            CompactArray(
-                ("name", CompactString("utf-8")),
+            Array(
+                ("name", String("utf-8")),
                 (
                     "partitions",
-                    CompactArray(
+                    Array(
                         ("partition_index", Int32),
                         ("error_code", Int16),
-                        ("error_message", CompactString("utf-8")),
-                        ("tags", TaggedFields),
+                        ("error_message", String("utf-8")),
                     ),
                 ),
-                ("tags", TaggedFields),
             ),
         ),
-        ("tags", TaggedFields),
     )
 
 
 class AlterPartitionReassignmentsRequest_v0(RequestStruct):
-    FLEXIBLE_VERSION = True
     API_KEY = 45
     API_VERSION = 0
+    FLEXIBLE_VERSION = True
     RESPONSE_TYPE = AlterPartitionReassignmentsResponse_v0
     SCHEMA = Schema(
         ("timeout_ms", Int32),
         (
             "topics",
-            CompactArray(
-                ("name", CompactString("utf-8")),
+            Array(
+                ("name", String("utf-8")),
                 (
                     "partitions",
-                    CompactArray(
+                    Array(
                         ("partition_index", Int32),
-                        ("replicas", CompactArray(Int32)),
-                        ("tags", TaggedFields),
+                        ("replicas", Array(Int32)),
                     ),
                 ),
-                ("tags", TaggedFields),
             ),
         ),
-        ("tags", TaggedFields),
     )
 
 
@@ -1516,44 +1508,40 @@ class AlterPartitionReassignmentsRequest(
     def __init__(
         self,
         timeout_ms: int,
-        topics: list[tuple[str, tuple[int, list[int], TaggedFields], TaggedFields]],
-        tags: TaggedFields,
+        topics: list[tuple[str, tuple[int, list[int]]]],
     ):
         self._timeout_ms = timeout_ms
         self._topics = topics
-        self._tags = tags
 
     def build(
         self, request_struct_class: type[AlterPartitionReassignmentsRequestStruct]
     ) -> AlterPartitionReassignmentsRequestStruct:
-        return request_struct_class(self._timeout_ms, self._topics, self._tags)
+        return request_struct_class(self._timeout_ms, self._topics)
 
 
 class ListPartitionReassignmentsResponse_v0(Response):
     API_KEY = 46
     API_VERSION = 0
+    FLEXIBLE_VERSION = True
     SCHEMA = Schema(
         ("throttle_time_ms", Int32),
         ("error_code", Int16),
-        ("error_message", CompactString("utf-8")),
+        ("error_message", String("utf-8")),
         (
             "topics",
-            CompactArray(
-                ("name", CompactString("utf-8")),
+            Array(
+                ("name", String("utf-8")),
                 (
                     "partitions",
-                    CompactArray(
+                    Array(
                         ("partition_index", Int32),
-                        ("replicas", CompactArray(Int32)),
-                        ("adding_replicas", CompactArray(Int32)),
-                        ("removing_replicas", CompactArray(Int32)),
-                        ("tags", TaggedFields),
+                        ("replicas", Array(Int32)),
+                        ("adding_replicas", Array(Int32)),
+                        ("removing_replicas", Array(Int32)),
                     ),
                 ),
-                ("tags", TaggedFields),
             ),
         ),
-        ("tags", TaggedFields),
     )
 
 
@@ -1566,13 +1554,11 @@ class ListPartitionReassignmentsRequest_v0(RequestStruct):
         ("timeout_ms", Int32),
         (
             "topics",
-            CompactArray(
-                ("name", CompactString("utf-8")),
-                ("partition_index", CompactArray(Int32)),
-                ("tags", TaggedFields),
+            Array(
+                ("name", String("utf-8")),
+                ("partition_index", Array(Int32)),
             ),
         ),
-        ("tags", TaggedFields),
     )
 
 
@@ -1589,17 +1575,15 @@ class ListPartitionReassignmentsRequest(
     def __init__(
         self,
         timeout_ms: int,
-        topics: list[tuple[str, tuple[int, list[int], TaggedFields], TaggedFields]],
-        tags: TaggedFields,
+        topics: list[tuple[str, tuple[int, list[int]]]],
     ):
         self._timeout_ms = timeout_ms
         self._topics = topics
-        self._tags = tags
 
     def build(
         self, request_struct_class: type[ListPartitionReassignmentsRequestStruct]
     ) -> ListPartitionReassignmentsRequestStruct:
-        return request_struct_class(self._timeout_ms, self._topics, self._tags)
+        return request_struct_class(self._timeout_ms, self._topics)
 
 
 class DeleteRecordsResponse_v0(Response):
@@ -1633,26 +1617,8 @@ class DeleteRecordsResponse_v1(Response):
 class DeleteRecordsResponse_v2(Response):
     API_KEY = 21
     API_VERSION = 2
-    SCHEMA = Schema(
-        ("throttle_time_ms", Int32),
-        (
-            "topics",
-            CompactArray(
-                ("name", CompactString("utf-8")),
-                (
-                    "partitions",
-                    CompactArray(
-                        ("partition_index", Int32),
-                        ("low_watermark", Int64),
-                        ("error_code", Int16),
-                        ("tags", TaggedFields),
-                    ),
-                ),
-                ("tags", TaggedFields),
-            ),
-        ),
-        ("tags", TaggedFields),
-    )
+    FLEXIBLE_VERSION = True
+    SCHEMA = DeleteRecordsResponse_v0.SCHEMA
 
 
 class DeleteRecordsRequest_v0(RequestStruct):
@@ -1689,25 +1655,7 @@ class DeleteRecordsRequest_v2(RequestStruct):
     API_VERSION = 2
     FLEXIBLE_VERSION = True
     RESPONSE_TYPE = DeleteRecordsResponse_v2
-    SCHEMA = Schema(
-        (
-            "topics",
-            CompactArray(
-                ("name", CompactString("utf-8")),
-                (
-                    "partitions",
-                    CompactArray(
-                        ("partition_index", Int32),
-                        ("offset", Int64),
-                        ("tags", TaggedFields),
-                    ),
-                ),
-                ("tags", TaggedFields),
-            ),
-        ),
-        ("timeout_ms", Int32),
-        ("tags", TaggedFields),
-    )
+    SCHEMA = DeleteRecordsRequest_v0.SCHEMA
 
 
 DeleteRecordsRequestStruct: TypeAlias = (
@@ -1722,43 +1670,20 @@ class DeleteRecordsRequest(Request[DeleteRecordsRequestStruct]):
         self,
         topics: Iterable[tuple[str, Iterable[tuple[int, int]]]],
         timeout_ms: int,
-        tags: dict[int, bytes] | None = None,
     ) -> None:
         self._topics = topics
         self._timeout_ms = timeout_ms
-        self._tags = tags
 
     def build(
         self, request_struct_class: type[DeleteRecordsRequestStruct]
     ) -> DeleteRecordsRequestStruct:
-        if request_struct_class.API_VERSION < 2:
-            if self._tags is not None:
-                raise IncompatibleBrokerVersion(
-                    "tags requires DeleteRecordsRequest >= v2"
-                )
-
-            return request_struct_class(
-                [
-                    (
-                        topic,
-                        list(partitions),
-                    )
-                    for (topic, partitions) in self._topics
-                ],
-                self._timeout_ms,
-            )
         return request_struct_class(
             [
                 (
                     topic,
-                    [
-                        (partition, before_offset, {})
-                        for partition, before_offset in partitions
-                    ],
-                    {},
+                    list(partitions),
                 )
                 for (topic, partitions) in self._topics
             ],
             self._timeout_ms,
-            self._tags or {},
         )

--- a/aiokafka/protocol/struct.py
+++ b/aiokafka/protocol/struct.py
@@ -8,6 +8,7 @@ from .types import Schema
 
 class Struct:
     SCHEMA: ClassVar = Schema()
+    FLEXIBLE_VERSION: ClassVar[bool] = False
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         if len(args) == len(self.SCHEMA.fields):
@@ -26,13 +27,15 @@ class Struct:
                 )
 
     def encode(self) -> bytes:
-        return self.SCHEMA.encode([self.__dict__[name] for name in self.SCHEMA.names])
+        return self.SCHEMA.encode(
+            [self.__dict__[name] for name in self.SCHEMA.names], self.FLEXIBLE_VERSION
+        )
 
     @classmethod
     def decode(cls, data: BytesIO | bytes) -> Self:
         if isinstance(data, bytes):
             data = BytesIO(data)
-        return cls(*[field.decode(data) for field in cls.SCHEMA.fields])
+        return cls(*cls.SCHEMA.decode(data, cls.FLEXIBLE_VERSION))
 
     def get_item(self, name: str) -> Any:
         if name not in self.SCHEMA.names:

--- a/aiokafka/protocol/types.py
+++ b/aiokafka/protocol/types.py
@@ -19,6 +19,10 @@ T = TypeVar("T")
 
 ValueT: TypeAlias = Union[type[AbstractType[Any]], "String", "Array", "Schema"]
 
+TaggedFieldId: TypeAlias = tuple[str, int]
+
+FieldId: TypeAlias = TaggedFieldId | str
+
 
 def _pack(f: Callable[[T], bytes], value: T) -> bytes:
     try:
@@ -47,11 +51,11 @@ class Int8(AbstractType[int]):
     _unpack = struct.Struct(">b").unpack
 
     @classmethod
-    def encode(cls, value: int) -> bytes:
+    def encode(cls, value: int, flexible: bool = False) -> bytes:
         return _pack(cls._pack, value)
 
     @classmethod
-    def decode(cls, data: BytesIO) -> int:
+    def decode(cls, data: BytesIO, flexible: bool = False) -> int:
         return _unpack(cls._unpack, data.read(1))
 
 
@@ -60,11 +64,11 @@ class Int16(AbstractType[int]):
     _unpack = struct.Struct(">h").unpack
 
     @classmethod
-    def encode(cls, value: int) -> bytes:
+    def encode(cls, value: int, flexible: bool = False) -> bytes:
         return _pack(cls._pack, value)
 
     @classmethod
-    def decode(cls, data: BytesIO) -> int:
+    def decode(cls, data: BytesIO, flexible: bool = False) -> int:
         return _unpack(cls._unpack, data.read(2))
 
 
@@ -73,11 +77,11 @@ class Int32(AbstractType[int]):
     _unpack = struct.Struct(">i").unpack
 
     @classmethod
-    def encode(cls, value: int) -> bytes:
+    def encode(cls, value: int, flexible: bool = False) -> bytes:
         return _pack(cls._pack, value)
 
     @classmethod
-    def decode(cls, data: BytesIO) -> int:
+    def decode(cls, data: BytesIO, flexible: bool = False) -> int:
         return _unpack(cls._unpack, data.read(4))
 
 
@@ -86,11 +90,11 @@ class UInt32(AbstractType[int]):
     _unpack = struct.Struct(">I").unpack
 
     @classmethod
-    def encode(cls, value: int) -> bytes:
+    def encode(cls, value: int, flexible: bool = False) -> bytes:
         return _pack(cls._pack, value)
 
     @classmethod
-    def decode(cls, data: BytesIO) -> int:
+    def decode(cls, data: BytesIO, flexible: bool = False) -> int:
         return _unpack(cls._unpack, data.read(4))
 
 
@@ -99,11 +103,11 @@ class Int64(AbstractType[int]):
     _unpack = struct.Struct(">q").unpack
 
     @classmethod
-    def encode(cls, value: int) -> bytes:
+    def encode(cls, value: int, flexible: bool = False) -> bytes:
         return _pack(cls._pack, value)
 
     @classmethod
-    def decode(cls, data: BytesIO) -> int:
+    def decode(cls, data: BytesIO, flexible: bool = False) -> int:
         return _unpack(cls._unpack, data.read(8))
 
 
@@ -112,26 +116,39 @@ class Float64(AbstractType[float]):
     _unpack = struct.Struct(">d").unpack
 
     @classmethod
-    def encode(cls, value: float) -> bytes:
+    def encode(cls, value: float, flexible: bool = False) -> bytes:
         return _pack(cls._pack, value)
 
     @classmethod
-    def decode(cls, data: BytesIO) -> float:
+    def decode(cls, data: BytesIO, flexible: bool = False) -> float:
         return _unpack(cls._unpack, data.read(8))
 
 
 class String:
-    def __init__(self, encoding: str = "utf-8"):
+    def __init__(self, encoding: str = "utf-8", allow_flexible: bool = True):
         self.encoding = encoding
+        self.allow_flexible = allow_flexible
 
-    def encode(self, value: str | None) -> bytes:
+    def encode(self, value: str | None, flexible: bool) -> bytes:
         if value is None:
-            return Int16.encode(-1)
+            return (
+                UnsignedVarInt32.encode(0)
+                if flexible and self.allow_flexible
+                else Int16.encode(-1, flexible)
+            )
         encoded_value = str(value).encode(self.encoding)
-        return Int16.encode(len(encoded_value)) + encoded_value
+        return (
+            UnsignedVarInt32.encode(len(encoded_value) + 1) + encoded_value
+            if flexible and self.allow_flexible
+            else Int16.encode(len(encoded_value), flexible) + encoded_value
+        )
 
-    def decode(self, data: BytesIO) -> str | None:
-        length = Int16.decode(data)
+    def decode(self, data: BytesIO, flexible: bool) -> str | None:
+        length = (
+            UnsignedVarInt32.decode(data) - 1
+            if flexible and self.allow_flexible
+            else Int16.decode(data, flexible)
+        )
         if length < 0:
             return None
         value = data.read(length)
@@ -146,15 +163,25 @@ class String:
 
 class Bytes(AbstractType[bytes | None]):
     @classmethod
-    def encode(cls, value: bytes | None) -> bytes:
+    def encode(cls, value: bytes | None, flexible: bool) -> bytes:
         if value is None:
-            return Int32.encode(-1)
+            return (
+                UnsignedVarInt32.encode(0) if flexible else Int32.encode(-1, flexible)
+            )
         else:
-            return Int32.encode(len(value)) + value
+            return (
+                UnsignedVarInt32.encode(len(value) + 1) + value
+                if flexible
+                else Int32.encode(len(value), flexible) + value
+            )
 
     @classmethod
-    def decode(cls, data: BytesIO) -> bytes | None:
-        length = Int32.decode(data)
+    def decode(cls, data: BytesIO, flexible: bool) -> bytes | None:
+        length = (
+            UnsignedVarInt32.decode(data) - 1
+            if flexible
+            else Int32.decode(data, flexible)
+        )
         if length < 0:
             return None
         value = data.read(length)
@@ -174,33 +201,94 @@ class Boolean(AbstractType[bool]):
     _unpack = struct.Struct(">?").unpack
 
     @classmethod
-    def encode(cls, value: bool) -> bytes:
+    def encode(cls, value: bool, flexible: bool) -> bytes:
         return _pack(cls._pack, value)
 
     @classmethod
-    def decode(cls, data: BytesIO) -> bool:
+    def decode(cls, data: BytesIO, flexible: bool) -> bool:
         return _unpack(cls._unpack, data.read(1))
 
 
 class Schema:
     names: tuple[str, ...]
+    tags: tuple[int, ...]
     fields: tuple[ValueT, ...]
 
-    def __init__(self, *fields: tuple[str, ValueT]):
+    def __init__(self, *fields: tuple[FieldId, ValueT]):
         if fields:
-            self.names, self.fields = zip(*fields, strict=False)
+            tagged_names, values = zip(
+                *(
+                    (key, value) if isinstance(key, tuple) else ((key, None), value)
+                    for key, value in fields
+                ),
+                strict=False,
+            )
+            self.names = tuple(name for name, _ in tagged_names)
+            self.tags = tuple(tag for _, tag in tagged_names)
+            self.fields = tuple(values)
         else:
-            self.names, self.fields = (), ()
+            self.names, self.tags, self.fields = (), (), ()
 
-    def encode(self, item: Sequence[Any]) -> bytes:
+    def encode(self, item: Sequence[Any], flexible: bool) -> bytes:
         if len(item) != len(self.fields):
             raise ValueError("Item field count does not match Schema")
-        return b"".join(field.encode(item[i]) for i, field in enumerate(self.fields))
+        return b"".join(
+            field.encode(item[i], flexible)
+            for i, field in enumerate(self.fields)
+            if self.tags[i] is None
+        ) + (
+            self._encode_tagged_fields(
+                {
+                    self.tags[i]: field.encode(item[i], flexible)
+                    for i, field in enumerate(self.fields)
+                    if self.tags[i] is not None
+                }
+            )
+            if flexible
+            else b""
+        )
 
     def decode(
-        self, data: BytesIO
+        self, data: BytesIO, flexible: bool
     ) -> tuple[Any | str | None | list[Any | tuple[Any, ...]], ...]:
-        return tuple(field.decode(data) for field in self.fields)
+        result = [
+            field.decode(data, flexible) if self.tags[i] is None else None
+            for i, field in enumerate(self.fields)
+        ]
+        if flexible:
+            tagged_fields = self._decode_tagged_fields(data)
+            for i, tag in enumerate(self.tags):
+                if tag is not None:
+                    encoded_value = tagged_fields.get(tag)
+                    if encoded_value is not None:
+                        result[i] = self.fields[i].decode(
+                            BytesIO(encoded_value), flexible
+                        )
+
+        return tuple(result)
+
+    @staticmethod
+    def _encode_tagged_fields(value: dict[int, bytes]) -> bytes:
+        ret = UnsignedVarInt32.encode(len(value))
+        for k, v in value.items():
+            assert isinstance(k, int) and k >= 0, f"Key {k} is not a positive integer"
+            ret += UnsignedVarInt32.encode(k)
+            ret += UnsignedVarInt32.encode(len(v))
+            ret += v
+        return ret
+
+    @staticmethod
+    def _decode_tagged_fields(data: BytesIO) -> dict[int, bytes]:
+        num_fields = UnsignedVarInt32.decode(data)
+        ret: dict[int, bytes] = {}
+        if not num_fields:
+            return ret
+        for _ in range(num_fields):
+            tag = UnsignedVarInt32.decode(data)
+            size = UnsignedVarInt32.decode(data)
+            val = data.read(size)
+            ret[tag] = val
+        return ret
 
     def __len__(self) -> int:
         return len(self.fields)
@@ -227,16 +315,18 @@ class Array:
 
     @overload
     def __init__(
-        self, array_of_0: tuple[str, ValueT], *array_of: tuple[str, ValueT]
+        self,
+        array_of_0: tuple[FieldId, ValueT],
+        *array_of: tuple[FieldId, ValueT],
     ): ...
 
     def __init__(
         self,
-        array_of_0: ValueT | tuple[str, ValueT],
-        *array_of: tuple[str, ValueT],
+        array_of_0: ValueT | tuple[FieldId, ValueT],
+        *array_of: tuple[FieldId, ValueT],
     ) -> None:
         if array_of:
-            array_of_0 = cast(tuple[str, ValueT], array_of_0)
+            array_of_0 = cast(tuple[FieldId, ValueT], array_of_0)
             self.array_of = Schema(array_of_0, *array_of)
         else:
             array_of_0 = cast(ValueT, array_of_0)
@@ -247,19 +337,33 @@ class Array:
             else:
                 raise ValueError("Array instantiated with no array_of type")
 
-    def encode(self, items: Sequence[Any] | None) -> bytes:
+    def encode(self, items: Sequence[Any] | None, flexible: bool) -> bytes:
         if items is None:
-            return Int32.encode(-1)
-        encoded_items = (self.array_of.encode(item) for item in items)
-        return b"".join(
-            (Int32.encode(len(items)), *encoded_items),
+            return (
+                UnsignedVarInt32.encode(0) if flexible else Int32.encode(-1, flexible)
+            )
+        encoded_items = (self.array_of.encode(item, flexible) for item in items)
+        return (
+            b"".join(
+                (UnsignedVarInt32.encode(len(items) + 1), *encoded_items),
+            )
+            if flexible
+            else b"".join(
+                (Int32.encode(len(items), flexible), *encoded_items),
+            )
         )
 
-    def decode(self, data: BytesIO) -> list[Any | tuple[Any, ...]] | None:
-        length = Int32.decode(data)
+    def decode(
+        self, data: BytesIO, flexible: bool
+    ) -> list[Any | tuple[Any, ...]] | None:
+        length = (
+            UnsignedVarInt32.decode(data) - 1
+            if flexible
+            else Int32.decode(data, flexible)
+        )
         if length == -1:
             return None
-        return [self.array_of.decode(data) for _ in range(length)]
+        return [self.array_of.decode(data, flexible) for _ in range(length)]
 
     def repr(self, list_of_items: Sequence[Any] | None) -> str:
         if list_of_items is None:
@@ -267,7 +371,7 @@ class Array:
         return "[" + ", ".join(self.array_of.repr(item) for item in list_of_items) + "]"
 
 
-class UnsignedVarInt32(AbstractType[int]):
+class UnsignedVarInt32:
     @classmethod
     def decode(cls, data: BytesIO) -> int:
         value, i = 0, 0
@@ -293,128 +397,3 @@ class UnsignedVarInt32(AbstractType[int]):
             value >>= 7
         ret += struct.pack("B", value)
         return ret
-
-
-class VarInt32(AbstractType[int]):
-    @classmethod
-    def decode(cls, data: BytesIO) -> int:
-        value = UnsignedVarInt32.decode(data)
-        return (value >> 1) ^ -(value & 1)
-
-    @classmethod
-    def encode(cls, value: int) -> bytes:
-        # bring it in line with the java binary repr
-        value &= 0xFFFFFFFF
-        return UnsignedVarInt32.encode((value << 1) ^ (value >> 31))
-
-
-class VarInt64(AbstractType[int]):
-    @classmethod
-    def decode(cls, data: BytesIO) -> int:
-        value, i = 0, 0
-        b: int
-        while True:
-            (b,) = struct.unpack("B", data.read(1))
-            if not (b & 0x80):
-                break
-            value |= (b & 0x7F) << i
-            i += 7
-            if i > 63:
-                raise ValueError(f"Invalid value {value}")
-        value |= b << i
-        return (value >> 1) ^ -(value & 1)
-
-    @classmethod
-    def encode(cls, value: int) -> bytes:
-        # bring it in line with the java binary repr
-        value &= 0xFFFFFFFFFFFFFFFF
-        v = (value << 1) ^ (value >> 63)
-        ret = b""
-        while (v & 0xFFFFFFFFFFFFFF80) != 0:
-            b = (value & 0x7F) | 0x80
-            ret += struct.pack("B", b)
-            v >>= 7
-        ret += struct.pack("B", v)
-        return ret
-
-
-class CompactString(String):
-    def decode(self, data: BytesIO) -> str | None:
-        length = UnsignedVarInt32.decode(data) - 1
-        if length < 0:
-            return None
-        value = data.read(length)
-        if len(value) != length:
-            raise ValueError("Buffer underrun decoding string")
-        return value.decode(self.encoding)
-
-    def encode(self, value: str | None) -> bytes:
-        if value is None:
-            return UnsignedVarInt32.encode(0)
-        encoded_value = str(value).encode(self.encoding)
-        return UnsignedVarInt32.encode(len(encoded_value) + 1) + encoded_value
-
-
-class TaggedFields(AbstractType[dict[int, bytes]]):
-    @classmethod
-    def decode(cls, data: BytesIO) -> dict[int, bytes]:
-        num_fields = UnsignedVarInt32.decode(data)
-        ret: dict[int, bytes] = {}
-        if not num_fields:
-            return ret
-        prev_tag = -1
-        for _ in range(num_fields):
-            tag = UnsignedVarInt32.decode(data)
-            if tag <= prev_tag:
-                raise ValueError(f"Invalid or out-of-order tag {tag}")
-            prev_tag = tag
-            size = UnsignedVarInt32.decode(data)
-            val = data.read(size)
-            ret[tag] = val
-        return ret
-
-    @classmethod
-    def encode(cls, value: dict[int, bytes]) -> bytes:
-        ret = UnsignedVarInt32.encode(len(value))
-        for k, v in value.items():
-            # do we allow for other data types ?? It could get complicated really fast
-            assert isinstance(v, bytes), f"Value {v!r} is not a byte array"
-            assert isinstance(k, int) and k > 0, f"Key {k} is not a positive integer"
-            ret += UnsignedVarInt32.encode(k)
-            ret += v
-        return ret
-
-
-class CompactBytes(AbstractType[bytes | None]):
-    @classmethod
-    def decode(cls, data: BytesIO) -> bytes | None:
-        length = UnsignedVarInt32.decode(data) - 1
-        if length < 0:
-            return None
-        value = data.read(length)
-        if len(value) != length:
-            raise ValueError("Buffer underrun decoding Bytes")
-        return value
-
-    @classmethod
-    def encode(cls, value: bytes | None) -> bytes:
-        if value is None:
-            return UnsignedVarInt32.encode(0)
-        else:
-            return UnsignedVarInt32.encode(len(value) + 1) + value
-
-
-class CompactArray(Array):
-    def encode(self, items: Sequence[Any] | None) -> bytes:
-        if items is None:
-            return UnsignedVarInt32.encode(0)
-        encoded_items = (self.array_of.encode(item) for item in items)
-        return b"".join(
-            (UnsignedVarInt32.encode(len(items) + 1), *encoded_items),
-        )
-
-    def decode(self, data: BytesIO) -> list[Any | tuple[Any, ...]] | None:
-        length = UnsignedVarInt32.decode(data) - 1
-        if length == -1:
-            return None
-        return [self.array_of.decode(data) for _ in range(length)]

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -357,22 +357,22 @@ cases = [
         ],
     ),
     (
-        AlterPartitionReassignmentsRequest(timeout_ms=100, topics=[], tags={}),
+        AlterPartitionReassignmentsRequest(timeout_ms=100, topics=[]),
         [
             Versions(expected=IncompatibleBrokerVersion),
             Versions(
                 max_version=0,
-                expected=AlterPartitionReassignmentsRequest_v0(100, [], {}),
+                expected=AlterPartitionReassignmentsRequest_v0(100, []),
             ),
         ],
     ),
     (
-        ListPartitionReassignmentsRequest(timeout_ms=200, topics=[], tags={}),
+        ListPartitionReassignmentsRequest(timeout_ms=200, topics=[]),
         [
             Versions(expected=IncompatibleBrokerVersion),
             Versions(
                 max_version=0,
-                expected=ListPartitionReassignmentsRequest_v0(200, [], {}),
+                expected=ListPartitionReassignmentsRequest_v0(200, []),
             ),
         ],
     ),
@@ -388,16 +388,9 @@ cases = [
                 max_version=1,
                 expected=DeleteRecordsRequest_v1([("t1", [(0, 123)])], 50),
             ),
-        ],
-    ),
-    (
-        DeleteRecordsRequest(topics=[("t1", [(0, 123)])], timeout_ms=50, tags={}),
-        [
-            Versions(expected=IncompatibleBrokerVersion),
-            Versions(max_version=1, expected=IncompatibleBrokerVersion),
             Versions(
                 max_version=2,
-                expected=DeleteRecordsRequest_v2([("t1", [(0, 123, {})], {})], 50, {}),
+                expected=DeleteRecordsRequest_v2([("t1", [(0, 123)])], 50),
             ),
         ],
     ),


### PR DESCRIPTION
The flexible versions is a protocol specificity for newer versions of the API. When an API is flexible, it is using more compact structures and also allow additional "dynamic" fields that could be added without the need to introduce a new API versions.

This commit move the flexible versions support to the protocol layer, so it is more transparent and easy when defining Struct classes and schemas.

When defining the schema, we can specify a tagged field with a tuple containing the field name and the field tag.

<!-- Thank you for your contribution! 
Feel free to change the template if you feel confused.
-->

### Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
