### PR TITLE
Fix getone/getmany raising AttributeError when consumer not started

### DIFF
--- a/aiokafka/consumer/consumer.py
+++ b/aiokafka/consumer/consumer.py
@@ -1136,6 +1136,11 @@ class AIOKafkaConsumer:
         assert all(isinstance(k, TopicPartition) for k in partitions)
         if self._closed:
             raise ConsumerStoppedError()
+        if self._fetcher is None:
+            raise IllegalStateError(
+                "AIOKafkaConsumer is not started. Use `await consumer.start()` "
+                "or the `async with` context manager."
+            )
 
         # Raise coordination errors if any
         self._coordinator.check_errors()
@@ -1183,6 +1188,11 @@ class AIOKafkaConsumer:
         assert all(isinstance(k, TopicPartition) for k in partitions)
         if self._closed:
             raise ConsumerStoppedError()
+        if self._fetcher is None:
+            raise IllegalStateError(
+                "AIOKafkaConsumer is not started. Use `await consumer.start()` "
+                "or the `async with` context manager."
+            )
 
         if max_records is not None and (
             not isinstance(max_records, int) or max_records < 1

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -2247,3 +2247,25 @@ class TestConsumerIntegration(KafkaIntegrationTestCase):
             await _wait_mock_count(listener1, 4)
         self.assertEqual(listener1.revoke_mock.call_count, 5)
         self.assertEqual(listener1.assign_mock.call_count, 5)
+
+
+class TestConsumerNotStarted:
+    """Unit tests that do not require a running Kafka broker."""
+
+    @pytest.mark.asyncio
+    async def test_getone_before_start_raises_illegal_state(self):
+        consumer = AIOKafkaConsumer(
+            "some_topic",
+            bootstrap_servers="localhost:9092",
+        )
+        with pytest.raises(IllegalStateError, match="not started"):
+            await consumer.getone()
+
+    @pytest.mark.asyncio
+    async def test_getmany_before_start_raises_illegal_state(self):
+        consumer = AIOKafkaConsumer(
+            "some_topic",
+            bootstrap_servers="localhost:9092",
+        )
+        with pytest.raises(IllegalStateError, match="not started"):
+            await consumer.getmany()


### PR DESCRIPTION
## Problem

Calling `getone()` or `getmany()` on an `AIOKafkaConsumer` that has been created but not yet started raises an opaque `AttributeError`:

```
AttributeError: 'NoneType' object has no attribute 'check_errors'
```

Repro:
```python
consumer = AIOKafkaConsumer("topic", bootstrap_servers="localhost:9092")
await consumer.getmany()  # crashes with AttributeError
```

The problem: `self._coordinator` is `None` until `start()` is called, but the only guard in `getone()`/`getmany()` checks `self._closed`, which is `False` from `__init__`. So the code reaches `self._coordinator.check_errors()` on a `None` object.

## Fix

Add an explicit `if self._fetcher is None` check in both `getone()` and `getmany()`. `self._fetcher` is the first attribute assigned in `start()`, making it a reliable "started" indicator. When the consumer hasn't been started, raise `IllegalStateError` with an actionable message directing the user to call `await consumer.start()` or use the `async with` context manager.

Closes #1102