### PR TITLE
fix: add full jitter to Fetcher retry backoff (thundering herd on leader election)

### DIFF
--- a/aiokafka/consumer/fetcher.py
+++ b/aiokafka/consumer/fetcher.py
@@ -725,6 +725,12 @@ class Fetcher:
                 time.monotonic() + self._preferred_replica_ttl,
             )
 
+    def _jittered_backoff(self) -> float:
+        # Full jitter: spreads concurrent retriers across [0.5×, 1.5×] of the
+        # base backoff so they don't all wake at the same instant after a
+        # leader election or broker restart (thundering herd).
+        return self._retry_backoff * random.uniform(0.5, 1.5)
+
     def _invalidate_preferred_read_replica_for_node(self, node_id, request):
         """Drop cached preferred-replica entries that point to ``node_id``.
 
@@ -752,7 +758,7 @@ class Fetcher:
             # entries so the next attempt falls back to the leader instead of
             # repeatedly hitting the unreachable follower until TTL expiry.
             self._invalidate_preferred_read_replica_for_node(node_id, request)
-            await asyncio.sleep(self._retry_backoff)
+            await asyncio.sleep(self._jittered_backoff())
             return False
         except asyncio.CancelledError:
             # Either `close()` or partition unassigned. Either way the result
@@ -985,7 +991,7 @@ class Fetcher:
                 offsets = await self._proc_offset_request(node_id, topic_data)
             except Errors.KafkaError as err:
                 log.error("Failed fetch offsets from %s: %s", node_id, err)
-                await asyncio.sleep(self._retry_backoff)
+                await asyncio.sleep(self._jittered_backoff())
                 return needs_wakeup
         except asyncio.CancelledError:
             return needs_wakeup
@@ -1030,7 +1036,7 @@ class Fetcher:
                             raise
                         if error.invalid_metadata:
                             self._client.force_metadata_update()
-                        await asyncio.sleep(self._retry_backoff)
+                        await asyncio.sleep(self._jittered_backoff())
                     else:
                         return offsets
         except asyncio.TimeoutError as exc:


### PR DESCRIPTION
## Summary

All three `asyncio.sleep(self._retry_backoff)` calls in `fetcher.py` use a
**fixed constant** derived from `retry_backoff_ms`. When a broker failure
triggers a leader election, every consumer waiting on the same error receives
it at roughly the same instant, sleeps for exactly the same duration, and
retries simultaneously — a classic thundering herd that can overwhelm the
newly elected leader.

This PR introduces `Fetcher._jittered_backoff()` which spreads retries across
**[0.5×, 1.5×] of `retry_backoff_ms`** using `random.uniform` (full jitter),
then replaces all three callsites:

| Location | Error condition |
|---|---|
| `_proc_fetch_request` line ~761 | Transport-level fetch failure |
| `_proc_offset_fetch_request` line ~994 | Offset fetch failure |
| `_retrieve_offsets` inner loop line ~1039 | `retriable` offset error |

`random` was already imported in `fetcher.py`; no new dependencies are
introduced. The change is backward-compatible — `retry_backoff_ms` still
controls the **mean** of the sleep window.

## Note on PR #1164

PR #1164 adds a new `request_fetch_backoff` path in `subscription_state.py`
for `NotLeaderForPartitionError` specifically. The same jitter principle
applies there; this PR addresses the three pre-existing callsites in
`fetcher.py` regardless of whether #1164 is merged.

## Related

- Closes #1165
- See also: [AWS Architecture Blog — Exponential Backoff and Jitter](https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/)

## Test plan

- [ ] Existing test suite passes (`pytest tests/`)
- [ ] Manual verification: under simulated leader election, consumer logs show
  varied sleep durations instead of a uniform burst

---
*This fix was originally identified by [Quorum](https://github.com/KaustubhUp025/quorum), a Gemini-powered agent that reviews distributed coordination patterns in PRs.*