### PR TITLE
Force metadata refresh when a coordinator is dead

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ Bugfixes:
 * Fix type annotation for `AIOKafkaAdminClient` (issue #1148)
 * Return back and deprecate `api_version` parameter in client classes
   (issue #1147)
+* Avoid failures when a transaction coordinator is dead
+  (issue #1151)
 
 
 0.13.0 (2026-01-02)

--- a/aiokafka/client.py
+++ b/aiokafka/client.py
@@ -397,15 +397,15 @@ class AIOKafkaClient:
         try:
             if group == ConnectionGroup.DEFAULT:
                 broker = self.cluster.broker_metadata(node_id)
-                # XXX: earlier we only did an assert here, but it seems it's
-                # possible to get a leader that is for some reason not in
-                # metadata.
-                # I think requiring metadata should solve this problem
-                if broker is None:
-                    raise StaleMetadata(f"Broker id {node_id} not in current metadata")
             else:
                 broker = self.cluster.coordinator_metadata(node_id)
-                assert broker is not None
+
+            # XXX: earlier we only did an asserts, but it seems it's
+            # possible to get a leader/coordinator that is for
+            # some reason not in metadata.
+            # I think requiring metadata should solve this problem
+            if broker is None:
+                raise StaleMetadata(f"Broker id {node_id} not in current metadata")
 
             log.debug(
                 "Initiating connection to node %s at %s:%s",
@@ -436,10 +436,9 @@ class AIOKafkaClient:
                 )
         except (OSError, asyncio.TimeoutError, KafkaError) as err:
             log.error("Unable connect to node with id %s: %s", node_id, err)
-            if group == ConnectionGroup.DEFAULT:
-                # Connection failures imply that our metadata is stale, so
-                # let's refresh
-                self.force_metadata_update()
+            # Connection failures imply that our metadata is stale, so
+            # let's refresh
+            self.force_metadata_update()
             return None
         else:
             return self._conns[conn_id]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -143,6 +143,9 @@ class TestKafkaClientIntegration(KafkaIntegrationTestCase):
         with self.assertRaises(NodeNotReadyError):
             await client.send(0, None)
 
+        with self.assertRaises(NodeNotReadyError):
+            await client.send(0, None, group=ConnectionGroup.COORDINATION)
+
         self.assertEqual(md.unauthorized_topics, {"topic_auth_error"})
 
     @run_until_complete


### PR DESCRIPTION
<!-- Thank you for your contribution! 
Feel free to change the template if you feel confused.
-->
### Changes

Fixes #1151

<!-- Please give a short brief about these changes. -->

While doing transactional producing, commiting offets attached to a transaction is achieved by sending a message to the coordinator responsible of the consumer group.

It might be that when reaching this node, it is actually dead. We had previously an assert being made, making the whole "ready" test to explode instead of raising a NodeNotReady exception.

By replacing the assert by refreshing metadata and returning None, we behave the same as trying to find a broker for no groups.

### Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
