### PR TITLE
Fix spelling typos in source comments and documentation

### DIFF
--- a/aiokafka/consumer/fetcher.py
+++ b/aiokafka/consumer/fetcher.py
@@ -924,7 +924,7 @@ class Fetcher:
         """
         log.debug("Updating fetch positions for partitions %s", tps)
         needs_wakeup = False
-        # The list of partitions provided can consist of paritions that are
+        # The list of partitions provided can consist of partitions that are
         # awaiting reset already and freshly assigned partitions. The second
         # ones can yet have no commit point fetched, so we will check that.
         for tp in tps:

--- a/aiokafka/consumer/group_coordinator.py
+++ b/aiokafka/consumer/group_coordinator.py
@@ -480,7 +480,7 @@ class GroupCoordinator(BaseCoordinator):
 
         # update partition assignment
         self._subscription.assign_from_subscribed(assignment.partitions())
-        # The await bellow can change subscription, remember the ongoing one.
+        # The await below can change subscription, remember the ongoing one.
         subscription = self._subscription.subscription
 
         # give the assignor a chance to update internal state

--- a/aiokafka/record/_crecords/consts.pxi
+++ b/aiokafka/record/_crecords/consts.pxi
@@ -16,7 +16,7 @@ DEF _CONTROL_MASK = 0x20
 #       return to user.
 DEF _LEGACY_RECORD_METADATA_FREELIST_SIZE = 20
 # Fetcher will only use 1 parser per partition, so this is based on how much
-# partitions can be used simultaniously.
+# partitions can be used simultaneously.
 DEF _LEGACY_RECORD_BATCH_FREELIST_SIZE = 100
 DEF _LEGACY_RECORD_FREELIST_SIZE = 100
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -115,7 +115,7 @@ will handle those differently. Possible consumer errors include:
 * :exc:`~aiokafka.errors.TopicAuthorizationFailedError` - topic requires authorization.
   Always raised
 * :exc:`~aiokafka.errors.OffsetOutOfRangeError` - if you don't specify `auto_offset_reset` policy
-  and started cosumption from not valid offset. Always raised
+  and started consumption from not valid offset. Always raised
 * :exc:`~aiokafka.errors.RecordTooLargeError` - broker has a *MessageSet* larger than
   `max_partition_fetch_bytes`. **async for** - log error, **get*** will
   raise it.

--- a/docs/consumer.rst
+++ b/docs/consumer.rst
@@ -503,7 +503,7 @@ the consumer's configuration::
         isolation_level="read_committed"
     )
     await consumer.start()
-    async for msg in consumer:  # Only read committed tranasctions
+    async for msg in consumer:  # Only read committed transactions
         pass
 
 In `read_committed` mode, the consumer will read only those transactional
@@ -523,7 +523,7 @@ of which are in each method's documentation. Finally,
 :meth:`~.AIOKafkaConsumer.highwater` API to query the lSO on a currently
 assigned transaction::
 
-    async for msg in consumer:  # Only read committed tranasctions
+    async for msg in consumer:  # Only read committed transactions
         tp = TopicPartition(msg.topic, msg.partition)
         lso = consumer.last_stable_offset(tp)
         lag = lso - msg.offset

--- a/docs/examples/transaction_example.rst
+++ b/docs/examples/transaction_example.rst
@@ -6,7 +6,7 @@ Transactional Consume-Process-Produce
 If you have a pattern where you want to consume from one topic, process data
 and produce to a different one, you would really like to do it with using
 Transactional Producer. In the example below we read from ``IN_TOPIC``,
-process data and produce the resut to ``OUT_TOPIC`` in a transactional manner.
+process data and produce the result to ``OUT_TOPIC`` in a transactional manner.
 
 
 .. code:: python


### PR DESCRIPTION
## Summary

Fix 6 spelling typos found by [codespell](https://pypi.org/project/codespell/). All changes are in code comments, docstrings, or documentation — no functional change.

| File | Before | After |
|------|--------|-------|
| `aiokafka/record/_crecords/consts.pxi` | `simultaniously` | `simultaneously` |
| `aiokafka/consumer/fetcher.py` | `paritions` | `partitions` |
| `aiokafka/consumer/group_coordinator.py` | `bellow` | `below` |
| `docs/api.rst` | `cosumption` | `consumption` |
| `docs/consumer.rst` (x2) | `tranasctions` | `transactions` |
| `docs/examples/transaction_example.rst` | `resut` | `result` |