### PR TITLE
Revisit tagged fields

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,15 @@
 Changelog
 =========
 
+0.15.0 (2026-??-??)
+===================
+
+New features:
+
+* Change the way tagged fields are managed in the protocol definitions
+  (pr #1162 by @vmaurin)
+
+
 0.14.0 (2026-04-29)
 ===================
 

--- a/aiokafka/protocol/admin.py
+++ b/aiokafka/protocol/admin.py
@@ -17,7 +17,6 @@ from .types import (
     Int64,
     Schema,
     String,
-    TaggedFields,
 )
 
 
@@ -1467,18 +1466,17 @@ class AlterPartitionReassignmentsResponse_v0(Response):
                         ("partition_index", Int32),
                         ("error_code", Int16),
                         ("error_message", CompactString("utf-8")),
-                        ("tags", TaggedFields),
+                        tagged_fields=(),
                     ),
                 ),
-                ("tags", TaggedFields),
+                tagged_fields=(),
             ),
         ),
-        ("tags", TaggedFields),
+        tagged_fields=(),
     )
 
 
 class AlterPartitionReassignmentsRequest_v0(RequestStruct):
-    FLEXIBLE_VERSION = True
     API_KEY = 45
     API_VERSION = 0
     RESPONSE_TYPE = AlterPartitionReassignmentsResponse_v0
@@ -1493,13 +1491,13 @@ class AlterPartitionReassignmentsRequest_v0(RequestStruct):
                     CompactArray(
                         ("partition_index", Int32),
                         ("replicas", CompactArray(Int32)),
-                        ("tags", TaggedFields),
+                        tagged_fields=(),
                     ),
                 ),
-                ("tags", TaggedFields),
+                tagged_fields=(),
             ),
         ),
-        ("tags", TaggedFields),
+        tagged_fields=(),
     )
 
 
@@ -1516,17 +1514,15 @@ class AlterPartitionReassignmentsRequest(
     def __init__(
         self,
         timeout_ms: int,
-        topics: list[tuple[str, tuple[int, list[int], TaggedFields], TaggedFields]],
-        tags: TaggedFields,
+        topics: list[tuple[str, tuple[int, list[int]]]],
     ):
         self._timeout_ms = timeout_ms
         self._topics = topics
-        self._tags = tags
 
     def build(
         self, request_struct_class: type[AlterPartitionReassignmentsRequestStruct]
     ) -> AlterPartitionReassignmentsRequestStruct:
-        return request_struct_class(self._timeout_ms, self._topics, self._tags)
+        return request_struct_class(self._timeout_ms, self._topics)
 
 
 class ListPartitionReassignmentsResponse_v0(Response):
@@ -1547,18 +1543,17 @@ class ListPartitionReassignmentsResponse_v0(Response):
                         ("replicas", CompactArray(Int32)),
                         ("adding_replicas", CompactArray(Int32)),
                         ("removing_replicas", CompactArray(Int32)),
-                        ("tags", TaggedFields),
+                        tagged_fields=(),
                     ),
                 ),
-                ("tags", TaggedFields),
+                tagged_fields=(),
             ),
         ),
-        ("tags", TaggedFields),
+        tagged_fields=(),
     )
 
 
 class ListPartitionReassignmentsRequest_v0(RequestStruct):
-    FLEXIBLE_VERSION = True
     API_KEY = 46
     API_VERSION = 0
     RESPONSE_TYPE = ListPartitionReassignmentsResponse_v0
@@ -1569,10 +1564,10 @@ class ListPartitionReassignmentsRequest_v0(RequestStruct):
             CompactArray(
                 ("name", CompactString("utf-8")),
                 ("partition_index", CompactArray(Int32)),
-                ("tags", TaggedFields),
+                tagged_fields=(),
             ),
         ),
-        ("tags", TaggedFields),
+        tagged_fields=(),
     )
 
 
@@ -1589,17 +1584,15 @@ class ListPartitionReassignmentsRequest(
     def __init__(
         self,
         timeout_ms: int,
-        topics: list[tuple[str, tuple[int, list[int], TaggedFields], TaggedFields]],
-        tags: TaggedFields,
+        topics: list[tuple[str, tuple[int, list[int]]]],
     ):
         self._timeout_ms = timeout_ms
         self._topics = topics
-        self._tags = tags
 
     def build(
         self, request_struct_class: type[ListPartitionReassignmentsRequestStruct]
     ) -> ListPartitionReassignmentsRequestStruct:
-        return request_struct_class(self._timeout_ms, self._topics, self._tags)
+        return request_struct_class(self._timeout_ms, self._topics)
 
 
 class DeleteRecordsResponse_v0(Response):
@@ -1645,13 +1638,13 @@ class DeleteRecordsResponse_v2(Response):
                         ("partition_index", Int32),
                         ("low_watermark", Int64),
                         ("error_code", Int16),
-                        ("tags", TaggedFields),
+                        tagged_fields=(),
                     ),
                 ),
-                ("tags", TaggedFields),
+                tagged_fields=(),
             ),
         ),
-        ("tags", TaggedFields),
+        tagged_fields=(),
     )
 
 
@@ -1687,7 +1680,6 @@ class DeleteRecordsRequest_v1(RequestStruct):
 class DeleteRecordsRequest_v2(RequestStruct):
     API_KEY = 21
     API_VERSION = 2
-    FLEXIBLE_VERSION = True
     RESPONSE_TYPE = DeleteRecordsResponse_v2
     SCHEMA = Schema(
         (
@@ -1699,14 +1691,14 @@ class DeleteRecordsRequest_v2(RequestStruct):
                     CompactArray(
                         ("partition_index", Int32),
                         ("offset", Int64),
-                        ("tags", TaggedFields),
+                        tagged_fields=(),
                     ),
                 ),
-                ("tags", TaggedFields),
+                tagged_fields=(),
             ),
         ),
         ("timeout_ms", Int32),
-        ("tags", TaggedFields),
+        tagged_fields=(),
     )
 
 
@@ -1722,21 +1714,14 @@ class DeleteRecordsRequest(Request[DeleteRecordsRequestStruct]):
         self,
         topics: Iterable[tuple[str, Iterable[tuple[int, int]]]],
         timeout_ms: int,
-        tags: dict[int, bytes] | None = None,
     ) -> None:
         self._topics = topics
         self._timeout_ms = timeout_ms
-        self._tags = tags
 
     def build(
         self, request_struct_class: type[DeleteRecordsRequestStruct]
     ) -> DeleteRecordsRequestStruct:
         if request_struct_class.API_VERSION < 2:
-            if self._tags is not None:
-                raise IncompatibleBrokerVersion(
-                    "tags requires DeleteRecordsRequest >= v2"
-                )
-
             return request_struct_class(
                 [
                     (
@@ -1752,13 +1737,11 @@ class DeleteRecordsRequest(Request[DeleteRecordsRequestStruct]):
                 (
                     topic,
                     [
-                        (partition, before_offset, {})
+                        (partition, before_offset)
                         for partition, before_offset in partitions
                     ],
-                    {},
                 )
                 for (topic, partitions) in self._topics
             ],
             self._timeout_ms,
-            self._tags or {},
         )

--- a/aiokafka/protocol/api.py
+++ b/aiokafka/protocol/api.py
@@ -8,7 +8,7 @@ from typing import Any, ClassVar, Generic, TypeVar, get_args, get_origin
 from aiokafka.errors import IncompatibleBrokerVersion
 
 from .struct import Struct
-from .types import Array, Int16, Int32, Schema, String, TaggedFields
+from .types import Array, Int16, Int32, Schema, String
 
 
 class RequestHeader_v1(Struct):
@@ -37,7 +37,7 @@ class RequestHeader_v2(Struct):
         ("api_version", Int16),
         ("correlation_id", Int32),
         ("client_id", String("utf-8")),
-        ("tags", TaggedFields),
+        tagged_fields=(),
     )
 
     def __init__(
@@ -45,10 +45,9 @@ class RequestHeader_v2(Struct):
         request: RequestStruct,
         correlation_id: int = 0,
         client_id: str = "aiokafka",
-        tags: dict[int, bytes] | None = None,
     ):
         super().__init__(
-            request.API_KEY, request.API_VERSION, correlation_id, client_id, tags or {}
+            request.API_KEY, request.API_VERSION, correlation_id, client_id
         )
 
 
@@ -61,7 +60,7 @@ class ResponseHeader_v0(Struct):
 class ResponseHeader_v1(Struct):
     SCHEMA = Schema(
         ("correlation_id", Int32),
-        ("tags", TaggedFields),
+        tagged_fields=(),
     )
 
 
@@ -149,8 +148,6 @@ class RequestStruct(Struct, metaclass=abc.ABCMeta):
 
     Attributes
     ----------
-    FLEXIBLE_VERSION : bool
-        Use request header with flexible tags
     API_KEY : int
         The unique API key identifying the request.
     API_VERSION : int
@@ -161,7 +158,6 @@ class RequestStruct(Struct, metaclass=abc.ABCMeta):
         An instance of Schema() representing the request structure.
     """
 
-    FLEXIBLE_VERSION: ClassVar[bool] = False
     API_KEY: ClassVar[int]
     API_VERSION: ClassVar[int]
     RESPONSE_TYPE: ClassVar[type[Response]]
@@ -186,7 +182,7 @@ class RequestStruct(Struct, metaclass=abc.ABCMeta):
     def build_request_header(
         self, correlation_id: int, client_id: str
     ) -> RequestHeader_v1 | RequestHeader_v2:
-        if self.FLEXIBLE_VERSION:
+        if self.SCHEMA.has_tagged_fields:
             return RequestHeader_v2(
                 self, correlation_id=correlation_id, client_id=client_id
             )
@@ -197,7 +193,7 @@ class RequestStruct(Struct, metaclass=abc.ABCMeta):
     def parse_response_header(
         self, read_buffer: BytesIO | bytes
     ) -> ResponseHeader_v0 | ResponseHeader_v1:
-        if self.FLEXIBLE_VERSION:
+        if self.SCHEMA.has_tagged_fields:
             return ResponseHeader_v1.decode(read_buffer)
         return ResponseHeader_v0.decode(read_buffer)
 

--- a/aiokafka/protocol/struct.py
+++ b/aiokafka/protocol/struct.py
@@ -32,7 +32,7 @@ class Struct:
     def decode(cls, data: BytesIO | bytes) -> Self:
         if isinstance(data, bytes):
             data = BytesIO(data)
-        return cls(*[field.decode(data) for field in cls.SCHEMA.fields])
+        return cls(*cls.SCHEMA.decode(data))
 
     def get_item(self, name: str) -> Any:
         if name not in self.SCHEMA.names:

--- a/aiokafka/protocol/types.py
+++ b/aiokafka/protocol/types.py
@@ -1,5 +1,5 @@
 import struct
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from io import BytesIO
 from struct import error
 from typing import (
@@ -185,22 +185,118 @@ class Boolean(AbstractType[bool]):
 class Schema:
     names: tuple[str, ...]
     fields: tuple[ValueT, ...]
+    tags: tuple[int, ...]
+    tagged_fields_offset: int
 
-    def __init__(self, *fields: tuple[str, ValueT]):
-        if fields:
-            self.names, self.fields = zip(*fields, strict=False)
-        else:
-            self.names, self.fields = (), ()
+    def __init__(
+        self,
+        *fields: tuple[str, ValueT],
+        tagged_fields: Iterable[tuple[int, str, ValueT]] | None = None,
+    ):
+        self.tagged_fields_offset = -1
+        all_names = []
+        all_fields = []
+        all_tags = []
+        for name, field in fields:
+            all_names.append(name)
+            all_fields.append(field)
+            all_tags.append(-1)
+
+        if tagged_fields is not None:
+            self.tagged_fields_offset = len(fields)
+            previous_tag = -1
+            for tag, name, field in tagged_fields:
+                if tag <= previous_tag:
+                    raise ValueError(
+                        "Tagged fields must be declared ordered by tag."
+                        f" {name} is out-of-order"
+                    )
+                previous_tag = tag
+                all_names.append(name)
+                all_fields.append(field)
+                all_tags.append(tag)
+
+        self.names = tuple(all_names)
+        self.fields = tuple(all_fields)
+        self.tags = tuple(all_tags)
+
+    @property
+    def has_tagged_fields(self) -> bool:
+        return self.tagged_fields_offset >= 0
 
     def encode(self, item: Sequence[Any]) -> bytes:
         if len(item) != len(self.fields):
             raise ValueError("Item field count does not match Schema")
-        return b"".join(field.encode(item[i]) for i, field in enumerate(self.fields))
+        return b"".join(
+            self.fields[i].encode(item[i])
+            for i in range(
+                self.tagged_fields_offset
+                if self.tagged_fields_offset >= 0
+                else len(self.fields),
+            )
+        ) + (
+            self._encode_tagged_fields(
+                [
+                    (
+                        self.tags[i],
+                        self.fields[i].encode(item[i]),
+                    )
+                    for i in range(self.tagged_fields_offset, len(self.fields))
+                    if item[i] is not None
+                ]
+            )
+            if self.tagged_fields_offset >= 0
+            else b""
+        )
 
     def decode(
         self, data: BytesIO
     ) -> tuple[Any | str | None | list[Any | tuple[Any, ...]], ...]:
-        return tuple(field.decode(data) for field in self.fields)
+        result = [
+            self.fields[i].decode(data)
+            for i in range(
+                self.tagged_fields_offset
+                if self.tagged_fields_offset >= 0
+                else len(self.fields)
+            )
+        ]
+        if self.tagged_fields_offset >= 0:
+            tagged_fields = self._decode_tagged_fields(data)
+            for i in range(self.tagged_fields_offset, len(self.fields)):
+                encoded_value = tagged_fields.get(self.tags[i])
+                if encoded_value is not None:
+                    result.append(self.fields[i].decode(BytesIO(encoded_value)))
+                else:
+                    result.append(None)
+
+        return tuple(result)
+
+    @staticmethod
+    def _encode_tagged_fields(value: list[tuple[int, bytes]]) -> bytes:
+        ret = UnsignedVarInt32.encode(len(value))
+        for k, v in value:
+            ret += UnsignedVarInt32.encode(k)
+            ret += UnsignedVarInt32.encode(len(v))
+            ret += v
+        return ret
+
+    @staticmethod
+    def _decode_tagged_fields(data: BytesIO) -> dict[int, bytes]:
+        # According to the specs https://cwiki.apache.org/confluence/display/KAFKA/KIP-482%3A+The+Kafka+Protocol+should+Support+Optional+Tagged+Fields
+        # "They are serialized in ascending order of their tag"
+        # On deserialize, we prefer supporting any order:
+        # * it doesn't complexify the implementation
+        # * it is more robust in case a future broker version produce them unordered
+        num_fields = UnsignedVarInt32.decode(data)
+        ret: dict[int, bytes] = {}
+        if not num_fields:
+            return ret
+        for _ in range(num_fields):
+            tag = UnsignedVarInt32.decode(data)
+            size = UnsignedVarInt32.decode(data)
+            val = data.read(size)
+            ret[tag] = val
+        return ret
 
     def __len__(self) -> int:
         return len(self.fields)
@@ -227,17 +323,21 @@ class Array:
 
     @overload
     def __init__(
-        self, array_of_0: tuple[str, ValueT], *array_of: tuple[str, ValueT]
+        self,
+        array_of_0: tuple[str, ValueT],
+        *array_of: tuple[str, ValueT],
+        tagged_fields: Iterable[tuple[int, str, ValueT]] | None = None,
     ): ...
 
     def __init__(
         self,
         array_of_0: ValueT | tuple[str, ValueT],
         *array_of: tuple[str, ValueT],
+        tagged_fields: Iterable[tuple[int, str, ValueT]] | None = None,
     ) -> None:
-        if array_of:
+        if array_of or tagged_fields:
             array_of_0 = cast(tuple[str, ValueT], array_of_0)
-            self.array_of = Schema(array_of_0, *array_of)
+            self.array_of = Schema(array_of_0, *array_of, tagged_fields=tagged_fields)
         else:
             array_of_0 = cast(ValueT, array_of_0)
             if isinstance(array_of_0, String | Array | Schema) or issubclass(
@@ -353,36 +453,6 @@ class CompactString(String):
             return UnsignedVarInt32.encode(0)
         encoded_value = str(value).encode(self.encoding)
         return UnsignedVarInt32.encode(len(encoded_value) + 1) + encoded_value
-
-
-class TaggedFields(AbstractType[dict[int, bytes]]):
-    @classmethod
-    def decode(cls, data: BytesIO) -> dict[int, bytes]:
-        num_fields = UnsignedVarInt32.decode(data)
-        ret: dict[int, bytes] = {}
-        if not num_fields:
-            return ret
-        prev_tag = -1
-        for _ in range(num_fields):
-            tag = UnsignedVarInt32.decode(data)
-            if tag <= prev_tag:
-                raise ValueError(f"Invalid or out-of-order tag {tag}")
-            prev_tag = tag
-            size = UnsignedVarInt32.decode(data)
-            val = data.read(size)
-            ret[tag] = val
-        return ret
-
-    @classmethod
-    def encode(cls, value: dict[int, bytes]) -> bytes:
-        ret = UnsignedVarInt32.encode(len(value))
-        for k, v in value.items():
-            # do we allow for other data types ?? It could get complicated really fast
-            assert isinstance(v, bytes), f"Value {v!r} is not a byte array"
-            assert isinstance(k, int) and k > 0, f"Key {k} is not a positive integer"
-            ret += UnsignedVarInt32.encode(k)
-            ret += v
-        return ret
 
 
 class CompactBytes(AbstractType[bytes | None]):

--- a/tests/test_protocol_tagged_fields.py
+++ b/tests/test_protocol_tagged_fields.py
@@ -1,0 +1,131 @@
+import pytest
+
+from aiokafka.protocol.struct import Struct
+from aiokafka.protocol.types import (
+    CompactArray,
+    CompactString,
+    Int16,
+    Schema,
+)
+
+
+def _make_test_class(schema: Schema) -> type[Struct]:
+    class TestClass(Struct):
+        SCHEMA = schema
+
+    return TestClass
+
+
+def test_invalid_tagged_field_definition() -> None:
+    with pytest.raises(ValueError):
+        Schema(
+            ("name", CompactString("utf-8")),
+            tagged_fields=(
+                (6, "tagged_field2", CompactString("utf-8")),
+                (0, "tagged_field1", CompactString("utf-8")),
+            ),
+        )
+
+
+@pytest.mark.parametrize(
+    ("data", "expected"),
+    [
+        (
+            (
+                b"\x06hello"  # name="hello"
+                b"\x02"  # 2 tagged fields follow
+                b"\x00"  # tag=0
+                b"\x06"  # encoded value is 6 bytes
+                b"\x06world"  # tagged_field1="world"
+                b"\x06"  # tag=6
+                b"\x02"  # encoded value is 2 bytes
+                b"\x02!"  # tagged_field2="!"
+            ),
+            ("hello", "world", "!"),
+        ),
+        (
+            (
+                b"\x06hello"  # name="hello"
+                b"\x01"  # 1 tagged fields follow
+                b"\x06"  # tag=6
+                b"\x02"  # encoded value is 2 bytes
+                b"\x02!"  # tagged_field2="!"
+            ),
+            ("hello", None, "!"),
+        ),
+        (
+            (
+                b"\x06hello"  # name="hello"
+                b"\x02"  # 2 tagged fields follow
+                b"\x00"  # tag=0
+                b"\x06"  # encoded value is 6 bytes
+                b"\x06world"  # tagged_field1="world"
+                b"\x08"  # tag=8
+                b"\x02"  # encoded value is 2 bytes
+                b"\x02!"  # tagged_field2="!"
+            ),
+            ("hello", "world", None),
+        ),
+    ],
+)
+def test_decode_tagged_fields(data, expected) -> None:
+    TestClass = _make_test_class(
+        Schema(
+            ("name", CompactString("utf-8")),
+            tagged_fields=(
+                (0, "tagged_field1", CompactString("utf-8")),
+                (6, "tagged_field2", CompactString("utf-8")),
+            ),
+        )
+    )
+
+    tc = TestClass.decode(data)
+    v1, v2, v3 = expected
+    assert tc.get_item("name") == v1
+    assert tc.get_item("tagged_field1") == v2
+    assert tc.get_item("tagged_field2") == v3
+
+
+def test_happy_roundtrip() -> None:
+    TestClass = _make_test_class(
+        Schema(
+            ("name", CompactString("utf-8")),
+            ("myarray", CompactArray(Int16)),
+            tagged_fields=(
+                (0, "tagged_field1", CompactString("utf-8")),
+                (42, "tagged_field2", Int16),
+                (
+                    53,
+                    "tagged_field3",
+                    CompactArray(
+                        ("name", CompactString("utf-8")),
+                        tagged_fields=(
+                            (0, "tag1", Int16),
+                            (1, "tag2", Int16),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
+
+    tc = TestClass(
+        name="foo",
+        myarray=[1, 2, 3],
+        tagged_field1="bar",
+        tagged_field2=23,
+        tagged_field3=[("hello", 1, 2), ("world", 3, 4)],
+    )
+    encoded = tc.encode()
+    assert tc.get_item("name") == "foo"
+    assert tc.get_item("myarray") == [1, 2, 3]
+    assert tc.get_item("tagged_field1") == "bar"
+    assert tc.get_item("tagged_field2") == 23
+    assert tc.get_item("tagged_field3") == [("hello", 1, 2), ("world", 3, 4)]
+
+    tc = TestClass.decode(encoded)
+    assert tc.get_item("name") == "foo"
+    assert tc.get_item("myarray") == [1, 2, 3]
+    assert tc.get_item("tagged_field1") == "bar"
+    assert tc.get_item("tagged_field2") == 23
+    assert tc.get_item("tagged_field3") == [("hello", 1, 2), ("world", 3, 4)]

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -28,7 +28,6 @@ from aiokafka.protocol.admin import (
     DeleteRecordsRequest,
     DeleteRecordsRequest_v0,
     DeleteRecordsRequest_v1,
-    DeleteRecordsRequest_v2,
     DeleteTopicsRequest,
     DeleteTopicsRequest_v0,
     DescribeAclsRequest,
@@ -357,22 +356,22 @@ cases = [
         ],
     ),
     (
-        AlterPartitionReassignmentsRequest(timeout_ms=100, topics=[], tags={}),
+        AlterPartitionReassignmentsRequest(timeout_ms=100, topics=[]),
         [
             Versions(expected=IncompatibleBrokerVersion),
             Versions(
                 max_version=0,
-                expected=AlterPartitionReassignmentsRequest_v0(100, [], {}),
+                expected=AlterPartitionReassignmentsRequest_v0(100, []),
             ),
         ],
     ),
     (
-        ListPartitionReassignmentsRequest(timeout_ms=200, topics=[], tags={}),
+        ListPartitionReassignmentsRequest(timeout_ms=200, topics=[]),
         [
             Versions(expected=IncompatibleBrokerVersion),
             Versions(
                 max_version=0,
-                expected=ListPartitionReassignmentsRequest_v0(200, [], {}),
+                expected=ListPartitionReassignmentsRequest_v0(200, []),
             ),
         ],
     ),
@@ -387,17 +386,6 @@ cases = [
             Versions(
                 max_version=1,
                 expected=DeleteRecordsRequest_v1([("t1", [(0, 123)])], 50),
-            ),
-        ],
-    ),
-    (
-        DeleteRecordsRequest(topics=[("t1", [(0, 123)])], timeout_ms=50, tags={}),
-        [
-            Versions(expected=IncompatibleBrokerVersion),
-            Versions(max_version=1, expected=IncompatibleBrokerVersion),
-            Versions(
-                max_version=2,
-                expected=DeleteRecordsRequest_v2([("t1", [(0, 123, {})], {})], 50, {}),
             ),
         ],
     ),


### PR DESCRIPTION
Instead of a dedicated field type, treat tagged fields as an option of schema, to then be able to specify them with a name (and their tag) so it is easier to maniuplate on the Struct class.

It tries to reproduce the generated code of the official Java client with the `TaggedFieldsSection` class.

It also drops the FLEXIBLE_VERSION boolean detected by the presence of tagged_fields in the request schema

### Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
