### PR TITLE
Fix last_stable_offset parsing for FetchResponse v5..v10

### DIFF
--- a/CHANGES/1160.bugfix
+++ b/CHANGES/1160.bugfix
@@ -1,0 +1,2 @@
+Fix ``Consumer.last_stable_offset()`` always returning 0 against brokers older than Kafka 2.3 (``FetchResponse`` versions 5..10). The fetcher was reading the wrong field from the per-partition response tuple, breaking ``read_committed`` consumers and any code that relied on the LSO when talking to those brokers.
+

--- a/aiokafka/consumer/fetcher.py
+++ b/aiokafka/consumer/fetcher.py
@@ -813,8 +813,14 @@ class Fetcher:
                         if rack_aware:
                             self._update_preferred_read_replica(tp, part_data[3])
                     elif response.API_VERSION >= 4:
+                        # part_data layout:
+                        #   v4:     [lso, aborted_transactions, message_set]
+                        #   v5..v10:[lso, log_start_offset,
+                        #            aborted_transactions, message_set]
+                        # lso is always part_data[0] and
+                        # aborted_transactions is always part_data[-2].
+                        lso = part_data[0]
                         aborted_transactions = part_data[-2]
-                        lso = part_data[-3]
                     else:
                         aborted_transactions = None
                         lso = None

--- a/tests/test_transactional_consumer.py
+++ b/tests/test_transactional_consumer.py
@@ -69,11 +69,9 @@ class TestKafkaConsumerIntegration(KafkaIntegrationTestCase):
         self.assertEqual(msg.value, b"Hello from non-transaction")
         self.assertEqual(msg.key, None)
 
-        # 3, because we have a commit marker also.
-        # Drive a no-data fetch round-trip so the consumer picks up the
-        # transaction commit marker and updates last_stable_offset/highwater
-        # before we assert on them. Sleeping a fixed interval here was racy
-        # under Python 3.14's task scheduler.
+        # 3, because we have a commit marker also. Drive a no-data fetch
+        # round-trip so the consumer observes the transaction commit marker
+        # and updates last_stable_offset/highwater before we assert.
         self.assertEqual(await consumer.getmany(timeout_ms=1000), {})
 
         tp = TopicPartition(self.topic, 0)
@@ -132,10 +130,9 @@ class TestKafkaConsumerIntegration(KafkaIntegrationTestCase):
         self.assertEqual(msg.value, b"Hello from non-transaction")
         self.assertEqual(msg.key, None)
 
-        # Drive a no-data fetch round-trip so the consumer picks up the
+        # Drive a no-data fetch round-trip so the consumer observes the
         # transaction abort marker and updates last_stable_offset/highwater
-        # before we assert on them. Replaces a former asyncio.wait_for(getone,
-        # timeout=0.5) which was racy under Python 3.14's task scheduler.
+        # before we assert.
         self.assertEqual(await consumer.getmany(timeout_ms=1000), {})
 
         tp = TopicPartition(self.topic, 0)


### PR DESCRIPTION
Fixes the regression introduced by #1159 (rack-aware fetching, KIP-392).

That PR extended FetchRequestStruct from v1..v4 to v1..v11, which silently bumped the negotiated Fetch wire format against every broker between Kafka 0.11 and 2.2 (inclusive). The response parser in Fetcher._proc_fetch_request was not updated to match: for FetchResponse v5..v10 it kept reading

`lso = part_data[-3]`

which in the v5..v10 partition layout

```
(partition, error_code, highwater,
 last_stable_offset, log_start_offset,
 aborted_transactions, message_set)
```

is log_start_offset (typically 0), not last_stable_offset. As a result tp_state.lso never advanced and Consumer.last_stable_offset(tp) always returned 0 against brokers older than Kafka 2.3. Brokers >= 2.3 take the explicit v11 branch and were unaffected, hiding the bug in CI legs that only exercised Kafka 2.8.1.

Fix:

Parse lso from part_data[0] for the v4..v10 branch (single branch; both layouts have lso at index 0 and aborted_transactions at index -2). The v11 branch is unchanged.


### Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder  (CHANGES/1160.bugfix)
