### PR TITLE
fix: add retry backoff for NotLeaderForPartitionError in _proc_fetch_request

### DIFF
--- a/aiokafka/consumer/fetcher.py
+++ b/aiokafka/consumer/fetcher.py
@@ -590,6 +590,7 @@ class Fetcher:
         fetchable = collections.defaultdict(list)
         awaiting_reset = collections.defaultdict(list)
         backoff_by_nodes = collections.defaultdict(list)
+        fetch_backoffs = []
         resume_futures = []
         invalid_metadata = False
 
@@ -634,6 +635,10 @@ class Fetcher:
             elif tp_state.paused:
                 resume_futures.append(tp_state.resume_fut)
             else:
+                backoff = tp_state.fetch_backoff()
+                if backoff:
+                    fetch_backoffs.append(backoff)
+                    continue
                 position = tp_state.position
                 fetchable[node_id].append((tp, position))
                 log.debug(
@@ -669,10 +674,10 @@ class Fetcher:
             )
             fetch_requests.append((node_id, req))
 
-        if backoff_by_nodes:
+        if backoff_by_nodes or fetch_backoffs:
             # Return min time till any node will be ready to send event
             # (max of it's backoffs)
-            backoff = min(map(max, backoff_by_nodes.values()))
+            backoff = min([*map(max, backoff_by_nodes.values()), *fetch_backoffs])
         else:
             backoff = self._fetcher_timeout
         return (
@@ -888,6 +893,7 @@ class Fetcher:
                         Errors.UnknownTopicOrPartitionError,
                     ):
                         self._client.force_metadata_update()
+                        tp_state.request_fetch_backoff(self._retry_backoff)
                     elif error_type is Errors.OffsetOutOfRangeError:
                         if self._default_reset_strategy != OffsetResetStrategy.NONE:
                             tp_state.await_reset(self._default_reset_strategy)

--- a/aiokafka/consumer/subscription_state.py
+++ b/aiokafka/consumer/subscription_state.py
@@ -474,6 +474,7 @@ class TopicPartitionState:
 
         self._paused = False
         self._resume_fut = None
+        self._fetch_backoff_until = 0
 
     @property
     def paused(self):
@@ -553,6 +554,12 @@ class TopicPartitionState:
 
     def wait_for_position(self):
         return shield(self._position_fut)
+
+    def request_fetch_backoff(self, backoff: float):
+        self._fetch_backoff_until = time.monotonic() + backoff
+
+    def fetch_backoff(self):
+        return max(0, self._fetch_backoff_until - time.monotonic())
 
     # Pause/Unpause
     def pause(self):

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -332,6 +332,84 @@ class TestFetcher(unittest.TestCase):
 
         await fetcher.close()
 
+    @run_until_complete
+    async def test_proc_fetch_request_notleader_partition_backoff(self):
+        client = AIOKafkaClient(bootstrap_servers=[])
+        subscriptions = SubscriptionState()
+        fetcher = Fetcher(client, subscriptions)
+        fetcher._fetch_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await fetcher._fetch_task
+        fetcher._fetch_task = create_task(asyncio.sleep(1000000))
+
+        tp0 = TopicPartition("test", 0)
+        tp1 = TopicPartition("test", 1)
+        tp_info = (
+            tp0.topic,
+            [(tp0.partition, 4, 100000), (tp1.partition, 4, 100000)],
+        )
+        req = FetchRequest(-1, 100, 100, [tp_info])
+
+        def force_metadata_update():
+            fut = create_future()
+            fut.set_result(False)
+            return fut
+
+        client.ready = mock.MagicMock(side_effect=lambda conn: create_future())
+        client.force_metadata_update = mock.MagicMock(side_effect=force_metadata_update)
+        client.cluster.leader_for_partition = mock.MagicMock(return_value=0)
+
+        subscriptions.assign_from_user({tp0, tp1})
+        assignment = subscriptions.subscription.assignment
+        subscriptions.seek(tp0, 4)
+        subscriptions.seek(tp1, 4)
+
+        builder = DefaultRecordBatchBuilder(
+            magic=2, compression_type=0, batch_size=99999999,
+            is_transactional=0, producer_id=-1, producer_epoch=-1,
+            base_sequence=0,
+        )
+        builder.append(offset=4, value=b"ok", key=None, timestamp=None, headers=[])
+        raw_batch = bytes(builder.build())
+        fetch_response = FetchResponse(
+            [
+                (
+                    "test",
+                    [
+                        (0, NotLeaderForPartitionError.errno, 9, b""),
+                        (1, 0, 9, raw_batch),
+                    ],
+                )
+            ]
+        )
+
+        async def send(node, request):
+            return fetch_response
+
+        client.send = mock.MagicMock(side_effect=send)
+        needs_wake_up = await fetcher._proc_fetch_request(assignment, 0, req)
+
+        self.assertTrue(needs_wake_up)
+        self.assertGreater(assignment.state_value(tp0).fetch_backoff(), 0)
+        self.assertEqual(assignment.state_value(tp1).fetch_backoff(), 0)
+
+        fetcher._records.clear()
+        fetch_requests, _, timeout, invalid_metadata, _ = fetcher._get_actions_per_node(
+            assignment
+        )
+
+        self.assertFalse(invalid_metadata)
+        self.assertLessEqual(timeout, fetcher._retry_backoff)
+        self.assertEqual(len(fetch_requests), 1)
+        node_id, request = fetch_requests[0]
+        self.assertEqual(node_id, 0)
+        self.assertEqual(
+            request.topics,
+            [("test", [(1, 4, fetcher._max_partition_fetch_bytes)])],
+        )
+
+        await fetcher.close()
+
     def _setup_error_after_data(self):
         subscriptions = SubscriptionState()
         client = AIOKafkaClient(bootstrap_servers=[])

--- a/tests/test_rack_awareness.py
+++ b/tests/test_rack_awareness.py
@@ -72,6 +72,7 @@ def _make_assignment(fetcher, tps):
         state.has_valid_position = True
         state.paused = False
         state.position = 0
+        state.fetch_backoff.return_value = 0
         return state
 
     assignment.state_value = state_value


### PR DESCRIPTION
## Problem

Closes #1155.

When a broker returns `NotLeaderForPartitionError` or `UnknownTopicOrPartitionError` for one partition in a fetch response, aiokafka forces a metadata update but immediately retries that partition. During leader changes this can create a tight fetch loop while metadata is still propagating.

## Fix

This PR adds a per-partition fetch backoff after leader metadata errors:

- `TopicPartitionState` tracks a fetch-backoff deadline
- `_proc_fetch_request` requests `_retry_backoff` only for partitions that returned stale-leader metadata errors
- `_get_actions_per_node` skips only those backed-off partitions while still allowing other partitions to fetch

This avoids blocking unrelated partitions and still prevents repeated immediate fetches for partitions waiting on fresh metadata.

## Tests

- `AIOKAFKA_NO_EXTENSIONS=1 PYTHONPATH=. pytest tests/test_fetcher.py -q`
- `AIOKAFKA_NO_EXTENSIONS=1 PYTHONPATH=. pytest tests/test_rack_awareness.py -q`
- `ruff check aiokafka/consumer/fetcher.py aiokafka/consumer/subscription_state.py tests/test_fetcher.py tests/test_rack_awareness.py`