### PR TITLE
feat: use zstd from stdlib on python >= 3.14

### DIFF
--- a/CHANGES/1146.feat
+++ b/CHANGES/1146.feat
@@ -1,0 +1,2 @@
+Use the stdlib ``compression.zstd`` module (added in Python 3.14) for zstd
+compression when available, falling back to ``cramjam``.

--- a/aiokafka/codec.py
+++ b/aiokafka/codec.py
@@ -8,6 +8,11 @@ _XERIAL_V1_HEADER = (-126, b"S", b"N", b"A", b"P", b"P", b"Y", 0, 1, 1)
 _XERIAL_V1_FORMAT = "bccccccBii"
 
 try:
+    import compression.zstd as _zstd_stdlib  # added in Python 3.14
+except ImportError:
+    _zstd_stdlib = None
+
+try:
     import cramjam
 except ImportError:
     cramjam = None
@@ -22,7 +27,7 @@ def has_snappy() -> bool:
 
 
 def has_zstd() -> bool:
-    return cramjam is not None
+    return _zstd_stdlib is not None or cramjam is not None
 
 
 def has_lz4() -> bool:
@@ -194,6 +199,8 @@ def zstd_encode(payload: Buffer, level: int | None = None) -> bytes:
         # https://cwiki.apache.org/confluence/display/KAFKA/KIP-390%3A+Support+Compression+Level
         level = 3
 
+    if _zstd_stdlib is not None:
+        return _zstd_stdlib.compress(payload, level=level)
     return bytes(cramjam.zstd.compress(payload, level=level))
 
 
@@ -201,4 +208,6 @@ def zstd_decode(payload: Buffer) -> bytes:
     if not has_zstd():
         raise NotImplementedError("Zstd codec is not available")
 
+    if _zstd_stdlib is not None:
+        return _zstd_stdlib.decompress(payload)
     return bytes(cramjam.zstd.decompress(payload))


### PR DESCRIPTION


<!-- Thank you for your contribution! 
Feel free to change the template if you feel confused.
-->
### Changes

Fixes #1146

Python 3.14 added the module `compression.zstd` (https://docs.python.org/3/library/compression.zstd.html), which uses `libzstd` unser the hood. Benchamrks show that the standard library performs much better than cramjam.

```
stdlib_compress_random_1024: Mean +- std dev: 1.58 us +- 0.03 us
stdlib_decompress_random_1024: Mean +- std dev: 361 ns +- 7 ns
cramjam_compress_random_1024: Mean +- std dev: 2.66 us +- 0.77 us
cramjam_decompress_random_1024: Mean +- std dev: 1.27 us +- 0.02 us
stdlib_compress_text_1024: Mean +- std dev: 1.11 us +- 0.02 us
stdlib_decompress_text_1024: Mean +- std dev: 423 ns +- 10 ns
cramjam_compress_text_1024: Mean +- std dev: 2.12 us +- 0.04 us
cramjam_decompress_text_1024: Mean +- std dev: 1.33 us +- 0.02 us
stdlib_compress_random_65536: Mean +- std dev: 10.7 us +- 0.2 us
stdlib_decompress_random_65536: Mean +- std dev: 3.26 us +- 0.11 us
cramjam_compress_random_65536: Mean +- std dev: 16.9 us +- 0.4 us
cramjam_decompress_random_65536: Mean +- std dev: 6.66 us +- 0.13 us
stdlib_compress_text_65536: Mean +- std dev: 4.92 us +- 0.06 us
stdlib_decompress_text_65536: Mean +- std dev: 7.99 us +- 0.60 us
cramjam_compress_text_65536: Mean +- std dev: 10.5 us +- 0.1 us
cramjam_decompress_text_65536: Mean +- std dev: 13.3 us +- 1.2 us
stdlib_compress_random_1048576: Mean +- std dev: 160 us +- 7 us
stdlib_decompress_random_1048576: Mean +- std dev: 94.8 us +- 8.6 us
cramjam_compress_random_1048576: Mean +- std dev: 310 us +- 42 us
cramjam_decompress_random_1048576: Mean +- std dev: 130 us +- 17 us
stdlib_compress_text_1048576: Mean +- std dev: 99.8 us +- 2.6 us
stdlib_decompress_text_1048576: Mean +- std dev: 159 us +- 9 us
cramjam_compress_text_1048576: Mean +- std dev: 192 us +- 5 us
cramjam_decompress_text_1048576: Mean +- std dev: 184 us +- 14 us
```

Note that the with this change we will always use the stdlib in python 3.14, which ensures that no changes in the tests are needed.
<!-- Please give a short brief about these changes. -->

### Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
 