### PR TITLE
Rename RequestHeader_vX classes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,8 @@ Bugfixes:
 * Ensure the transaction coordinator is refreshed after broker fail‑over,
   so transactional producers resume once a new coordinator is elected.
   (pr #1135 by @vmaurin)
+* Rename the RequestHeader version classes to match official version
+  schemas (pr #1141 by @vmaurin)
 
 
 Misc:

--- a/aiokafka/protocol/api.py
+++ b/aiokafka/protocol/api.py
@@ -11,7 +11,7 @@ from .struct import Struct
 from .types import Array, Int16, Int32, Schema, String, TaggedFields
 
 
-class RequestHeader_v0(Struct):
+class RequestHeader_v1(Struct):
     SCHEMA = Schema(
         ("api_key", Int16),
         ("api_version", Int16),
@@ -30,7 +30,7 @@ class RequestHeader_v0(Struct):
         )
 
 
-class RequestHeader_v1(Struct):
+class RequestHeader_v2(Struct):
     # Flexible response / request headers end in field buffer
     SCHEMA = Schema(
         ("api_key", Int16),
@@ -185,12 +185,12 @@ class RequestStruct(Struct, metaclass=abc.ABCMeta):
 
     def build_request_header(
         self, correlation_id: int, client_id: str
-    ) -> RequestHeader_v0 | RequestHeader_v1:
+    ) -> RequestHeader_v1 | RequestHeader_v2:
         if self.FLEXIBLE_VERSION:
-            return RequestHeader_v1(
+            return RequestHeader_v2(
                 self, correlation_id=correlation_id, client_id=client_id
             )
-        return RequestHeader_v0(
+        return RequestHeader_v1(
             self, correlation_id=correlation_id, client_id=client_id
         )
 

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -3,7 +3,7 @@ import struct
 
 import pytest
 
-from aiokafka.protocol.api import RequestHeader_v0, RequestStruct, Response
+from aiokafka.protocol.api import RequestHeader_v1, RequestStruct, Response
 from aiokafka.protocol.coordination import FindCoordinatorRequest_v0
 from aiokafka.protocol.fetch import FetchRequest_v0, FetchResponse_v0
 from aiokafka.protocol.message import Message, MessageSet, PartialMessage
@@ -192,7 +192,7 @@ def test_encode_message_header() -> None:
     )
 
     req = FindCoordinatorRequest_v0("foo")
-    header = RequestHeader_v0(req, correlation_id=4, client_id="client3")
+    header = RequestHeader_v1(req, correlation_id=4, client_id="client3")
     assert header.encode() == expect
 
 


### PR DESCRIPTION
According the java client schema, v0 was a version only used for ControlledShutdownRequest.

The first version to have a client id was version 1.

https://github.com/apache/kafka/blob/2.8.1/clients/src/main/resources/common/message/RequestHeader.json

There could have been a confusion as in KIP-482, the v2 is named "version 1".

https://cwiki.apache.org/confluence/display/KAFKA/KIP-482%3A+The+Kafka+Protocol+should+Support+Optional+Tagged+Fields

<!-- Thank you for your contribution! 
Feel free to change the template if you feel confused.
-->
### Changes

Fixes #<!-- Provide issue number if exists -->

<!-- Please give a short brief about these changes. -->

### Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
