### PR TITLE
Don't send more than one JoinGroup request when more than one Assignors are specified

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,9 @@ New features:
 
 * Change the way tagged fields are managed in the protocol definitions
   (pr #1162 by @vmaurin)
+
+Bugfixes:
+
 * Don't send more than one JoinGroup request when more than one Assignors are specified (pr #1168 by @ilolis)
 
 0.14.0 (2026-04-29)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,7 @@ New features:
 
 * Change the way tagged fields are managed in the protocol definitions
   (pr #1162 by @vmaurin)
-
+* Don't send more than one JoinGroup request when more than one Assignors are specified (pr #XXX by @ilolis)
 
 0.14.0 (2026-04-29)
 ===================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,7 @@ New features:
 
 * Change the way tagged fields are managed in the protocol definitions
   (pr #1162 by @vmaurin)
-* Don't send more than one JoinGroup request when more than one Assignors are specified (pr #XXX by @ilolis)
+* Don't send more than one JoinGroup request when more than one Assignors are specified (pr #1168 by @ilolis)
 
 0.14.0 (2026-04-29)
 ===================

--- a/aiokafka/consumer/group_coordinator.py
+++ b/aiokafka/consumer/group_coordinator.py
@@ -1272,7 +1272,7 @@ class CoordinatorGroupRebalance:
                 metadata = metadata.encode()
             group_protocol = (assignor.name, metadata)
             metadata_list.append(group_protocol)
-        
+
         # for KIP-394 we may have to send a second join request
         try_join = True
         while try_join:

--- a/aiokafka/consumer/group_coordinator.py
+++ b/aiokafka/consumer/group_coordinator.py
@@ -1272,42 +1272,43 @@ class CoordinatorGroupRebalance:
                 metadata = metadata.encode()
             group_protocol = (assignor.name, metadata)
             metadata_list.append(group_protocol)
-            # for KIP-394 we may have to send a second join request
-            try_join = True
-            while try_join:
-                try_join = False
+        
+        # for KIP-394 we may have to send a second join request
+        try_join = True
+        while try_join:
+            try_join = False
 
-                request = JoinGroupRequest(
-                    self.group_id,
-                    self._session_timeout_ms,
-                    self._rebalance_timeout_ms,
-                    self._coordinator.member_id,
-                    self._coordinator._group_instance_id,
-                    ConsumerProtocol.PROTOCOL_TYPE,
-                    metadata_list,
-                )
+            request = JoinGroupRequest(
+                self.group_id,
+                self._session_timeout_ms,
+                self._rebalance_timeout_ms,
+                self._coordinator.member_id,
+                self._coordinator._group_instance_id,
+                ConsumerProtocol.PROTOCOL_TYPE,
+                metadata_list,
+            )
 
-                # create the request for the coordinator
-                log.debug(
-                    "Sending JoinGroup (%s) to coordinator %s",
-                    request,
-                    self.coordinator_id,
-                )
-                try:
-                    response = await self._coordinator._send_req(request)
-                except Errors.KafkaError:
-                    # Return right away. It's a connection error, so backoff will be
-                    # handled by coordinator lookup
-                    return None
-                if not self._subscription.active:
-                    # Subscription changed. Ignore response and restart group join
-                    return None
+            # create the request for the coordinator
+            log.debug(
+                "Sending JoinGroup (%s) to coordinator %s",
+                request,
+                self.coordinator_id,
+            )
+            try:
+                response = await self._coordinator._send_req(request)
+            except Errors.KafkaError:
+                # Return right away. It's a connection error, so backoff will be
+                # handled by coordinator lookup
+                return None
+            if not self._subscription.active:
+                # Subscription changed. Ignore response and restart group join
+                return None
 
-                error_type = Errors.for_code(response.error_code)
+            error_type = Errors.for_code(response.error_code)
 
-                if error_type is Errors.MemberIdRequired:
-                    self._coordinator.member_id = response.member_id
-                    try_join = True
+            if error_type is Errors.MemberIdRequired:
+                self._coordinator.member_id = response.member_id
+                try_join = True
 
         if error_type is Errors.NoError:
             log.debug("Join group response %s", response)

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1481,12 +1481,8 @@ async def test_join_group_sent_once_with_multiple_assignors():
     coordinator._group_instance_id = None
     coordinator._rebalance_timeout_ms = 30000
 
-    send_req_call_count = 0
-
-    async def mock_send_req(request):
-        nonlocal send_req_call_count
-        send_req_call_count += 1
-        return JoinGroupResponse_v0(
+    coordinator._send_req = mock.AsyncMock(
+        return_value=JoinGroupResponse_v0(
             error_code=Errors.NoError.errno,
             generation_id=1,
             group_protocol="roundrobin",
@@ -1494,8 +1490,7 @@ async def test_join_group_sent_once_with_multiple_assignors():
             member_id="member-1",
             members=[],
         )
-
-    coordinator._send_req = mock_send_req
+    )
 
     subscription = mock.MagicMock()
     subscription.topics = {"topic1"}
@@ -1520,7 +1515,4 @@ async def test_join_group_sent_once_with_multiple_assignors():
 
     await rebalance.perform_group_join()
 
-    assert send_req_call_count == 1, (
-        f"Expected 1 JoinGroupRequest, got {send_req_call_count}. "
-        "The join loop may have been incorrectly nested inside the assignors loop."
-    )
+    coordinator._send_req.assert_awaited_once()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -28,6 +28,8 @@ from aiokafka.protocol.group import (
 )
 from aiokafka.structs import OffsetAndMetadata, TopicPartition
 from aiokafka.util import create_future, create_task, get_running_loop
+from aiokafka.coordinator.assignors.range import RangePartitionAssignor
+from aiokafka.coordinator.assignors.roundrobin import RoundRobinPartitionAssignor
 
 from ._testutil import KafkaIntegrationTestCase, run_until_complete
 
@@ -1471,3 +1473,54 @@ class TestKafkaCoordinatorIntegration(KafkaIntegrationTestCase):
 
         await coordinator.close()
         await client.close()
+
+
+async def test_join_group_sent_once_with_multiple_assignors():
+    coordinator = mock.MagicMock()
+    coordinator.member_id = JoinGroupRequest.UNKNOWN_MEMBER_ID
+    coordinator._group_instance_id = None
+    coordinator._rebalance_timeout_ms = 30000
+
+    send_req_call_count = 0
+
+    async def mock_send_req(request):
+        nonlocal send_req_call_count
+        send_req_call_count += 1
+        return JoinGroupResponse_v0(
+            error_code=Errors.NoError.errno,
+            generation_id=1,
+            group_protocol="roundrobin",
+            leader_id="leader-1",
+            member_id="member-1",
+            members=[],
+        )
+
+    coordinator._send_req = mock_send_req
+
+    subscription = mock.MagicMock()
+    subscription.topics = {"topic1"}
+    subscription.active = True
+
+    assignors = (RoundRobinPartitionAssignor, RangePartitionAssignor)
+
+    rebalance = CoordinatorGroupRebalance(
+        coordinator,
+        group_id="test-group",
+        coordinator_id=1,
+        subscription=subscription,
+        assignors=assignors,
+        session_timeout_ms=10000,
+        retry_backoff_ms=100,
+    )
+
+    async def _on_join_follower():
+        return b"assignment"
+
+    rebalance._on_join_follower = _on_join_follower
+
+    await rebalance.perform_group_join()
+
+    assert send_req_call_count == 1, (
+        f"Expected 1 JoinGroupRequest, got {send_req_call_count}. "
+        "The join loop may have been incorrectly nested inside the assignors loop."
+    )


### PR DESCRIPTION
<!-- Thank you for your contribution! 
Feel free to change the template if you feel confused.
-->
### Changes

Fixes: Don't send more than one JoinGroup request when more than one Assignors are specified

If more than one assignors are specified, the library sends more than one JoinGroup requests. First JoinGroup request includes first specified assignor, second request includes first and second specified assignors etc. This happens because the code responsible for sending the JoinGroup request is inside the `for assignor in self._assignors:` block.

### Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`


