### PR TITLE
Add public coordinator_state property to AIOKafkaConsumer (fixes #1154)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,14 @@ Changelog
 0.14.0 (????-??-??)
 ===================
 
+Features:
+
+* Add ``AIOKafkaConsumer.coordinator_state`` property exposing the current
+  coordinator health as a string (``"STABLE"``, ``"REBALANCING"``,
+  ``"PENDING_ERROR"``, ``"COORDINATOR_DEAD"``, or ``"STOPPED"``), replacing
+  the need to inspect private attributes for health checks after broker
+  restarts or group rebalances (issue #1154)
+
 Bugfixes:
 
 * Fix type annotation for `AIOKafkaAdminClient` (issue #1148)

--- a/aiokafka/consumer/consumer.py
+++ b/aiokafka/consumer/consumer.py
@@ -494,6 +494,36 @@ class AIOKafkaConsumer:
         """
         return self._subscription.assigned_partitions()
 
+    @property
+    def coordinator_state(self):
+        """Return the current coordinator state.
+
+        Useful for health checks after broker restarts or group rebalances.
+        Returns one of the following strings:
+
+        * ``"STABLE"`` — the consumer has joined its group and is operating
+          normally.
+        * ``"REBALANCING"`` — a rejoin is pending; this is transient and the
+          consumer should recover on its own.
+        * ``"PENDING_ERROR"`` — a fatal coordinator error is waiting to be
+          surfaced. The coordinator loop is paused until the error is consumed
+          by calling :meth:`getone` or :meth:`getmany`. If your polling loop
+          has stopped, the consumer will not recover until you resume it or
+          restart the consumer.
+        * ``"COORDINATOR_DEAD"`` — the coordination background task has
+          crashed. The consumer cannot recover and must be restarted.
+        * ``"STOPPED"`` — the consumer has not been started or has been closed.
+
+        Example health check::
+
+            if consumer.coordinator_state in ("COORDINATOR_DEAD", "PENDING_ERROR"):
+                # trigger a restart
+                ...
+        """
+        if self._closed or self._coordinator is None:
+            return "STOPPED"
+        return self._coordinator.coordinator_state
+
     async def stop(self):
         """Close the consumer, while waiting for finalizers:
 

--- a/aiokafka/consumer/group_coordinator.py
+++ b/aiokafka/consumer/group_coordinator.py
@@ -184,6 +184,10 @@ class NoGroupCoordinator(BaseCoordinator):
         if self._reset_committed_task.done():  # pragma: no cover
             self._reset_committed_task.result()
 
+    @property
+    def coordinator_state(self):
+        return "STABLE"
+
 
 class GroupCoordinator(BaseCoordinator):
     """
@@ -546,6 +550,29 @@ class GroupCoordinator(BaseCoordinator):
             bool: True if consumer should rejoin group, False otherwise
         """
         return subscription.assignment is None or self._rejoin_needed_fut.done()
+
+    @property
+    def coordinator_state(self):
+        """Current coordinator state string.
+
+        Returns one of:
+            ``"STABLE"``           — healthy, joined and operating normally.
+            ``"REBALANCING"``      — needs to rejoin; transient, recovers on
+                                     its own.
+            ``"PENDING_ERROR"``    — a fatal error is waiting to be consumed
+                                     via getone/getmany; the coordinator loop
+                                     is paused until then.
+            ``"COORDINATOR_DEAD"`` — the coordination background task has
+                                     crashed; the consumer cannot recover and
+                                     must be restarted.
+        """
+        if self._coordination_task.done():
+            return "COORDINATOR_DEAD"
+        if self._pending_exception is not None:
+            return "PENDING_ERROR"
+        if self._rejoin_needed_fut.done():
+            return "REBALANCING"
+        return "STABLE"
 
     async def ensure_coordinator_known(self):
         """Block until the coordinator for this group is known."""

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1471,3 +1471,83 @@ class TestKafkaCoordinatorIntegration(KafkaIntegrationTestCase):
 
         await coordinator.close()
         await client.close()
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for coordinator_state (no Kafka broker required)
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_coordinator():
+    """Return a GroupCoordinator with all internals replaced by mocks/futures."""
+    gc = GroupCoordinator.__new__(GroupCoordinator)
+    gc._coordination_task = create_future()  # pending = alive
+    gc._pending_exception = None
+    gc._rejoin_needed_fut = create_future()  # pending = stable
+    return gc
+
+
+async def test_group_coordinator_state_stable():
+    gc = _make_mock_coordinator()
+    assert gc.coordinator_state == "STABLE"
+
+
+async def test_group_coordinator_state_rebalancing():
+    gc = _make_mock_coordinator()
+    gc._rejoin_needed_fut.set_result(None)
+    assert gc.coordinator_state == "REBALANCING"
+
+
+async def test_group_coordinator_state_pending_error():
+    gc = _make_mock_coordinator()
+    gc._rejoin_needed_fut.set_result(None)
+    gc._pending_exception = Exception("test error")
+    assert gc.coordinator_state == "PENDING_ERROR"
+
+
+async def test_group_coordinator_state_coordinator_dead():
+    gc = _make_mock_coordinator()
+    gc._coordination_task.set_result(None)  # task finished = dead
+    assert gc.coordinator_state == "COORDINATOR_DEAD"
+
+
+async def test_group_coordinator_dead_takes_priority_over_pending_error():
+    gc = _make_mock_coordinator()
+    gc._coordination_task.set_result(None)
+    gc._pending_exception = Exception("test error")
+    gc._rejoin_needed_fut.set_result(None)
+    assert gc.coordinator_state == "COORDINATOR_DEAD"
+
+
+async def test_no_group_coordinator_state_is_always_stable():
+    ngc = NoGroupCoordinator.__new__(NoGroupCoordinator)
+    assert ngc.coordinator_state == "STABLE"
+
+
+async def test_consumer_coordinator_state_stopped_when_not_started():
+    from aiokafka.consumer.consumer import AIOKafkaConsumer
+
+    consumer = AIOKafkaConsumer.__new__(AIOKafkaConsumer)
+    consumer._closed = False
+    consumer._coordinator = None
+    assert consumer.coordinator_state == "STOPPED"
+
+
+async def test_consumer_coordinator_state_stopped_when_closed():
+    from aiokafka.consumer.consumer import AIOKafkaConsumer
+
+    consumer = AIOKafkaConsumer.__new__(AIOKafkaConsumer)
+    consumer._closed = True
+    consumer._coordinator = None
+    assert consumer.coordinator_state == "STOPPED"
+
+
+async def test_consumer_coordinator_state_delegates():
+    from aiokafka.consumer.consumer import AIOKafkaConsumer
+    from unittest.mock import MagicMock
+
+    consumer = AIOKafkaConsumer.__new__(AIOKafkaConsumer)
+    consumer._closed = False
+    consumer._coordinator = MagicMock()
+    consumer._coordinator.coordinator_state = "REBALANCING"
+    assert consumer.coordinator_state == "REBALANCING"


### PR DESCRIPTION
### Changes

Fixes #1154

Exposes coordinator health via consumer.coordinator_state without relying on private internals. Returns "STABLE", "REBALANCING", "PENDING_ERROR", or "COORDINATOR_DEAD" / "STOPPED" so health checks can detect stuck consumers after broker restarts or group rebalances.

### Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
