### PR TITLE
Add lightweight producer metrics collector

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,7 @@ Changelog
 
 New features:
 
-* Add a lightweight callback-based producer metrics collector protocol
+* Add an experimental lightweight callback-based producer metrics collector API
   (issue #1166)
 * Change the way tagged fields are managed in the protocol definitions
   (pr #1162 by @vmaurin)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Changelog
 
 New features:
 
+* Add a lightweight callback-based producer metrics collector protocol
+  (issue #1166)
 * Change the way tagged fields are managed in the protocol definitions
   (pr #1162 by @vmaurin)
 

--- a/aiokafka/__init__.py
+++ b/aiokafka/__init__.py
@@ -4,7 +4,7 @@ from .abc import ConsumerRebalanceListener
 from .client import AIOKafkaClient
 from .consumer import AIOKafkaConsumer
 from .errors import ConsumerStoppedError, IllegalOperation
-from .metrics import NullProducerMetricsCollector, ProducerMetricsCollector
+from .metrics import ProducerMetricsCollector
 from .producer import AIOKafkaProducer
 from .structs import (
     ConsumerRecord,
@@ -20,7 +20,6 @@ __all__ = [  # noqa: RUF022
     "AIOKafkaClient",
     # Metrics
     "ProducerMetricsCollector",
-    "NullProducerMetricsCollector",
     # ABC's
     "ConsumerRebalanceListener",
     # Errors

--- a/aiokafka/__init__.py
+++ b/aiokafka/__init__.py
@@ -4,6 +4,7 @@ from .abc import ConsumerRebalanceListener
 from .client import AIOKafkaClient
 from .consumer import AIOKafkaConsumer
 from .errors import ConsumerStoppedError, IllegalOperation
+from .metrics import NullMetricsCollector, ProducerMetricsCollector
 from .producer import AIOKafkaProducer
 from .structs import (
     ConsumerRecord,
@@ -17,6 +18,9 @@ __all__ = [  # noqa: RUF022
     "AIOKafkaProducer",
     "AIOKafkaConsumer",
     "AIOKafkaClient",
+    # Metrics
+    "ProducerMetricsCollector",
+    "NullMetricsCollector",
     # ABC's
     "ConsumerRebalanceListener",
     # Errors

--- a/aiokafka/__init__.py
+++ b/aiokafka/__init__.py
@@ -4,7 +4,7 @@ from .abc import ConsumerRebalanceListener
 from .client import AIOKafkaClient
 from .consumer import AIOKafkaConsumer
 from .errors import ConsumerStoppedError, IllegalOperation
-from .metrics import NullMetricsCollector, ProducerMetricsCollector
+from .metrics import NullProducerMetricsCollector, ProducerMetricsCollector
 from .producer import AIOKafkaProducer
 from .structs import (
     ConsumerRecord,
@@ -20,7 +20,7 @@ __all__ = [  # noqa: RUF022
     "AIOKafkaClient",
     # Metrics
     "ProducerMetricsCollector",
-    "NullMetricsCollector",
+    "NullProducerMetricsCollector",
     # ABC's
     "ConsumerRebalanceListener",
     # Errors

--- a/aiokafka/metrics.py
+++ b/aiokafka/metrics.py
@@ -1,8 +1,10 @@
+"""Experimental producer metrics collector API."""
+
 import abc
 
 
 class ProducerMetricsCollector(abc.ABC):
-    """Receive producer batch lifecycle events.
+    """Receive experimental producer batch lifecycle events.
 
     All methods are synchronous and called from the producer hot path.
     Implementations should be fast and non-blocking. If asynchronous work is
@@ -11,10 +13,13 @@ class ProducerMetricsCollector(abc.ABC):
     Exceptions raised by collectors are logged and ignored.
 
     All time-valued arguments are in seconds.
+
+    .. warning::
+        This API is experimental and may change without a deprecation period.
     """
 
     @abc.abstractmethod
-    def on_batch_drained(
+    def on_batch_dispatched(
         self,
         *,
         topic: str,
@@ -22,42 +27,65 @@ class ProducerMetricsCollector(abc.ABC):
         queue_time_seconds: float,
         batch_size_bytes: int,
         record_count: int,
+        attempt: int,
     ) -> None:
-        """Called when a batch leaves the accumulator and is handed to sender."""
+        """Called each time a batch is handed to the sender.
+
+        ``queue_time_seconds`` covers only the queue time for this attempt.
+        ``attempt`` starts at 1. Batch size and record count are reported per
+        attempt and can therefore be observed more than once for retried
+        batches.
+        """
 
     @abc.abstractmethod
-    def on_batch_done(
+    def on_batch_completed(
         self,
         *,
         topic: str,
         partition: int,
-        request_latency_seconds: float,
+        send_to_completion_seconds: float,
         record_count: int,
+        acknowledged: bool,
+        batch_age_seconds: float,
     ) -> None:
-        """Called when the broker acknowledges a batch."""
+        """Called when the producer successfully completes a batch.
+
+        ``acknowledged`` is false when the producer is configured with
+        ``acks=0``. ``batch_age_seconds`` is an upper bound for the latency of
+        records in the batch and includes retries.
+        """
 
     @abc.abstractmethod
-    def on_batch_failure(
+    def on_batch_failed(
         self,
         *,
         topic: str,
         partition: int,
         exception: BaseException,
         record_count: int,
+        batch_age_seconds: float,
     ) -> None:
-        """Called when a batch ultimately fails."""
+        """Called when a batch ultimately fails.
+
+        ``batch_age_seconds`` is an upper bound for the latency of records in
+        the batch and includes retries.
+        """
 
     @abc.abstractmethod
     def on_buffer_wait(
         self, *, topic: str, partition: int, wait_seconds: float
     ) -> None:
-        """Called when appending a record waited for accumulator space."""
+        """Called once when a send operation waited for accumulator space."""
 
 
 class NullProducerMetricsCollector(ProducerMetricsCollector):
-    """Default no-op producer metrics collector."""
+    """Default no-op implementation of the experimental metrics API.
 
-    def on_batch_drained(
+    .. warning::
+        This API is experimental and may change without a deprecation period.
+    """
+
+    def on_batch_dispatched(
         self,
         *,
         topic: str,
@@ -65,26 +93,30 @@ class NullProducerMetricsCollector(ProducerMetricsCollector):
         queue_time_seconds: float,
         batch_size_bytes: int,
         record_count: int,
+        attempt: int,
     ) -> None:
         pass
 
-    def on_batch_done(
+    def on_batch_completed(
         self,
         *,
         topic: str,
         partition: int,
-        request_latency_seconds: float,
+        send_to_completion_seconds: float,
         record_count: int,
+        acknowledged: bool,
+        batch_age_seconds: float,
     ) -> None:
         pass
 
-    def on_batch_failure(
+    def on_batch_failed(
         self,
         *,
         topic: str,
         partition: int,
         exception: BaseException,
         record_count: int,
+        batch_age_seconds: float,
     ) -> None:
         pass
 

--- a/aiokafka/metrics.py
+++ b/aiokafka/metrics.py
@@ -1,5 +1,16 @@
 """Experimental producer metrics collector API."""
 
+import warnings
+
+_CALLBACK_NAMES = frozenset(
+    {
+        "on_batch_completed",
+        "on_batch_dispatched",
+        "on_batch_failed",
+        "on_buffer_wait",
+    }
+)
+
 
 class ProducerMetricsCollector:
     """Receive experimental producer batch lifecycle events.
@@ -11,13 +22,30 @@ class ProducerMetricsCollector:
     Exceptions raised by collectors are logged and ignored.
 
     Each callback has a no-op default implementation. Subclasses only need to
-    override the callbacks they use.
+    override the callbacks they use. Unknown methods starting with ``on_``
+    emit a warning when the subclass is defined to help detect callback name
+    typos.
 
     All time-valued arguments are in seconds.
 
     .. warning::
         This API is experimental and may change without a deprecation period.
     """
+
+    def __init_subclass__(cls, **kwargs) -> None:
+        super().__init_subclass__(**kwargs)
+        unknown_callbacks = sorted(
+            name
+            for name in vars(cls)
+            if name.startswith("on_") and name not in _CALLBACK_NAMES
+        )
+        if unknown_callbacks:
+            warnings.warn(
+                "Unknown producer metrics callbacks (possible typo): "
+                f"{', '.join(unknown_callbacks)}",
+                UserWarning,
+                stacklevel=2,
+            )
 
     def on_batch_dispatched(
         self,

--- a/aiokafka/metrics.py
+++ b/aiokafka/metrics.py
@@ -1,8 +1,7 @@
-from typing import Protocol, runtime_checkable
+import abc
 
 
-@runtime_checkable
-class ProducerMetricsCollector(Protocol):
+class ProducerMetricsCollector(abc.ABC):
     """Receive producer batch lifecycle events.
 
     All methods are synchronous and called from the producer hot path.
@@ -14,45 +13,55 @@ class ProducerMetricsCollector(Protocol):
     All time-valued arguments are in seconds.
     """
 
+    @abc.abstractmethod
     def on_batch_drained(
         self,
+        *,
         topic: str,
+        partition: int,
         queue_time_seconds: float,
         batch_size_bytes: int,
         record_count: int,
     ) -> None:
         """Called when a batch leaves the accumulator and is handed to sender."""
-        ...
 
+    @abc.abstractmethod
     def on_batch_done(
         self,
+        *,
         topic: str,
+        partition: int,
         request_latency_seconds: float,
         record_count: int,
     ) -> None:
         """Called when the broker acknowledges a batch."""
-        ...
 
+    @abc.abstractmethod
     def on_batch_failure(
         self,
+        *,
         topic: str,
+        partition: int,
         exception: BaseException,
         record_count: int,
     ) -> None:
         """Called when a batch ultimately fails."""
-        ...
 
-    def on_buffer_wait(self, topic: str, wait_seconds: float) -> None:
+    @abc.abstractmethod
+    def on_buffer_wait(
+        self, *, topic: str, partition: int, wait_seconds: float
+    ) -> None:
         """Called when appending a record waited for accumulator space."""
-        ...
 
 
-class NullProducerMetricsCollector:
+class NullProducerMetricsCollector(ProducerMetricsCollector):
     """Default no-op producer metrics collector."""
 
     def on_batch_drained(
         self,
+        *,
         topic: str,
+        partition: int,
         queue_time_seconds: float,
         batch_size_bytes: int,
         record_count: int,
@@ -61,7 +70,9 @@ class NullProducerMetricsCollector:
 
     def on_batch_done(
         self,
+        *,
         topic: str,
+        partition: int,
         request_latency_seconds: float,
         record_count: int,
     ) -> None:
@@ -69,11 +80,15 @@ class NullProducerMetricsCollector:
 
     def on_batch_failure(
         self,
+        *,
         topic: str,
+        partition: int,
         exception: BaseException,
         record_count: int,
     ) -> None:
         pass
 
-    def on_buffer_wait(self, topic: str, wait_seconds: float) -> None:
+    def on_buffer_wait(
+        self, *, topic: str, partition: int, wait_seconds: float
+    ) -> None:
         pass

--- a/aiokafka/metrics.py
+++ b/aiokafka/metrics.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class ProducerMetricsCollector(Protocol):
+    """Receive producer batch lifecycle events.
+
+    All methods are synchronous and called from the producer hot path.
+    Implementations should be fast and non-blocking. If asynchronous work is
+    required, defer it via an internal queue.
+
+    Exceptions raised by collectors are logged and ignored.
+
+    All time-valued arguments are in seconds.
+    """
+
+    def on_batch_drained(
+        self,
+        topic: str,
+        queue_time_seconds: float,
+        batch_size_bytes: int,
+        record_count: int,
+    ) -> None:
+        """Called when a batch leaves the accumulator and is handed to sender."""
+        ...
+
+    def on_batch_done(
+        self,
+        topic: str,
+        request_latency_seconds: float,
+        record_count: int,
+    ) -> None:
+        """Called when the broker acknowledges a batch."""
+        ...
+
+    def on_batch_failure(
+        self,
+        topic: str,
+        exception: BaseException,
+        record_count: int,
+    ) -> None:
+        """Called when a batch ultimately fails."""
+        ...
+
+    def on_buffer_wait(self, topic: str, wait_seconds: float) -> None:
+        """Called when appending a record waited for accumulator space."""
+        ...
+
+
+class NullMetricsCollector:
+    """Default no-op producer metrics collector."""
+
+    def on_batch_drained(
+        self,
+        topic: str,
+        queue_time_seconds: float,
+        batch_size_bytes: int,
+        record_count: int,
+    ) -> None:
+        pass
+
+    def on_batch_done(
+        self,
+        topic: str,
+        request_latency_seconds: float,
+        record_count: int,
+    ) -> None:
+        pass
+
+    def on_batch_failure(
+        self,
+        topic: str,
+        exception: BaseException,
+        record_count: int,
+    ) -> None:
+        pass
+
+    def on_buffer_wait(self, topic: str, wait_seconds: float) -> None:
+        pass

--- a/aiokafka/metrics.py
+++ b/aiokafka/metrics.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Protocol, runtime_checkable
 
 
@@ -49,7 +47,7 @@ class ProducerMetricsCollector(Protocol):
         ...
 
 
-class NullMetricsCollector:
+class NullProducerMetricsCollector:
     """Default no-op producer metrics collector."""
 
     def on_batch_drained(

--- a/aiokafka/metrics.py
+++ b/aiokafka/metrics.py
@@ -1,9 +1,7 @@
 """Experimental producer metrics collector API."""
 
-import abc
 
-
-class ProducerMetricsCollector(abc.ABC):
+class ProducerMetricsCollector:
     """Receive experimental producer batch lifecycle events.
 
     All methods are synchronous and called from the producer hot path.
@@ -12,13 +10,15 @@ class ProducerMetricsCollector(abc.ABC):
 
     Exceptions raised by collectors are logged and ignored.
 
+    Each callback has a no-op default implementation. Subclasses only need to
+    override the callbacks they use.
+
     All time-valued arguments are in seconds.
 
     .. warning::
         This API is experimental and may change without a deprecation period.
     """
 
-    @abc.abstractmethod
     def on_batch_dispatched(
         self,
         *,
@@ -37,7 +37,6 @@ class ProducerMetricsCollector(abc.ABC):
         batches.
         """
 
-    @abc.abstractmethod
     def on_batch_completed(
         self,
         *,
@@ -55,7 +54,6 @@ class ProducerMetricsCollector(abc.ABC):
         records in the batch and includes retries.
         """
 
-    @abc.abstractmethod
     def on_batch_failed(
         self,
         *,
@@ -71,56 +69,7 @@ class ProducerMetricsCollector(abc.ABC):
         the batch and includes retries.
         """
 
-    @abc.abstractmethod
     def on_buffer_wait(
         self, *, topic: str, partition: int, wait_seconds: float
     ) -> None:
         """Called once when a send operation waited for accumulator space."""
-
-
-class NullProducerMetricsCollector(ProducerMetricsCollector):
-    """Default no-op implementation of the experimental metrics API.
-
-    .. warning::
-        This API is experimental and may change without a deprecation period.
-    """
-
-    def on_batch_dispatched(
-        self,
-        *,
-        topic: str,
-        partition: int,
-        queue_time_seconds: float,
-        batch_size_bytes: int,
-        record_count: int,
-        attempt: int,
-    ) -> None:
-        pass
-
-    def on_batch_completed(
-        self,
-        *,
-        topic: str,
-        partition: int,
-        send_to_completion_seconds: float,
-        record_count: int,
-        acknowledged: bool,
-        batch_age_seconds: float,
-    ) -> None:
-        pass
-
-    def on_batch_failed(
-        self,
-        *,
-        topic: str,
-        partition: int,
-        exception: BaseException,
-        record_count: int,
-        batch_age_seconds: float,
-    ) -> None:
-        pass
-
-    def on_buffer_wait(
-        self, *, topic: str, partition: int, wait_seconds: float
-    ) -> None:
-        pass

--- a/aiokafka/producer/message_accumulator.py
+++ b/aiokafka/producer/message_accumulator.py
@@ -154,7 +154,8 @@ class MessageBatch:
         self._linger_time = linger_time
         self._metrics_collector = metrics_collector
         self._ctime = time.monotonic()
-        self._drained_at = None
+        self._queued_at = self._ctime
+        self._dispatched_at = None
 
         # Waiters
         # Set when messages are delivered to Kafka based on ACK setting
@@ -213,8 +214,8 @@ class MessageBatch:
         else:
             timestamp_type = 1
 
-        drained_at = self._drained_at
-        should_report = drained_at is not None and not self.future.done()
+        dispatched_at = self._dispatched_at
+        should_report = dispatched_at is not None and not self.future.done()
 
         # Set main batch future
         if not self.future.done():
@@ -252,16 +253,22 @@ class MessageBatch:
             )
 
         if should_report:
+            completed_at = time.monotonic()
             _call_metrics(
-                self._metrics_collector.on_batch_done,
+                self._metrics_collector.on_batch_completed,
                 topic=topic,
                 partition=partition,
-                request_latency_seconds=time.monotonic() - drained_at,
+                send_to_completion_seconds=completed_at - dispatched_at,
                 record_count=self.record_count,
+                acknowledged=True,
+                batch_age_seconds=completed_at - self._ctime,
             )
 
     def done_noack(self):
         """Resolve all pending futures to None"""
+        dispatched_at = self._dispatched_at
+        should_report = dispatched_at is not None and not self.future.done()
+
         # Faster resolve for base_offset=None case.
         if not self.future.done():
             self.future.set_result(None)
@@ -269,6 +276,18 @@ class MessageBatch:
             if future.done():
                 continue
             future.set_result(None)
+
+        if should_report:
+            completed_at = time.monotonic()
+            _call_metrics(
+                self._metrics_collector.on_batch_completed,
+                topic=self._tp.topic,
+                partition=self._tp.partition,
+                send_to_completion_seconds=completed_at - dispatched_at,
+                record_count=self.record_count,
+                acknowledged=False,
+                batch_age_seconds=completed_at - self._ctime,
+            )
 
     def failure(self, exception):
         should_report = not self.future.done()
@@ -293,12 +312,14 @@ class MessageBatch:
             self._drain_waiter.set_exception(exception)
 
         if should_report:
+            failed_at = time.monotonic()
             _call_metrics(
-                self._metrics_collector.on_batch_failure,
+                self._metrics_collector.on_batch_failed,
                 topic=self._tp.topic,
                 partition=self._tp.partition,
                 exception=exception,
                 record_count=self.record_count,
+                batch_age_seconds=failed_at - self._ctime,
             )
 
     async def wait_drain(self, timeout=None):
@@ -327,23 +348,25 @@ class MessageBatch:
             self._drain_waiter.set_result(None)
         self._retry_count += 1
 
-    def send_ready(self):
-        """Record that batch is handed to the sender."""
-        self._drained_at = time.monotonic()
+    def mark_dispatched(self):
+        """Record that the batch is handed to the sender."""
+        self._dispatched_at = time.monotonic()
         _call_metrics(
-            self._metrics_collector.on_batch_drained,
+            self._metrics_collector.on_batch_dispatched,
             topic=self._tp.topic,
             partition=self._tp.partition,
-            queue_time_seconds=self._drained_at - self._ctime,
+            queue_time_seconds=self._dispatched_at - self._queued_at,
             batch_size_bytes=self._builder.size(),
             record_count=self.record_count,
+            attempt=self._retry_count,
         )
 
     def reset_drain(self):
         """Reset drain waiter, until we will do another retry"""
         assert self._drain_waiter.done()
         self._drain_waiter = create_future()
-        self._drained_at = None
+        self._queued_at = time.monotonic()
+        self._dispatched_at = None
 
     def set_producer_state(self, producer_id, producer_epoch, base_sequence):
         assert not self._drain_waiter.done()
@@ -451,44 +474,52 @@ class MessageAccumulator:
         If batch is already full this method waits (`timeout` seconds maximum)
         until batch is drained by send task
         """
-        while True:
-            if self._closed:
-                # this can happen when producer is closing but try to send some
-                # messages in async task
-                raise ProducerClosed()
-            if self._exception is not None:
-                raise copy.copy(self._exception)
+        total_wait_time = 0.0
+        try:
+            while True:
+                if self._closed:
+                    # this can happen when producer is closing but try to send some
+                    # messages in async task
+                    raise ProducerClosed()
+                if self._exception is not None:
+                    raise copy.copy(self._exception)
 
-            pending_batches = self._batches.get(tp)
-            if not pending_batches:
-                builder = self.create_builder()
-                batch = self._append_batch(builder, tp)
-            else:
-                batch = pending_batches[-1]
+                pending_batches = self._batches.get(tp)
+                if not pending_batches:
+                    builder = self.create_builder()
+                    batch = self._append_batch(builder, tp)
+                else:
+                    batch = pending_batches[-1]
 
-            future = batch.append(key, value, timestamp_ms, headers=headers)
-            if future is not None:
-                return future
-            # Batch is full, can't append data atm,
-            # wake up the sender loop
-            # and wait until batch per topic-partition is drained
-            if not self._waiter_future.done():
-                self._waiter_future.set_result(None)
+                future = batch.append(key, value, timestamp_ms, headers=headers)
+                if future is not None:
+                    return future
+                # Batch is full, can't append data atm,
+                # wake up the sender loop
+                # and wait until batch per topic-partition is drained
+                if not self._waiter_future.done():
+                    self._waiter_future.set_result(None)
 
-            start = time.monotonic()
-            try:
-                await batch.wait_drain(timeout)
-            finally:
-                wait_time = time.monotonic() - start
-                _call_metrics(
-                    self._metrics_collector.on_buffer_wait,
-                    topic=tp.topic,
-                    partition=tp.partition,
-                    wait_seconds=wait_time,
-                )
-            timeout -= wait_time
-            if timeout <= 0:
-                raise KafkaTimeoutError()
+                start = time.monotonic()
+                try:
+                    await batch.wait_drain(timeout)
+                finally:
+                    wait_time = time.monotonic() - start
+                    total_wait_time += wait_time
+                    timeout -= wait_time
+                if timeout <= 0:
+                    raise KafkaTimeoutError()
+        finally:
+            self._report_buffer_wait(tp, total_wait_time)
+
+    def _report_buffer_wait(self, tp, wait_seconds):
+        if wait_seconds > 0:
+            _call_metrics(
+                self._metrics_collector.on_buffer_wait,
+                topic=tp.topic,
+                partition=tp.partition,
+                wait_seconds=wait_seconds,
+            )
 
     def waiter(self):
         """Return waiter future that will be resolved when accumulator contain
@@ -570,7 +601,7 @@ class MessageAccumulator:
             # with validation...
             if not batch.is_empty():
                 nodes[leader][tp] = batch
-                batch.send_ready()
+                batch.mark_dispatched()
             else:
                 # XXX: use something more graceful. We just want to trigger
                 # delivery future here, no message futures.
@@ -656,13 +687,21 @@ class MessageAccumulator:
         if self._exception is not None:
             raise copy.copy(self._exception)
 
-        start = time.monotonic()
-        while timeout > 0:
-            pending = self._batches.get(tp)
-            if pending:
-                await pending[-1].wait_drain(timeout=timeout)
-                timeout -= time.monotonic() - start
-            else:
-                batch = self._append_batch(builder, tp)
-                return asyncio.shield(batch.future)
-        raise KafkaTimeoutError()
+        total_wait_time = 0.0
+        try:
+            while timeout > 0:
+                pending = self._batches.get(tp)
+                if pending:
+                    start = time.monotonic()
+                    try:
+                        await pending[-1].wait_drain(timeout=timeout)
+                    finally:
+                        wait_time = time.monotonic() - start
+                        total_wait_time += wait_time
+                        timeout -= wait_time
+                else:
+                    batch = self._append_batch(builder, tp)
+                    return asyncio.shield(batch.future)
+            raise KafkaTimeoutError()
+        finally:
+            self._report_buffer_wait(tp, total_wait_time)

--- a/aiokafka/producer/message_accumulator.py
+++ b/aiokafka/producer/message_accumulator.py
@@ -320,11 +320,14 @@ class MessageBatch:
         return (time.monotonic() - self._ctime) > self._ttl
 
     def drain_ready(self):
-        """Compress batch to be ready for send"""
-        self._drained_at = time.monotonic()
+        """Mark batch as drained from the accumulator."""
         if not self._drain_waiter.done():
             self._drain_waiter.set_result(None)
         self._retry_count += 1
+
+    def send_ready(self):
+        """Record that batch is handed to the sender."""
+        self._drained_at = time.monotonic()
         _call_metrics(
             self._metrics_collector.on_batch_drained,
             self._tp.topic,
@@ -563,6 +566,7 @@ class MessageAccumulator:
             # with validation...
             if not batch.is_empty():
                 nodes[leader][tp] = batch
+                batch.send_ready()
             else:
                 # XXX: use something more graceful. We just want to trigger
                 # delivery future here, no message futures.

--- a/aiokafka/producer/message_accumulator.py
+++ b/aiokafka/producer/message_accumulator.py
@@ -1,6 +1,7 @@
 import asyncio
 import collections
 import copy
+import logging
 import time
 from collections.abc import Sequence
 
@@ -10,9 +11,19 @@ from aiokafka.errors import (
     NotLeaderForPartitionError,
     ProducerClosed,
 )
+from aiokafka.metrics import NullMetricsCollector
 from aiokafka.record.default_records import DefaultRecordBatchBuilder
 from aiokafka.structs import RecordMetadata
 from aiokafka.util import create_future, get_running_loop
+
+log = logging.getLogger(__name__)
+
+
+def _call_metrics(callback, *args):
+    try:
+        callback(*args)
+    except Exception:
+        log.exception("Producer metrics collector callback failed")
 
 
 class BatchBuilder:
@@ -136,12 +147,14 @@ class BatchBuilder:
 class MessageBatch:
     """This class encapsulate operations with batch of produce messages"""
 
-    def __init__(self, tp, builder, ttl, linger_time):
+    def __init__(self, tp, builder, ttl, linger_time, metrics_collector):
         self._builder = builder
         self._tp = tp
         self._ttl = ttl
         self._linger_time = linger_time
+        self._metrics_collector = metrics_collector
         self._ctime = time.monotonic()
+        self._drained_at = None
 
         # Waiters
         # Set when messages are delivered to Kafka based on ACK setting
@@ -200,6 +213,9 @@ class MessageBatch:
         else:
             timestamp_type = 1
 
+        drained_at = self._drained_at
+        should_report = drained_at is not None and not self.future.done()
+
         # Set main batch future
         if not self.future.done():
             self.future.set_result(
@@ -235,6 +251,14 @@ class MessageBatch:
                 )
             )
 
+        if should_report:
+            _call_metrics(
+                self._metrics_collector.on_batch_done,
+                topic,
+                time.monotonic() - drained_at,
+                self.record_count,
+            )
+
     def done_noack(self):
         """Resolve all pending futures to None"""
         # Faster resolve for base_offset=None case.
@@ -246,6 +270,8 @@ class MessageBatch:
             future.set_result(None)
 
     def failure(self, exception):
+        should_report = not self.future.done()
+
         if not self.future.done():
             self.future.set_exception(exception)
         for future, _ in self._msg_futures:
@@ -264,6 +290,14 @@ class MessageBatch:
         # reset also.
         if not self._drain_waiter.done():
             self._drain_waiter.set_exception(exception)
+
+        if should_report:
+            _call_metrics(
+                self._metrics_collector.on_batch_failure,
+                self._tp.topic,
+                exception,
+                self.record_count,
+            )
 
     async def wait_drain(self, timeout=None):
         """Wait until all message from this batch is processed"""
@@ -287,14 +321,23 @@ class MessageBatch:
 
     def drain_ready(self):
         """Compress batch to be ready for send"""
+        self._drained_at = time.monotonic()
         if not self._drain_waiter.done():
             self._drain_waiter.set_result(None)
         self._retry_count += 1
+        _call_metrics(
+            self._metrics_collector.on_batch_drained,
+            self._tp.topic,
+            self._drained_at - self._ctime,
+            self._builder.size(),
+            self.record_count,
+        )
 
     def reset_drain(self):
         """Reset drain waiter, until we will do another retry"""
         assert self._drain_waiter.done()
         self._drain_waiter = create_future()
+        self._drained_at = None
 
     def set_producer_state(self, producer_id, producer_epoch, base_sequence):
         assert not self._drain_waiter.done()
@@ -328,6 +371,7 @@ class MessageAccumulator:
         txn_manager=None,
         loop=None,
         linger_ms=0,
+        metrics_collector=None,
     ):
         if loop is None:
             loop = get_running_loop()
@@ -343,6 +387,9 @@ class MessageAccumulator:
         self._closed = False
         self._txn_manager = txn_manager
         self._linger_time = linger_ms / 1000
+        if metrics_collector is None:
+            metrics_collector = NullMetricsCollector()
+        self._metrics_collector = metrics_collector
 
         self._exception = None  # Critical exception
 
@@ -423,8 +470,16 @@ class MessageAccumulator:
                 self._waiter_future.set_result(None)
 
             start = time.monotonic()
-            await batch.wait_drain(timeout)
-            timeout -= time.monotonic() - start
+            try:
+                await batch.wait_drain(timeout)
+            finally:
+                wait_time = time.monotonic() - start
+                _call_metrics(
+                    self._metrics_collector.on_buffer_wait,
+                    tp.topic,
+                    wait_time,
+                )
+            timeout -= wait_time
             if timeout <= 0:
                 raise KafkaTimeoutError()
 
@@ -558,7 +613,13 @@ class MessageAccumulator:
         if self._txn_manager is not None:
             self._txn_manager.maybe_add_partition_to_txn(tp)
 
-        batch = MessageBatch(tp, builder, self._batch_ttl, self._linger_time)
+        batch = MessageBatch(
+            tp,
+            builder,
+            self._batch_ttl,
+            self._linger_time,
+            self._metrics_collector,
+        )
         self._batches[tp].append(batch)
         if not self._waiter_future.done():
             self._waiter_future.set_result(None)

--- a/aiokafka/producer/message_accumulator.py
+++ b/aiokafka/producer/message_accumulator.py
@@ -11,7 +11,7 @@ from aiokafka.errors import (
     NotLeaderForPartitionError,
     ProducerClosed,
 )
-from aiokafka.metrics import NullProducerMetricsCollector
+from aiokafka.metrics import ProducerMetricsCollector
 from aiokafka.record.default_records import DefaultRecordBatchBuilder
 from aiokafka.structs import RecordMetadata
 from aiokafka.util import create_future, get_running_loop
@@ -417,7 +417,7 @@ class MessageAccumulator:
         self._txn_manager = txn_manager
         self._linger_time = linger_ms / 1000
         if metrics_collector is None:
-            metrics_collector = NullProducerMetricsCollector()
+            metrics_collector = ProducerMetricsCollector()
         self._metrics_collector = metrics_collector
 
         self._exception = None  # Critical exception

--- a/aiokafka/producer/message_accumulator.py
+++ b/aiokafka/producer/message_accumulator.py
@@ -11,7 +11,7 @@ from aiokafka.errors import (
     NotLeaderForPartitionError,
     ProducerClosed,
 )
-from aiokafka.metrics import NullMetricsCollector
+from aiokafka.metrics import NullProducerMetricsCollector
 from aiokafka.record.default_records import DefaultRecordBatchBuilder
 from aiokafka.structs import RecordMetadata
 from aiokafka.util import create_future, get_running_loop
@@ -391,7 +391,7 @@ class MessageAccumulator:
         self._txn_manager = txn_manager
         self._linger_time = linger_ms / 1000
         if metrics_collector is None:
-            metrics_collector = NullMetricsCollector()
+            metrics_collector = NullProducerMetricsCollector()
         self._metrics_collector = metrics_collector
 
         self._exception = None  # Critical exception

--- a/aiokafka/producer/message_accumulator.py
+++ b/aiokafka/producer/message_accumulator.py
@@ -19,9 +19,9 @@ from aiokafka.util import create_future, get_running_loop
 log = logging.getLogger(__name__)
 
 
-def _call_metrics(callback, *args):
+def _call_metrics(callback, **kwargs):
     try:
-        callback(*args)
+        callback(**kwargs)
     except Exception:
         log.exception("Producer metrics collector callback failed")
 
@@ -254,9 +254,10 @@ class MessageBatch:
         if should_report:
             _call_metrics(
                 self._metrics_collector.on_batch_done,
-                topic,
-                time.monotonic() - drained_at,
-                self.record_count,
+                topic=topic,
+                partition=partition,
+                request_latency_seconds=time.monotonic() - drained_at,
+                record_count=self.record_count,
             )
 
     def done_noack(self):
@@ -294,9 +295,10 @@ class MessageBatch:
         if should_report:
             _call_metrics(
                 self._metrics_collector.on_batch_failure,
-                self._tp.topic,
-                exception,
-                self.record_count,
+                topic=self._tp.topic,
+                partition=self._tp.partition,
+                exception=exception,
+                record_count=self.record_count,
             )
 
     async def wait_drain(self, timeout=None):
@@ -330,10 +332,11 @@ class MessageBatch:
         self._drained_at = time.monotonic()
         _call_metrics(
             self._metrics_collector.on_batch_drained,
-            self._tp.topic,
-            self._drained_at - self._ctime,
-            self._builder.size(),
-            self.record_count,
+            topic=self._tp.topic,
+            partition=self._tp.partition,
+            queue_time_seconds=self._drained_at - self._ctime,
+            batch_size_bytes=self._builder.size(),
+            record_count=self.record_count,
         )
 
     def reset_drain(self):
@@ -479,8 +482,9 @@ class MessageAccumulator:
                 wait_time = time.monotonic() - start
                 _call_metrics(
                     self._metrics_collector.on_buffer_wait,
-                    tp.topic,
-                    wait_time,
+                    topic=tp.topic,
+                    partition=tp.partition,
+                    wait_seconds=wait_time,
                 )
             timeout -= wait_time
             if timeout <= 0:

--- a/aiokafka/producer/producer.py
+++ b/aiokafka/producer/producer.py
@@ -10,7 +10,7 @@ from aiokafka.errors import (
     IllegalOperation,
     MessageSizeTooLargeError,
 )
-from aiokafka.metrics import NullMetricsCollector
+from aiokafka.metrics import NullProducerMetricsCollector
 from aiokafka.partitioner import DefaultPartitioner
 from aiokafka.record.default_records import (
     DefaultRecordBatch,
@@ -298,7 +298,7 @@ class AIOKafkaProducer:
         self._max_request_size = max_request_size
         self._request_timeout_ms = request_timeout_ms
         if metrics_collector is None:
-            metrics_collector = NullMetricsCollector()
+            metrics_collector = NullProducerMetricsCollector()
         self._metrics_collector = metrics_collector
 
         self.client = AIOKafkaClient(

--- a/aiokafka/producer/producer.py
+++ b/aiokafka/producer/producer.py
@@ -10,10 +10,7 @@ from aiokafka.errors import (
     IllegalOperation,
     MessageSizeTooLargeError,
 )
-from aiokafka.metrics import (
-    NullProducerMetricsCollector,
-    ProducerMetricsCollector,
-)
+from aiokafka.metrics import ProducerMetricsCollector
 from aiokafka.partitioner import DefaultPartitioner
 from aiokafka.record.default_records import (
     DefaultRecordBatch,
@@ -302,7 +299,7 @@ class AIOKafkaProducer:
         self._max_request_size = max_request_size
         self._request_timeout_ms = request_timeout_ms
         if metrics_collector is None:
-            metrics_collector = NullProducerMetricsCollector()
+            metrics_collector = ProducerMetricsCollector()
         if not isinstance(metrics_collector, ProducerMetricsCollector):
             raise TypeError(
                 "metrics_collector must be an instance of ProducerMetricsCollector"

--- a/aiokafka/producer/producer.py
+++ b/aiokafka/producer/producer.py
@@ -10,7 +10,10 @@ from aiokafka.errors import (
     IllegalOperation,
     MessageSizeTooLargeError,
 )
-from aiokafka.metrics import NullProducerMetricsCollector
+from aiokafka.metrics import (
+    NullProducerMetricsCollector,
+    ProducerMetricsCollector,
+)
 from aiokafka.partitioner import DefaultPartitioner
 from aiokafka.record.default_records import (
     DefaultRecordBatch,
@@ -177,7 +180,8 @@ class AIOKafkaProducer:
             Default: :data:`None`
         metrics_collector (:class:`~aiokafka.metrics.ProducerMetricsCollector`):
             Optional synchronous callback object for producer batch lifecycle
-            metrics. Defaults to a no-op collector.
+            metrics. Defaults to a no-op collector. This API is experimental
+            and may change without a deprecation period.
 
     Note:
         Many configuration parameters are taken from the Java client:
@@ -299,6 +303,10 @@ class AIOKafkaProducer:
         self._request_timeout_ms = request_timeout_ms
         if metrics_collector is None:
             metrics_collector = NullProducerMetricsCollector()
+        if not isinstance(metrics_collector, ProducerMetricsCollector):
+            raise TypeError(
+                "metrics_collector must be an instance of ProducerMetricsCollector"
+            )
         self._metrics_collector = metrics_collector
 
         self.client = AIOKafkaClient(

--- a/aiokafka/producer/producer.py
+++ b/aiokafka/producer/producer.py
@@ -10,6 +10,7 @@ from aiokafka.errors import (
     IllegalOperation,
     MessageSizeTooLargeError,
 )
+from aiokafka.metrics import NullMetricsCollector
 from aiokafka.partitioner import DefaultPartitioner
 from aiokafka.record.default_records import (
     DefaultRecordBatch,
@@ -174,6 +175,9 @@ class AIOKafkaProducer:
         sasl_oauth_token_provider (:class:`~aiokafka.abc.AbstractTokenProvider`):
             OAuthBearer token provider instance.
             Default: :data:`None`
+        metrics_collector (:class:`~aiokafka.metrics.ProducerMetricsCollector`):
+            Optional synchronous callback object for producer batch lifecycle
+            metrics. Defaults to a no-op collector.
 
     Note:
         Many configuration parameters are taken from the Java client:
@@ -222,6 +226,7 @@ class AIOKafkaProducer:
         sasl_kerberos_service_name="kafka",
         sasl_kerberos_domain_name=None,
         sasl_oauth_token_provider=None,
+        metrics_collector=None,
     ):
         if loop is None:
             loop = get_running_loop()
@@ -292,6 +297,9 @@ class AIOKafkaProducer:
         self._partitioner = partitioner
         self._max_request_size = max_request_size
         self._request_timeout_ms = request_timeout_ms
+        if metrics_collector is None:
+            metrics_collector = NullMetricsCollector()
+        self._metrics_collector = metrics_collector
 
         self.client = AIOKafkaClient(
             loop=loop,
@@ -319,6 +327,7 @@ class AIOKafkaProducer:
             txn_manager=self._txn_manager,
             loop=loop,
             linger_ms=linger_ms,
+            metrics_collector=self._metrics_collector,
         )
         self._sender = Sender(
             self.client,

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -32,6 +32,15 @@ Helpers
     :member-order: alphabetical
     :members:
 
+Metrics
+-------
+
+.. autoclass:: aiokafka.metrics.ProducerMetricsCollector
+    :members:
+
+.. autoclass:: aiokafka.metrics.NullMetricsCollector
+    :members:
+
 Abstracts
 ---------
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -38,9 +38,6 @@ Metrics
 .. autoclass:: aiokafka.metrics.ProducerMetricsCollector
     :members:
 
-.. autoclass:: aiokafka.metrics.NullProducerMetricsCollector
-    :members:
-
 Abstracts
 ---------
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -38,7 +38,7 @@ Metrics
 .. autoclass:: aiokafka.metrics.ProducerMetricsCollector
     :members:
 
-.. autoclass:: aiokafka.metrics.NullMetricsCollector
+.. autoclass:: aiokafka.metrics.NullProducerMetricsCollector
     :members:
 
 Abstracts

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -159,6 +159,7 @@ Contents:
    :maxdepth: 3
 
    producer
+   metrics
    consumer
    kafka-python_difference
    api

--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -14,22 +14,24 @@ separate task. Exceptions raised by collectors are logged and ignored.
 
 .. code:: python
 
-    from aiokafka import AIOKafkaProducer
+    from aiokafka import AIOKafkaProducer, ProducerMetricsCollector
 
 
-    class MetricsCollector:
+    class MetricsCollector(ProducerMetricsCollector):
         def on_batch_drained(
-            self, topic, queue_time_seconds, batch_size_bytes, record_count
+            self, *, topic, partition, queue_time_seconds, batch_size_bytes, record_count
         ):
             ...
 
-        def on_batch_done(self, topic, request_latency_seconds, record_count):
+        def on_batch_done(
+            self, *, topic, partition, request_latency_seconds, record_count
+        ):
             ...
 
-        def on_batch_failure(self, topic, exception, record_count):
+        def on_batch_failure(self, *, topic, partition, exception, record_count):
             ...
 
-        def on_buffer_wait(self, topic, wait_seconds):
+        def on_buffer_wait(self, *, topic, partition, wait_seconds):
             ...
 
 
@@ -41,80 +43,85 @@ separate task. Exceptions raised by collectors are logged and ignored.
 Callbacks
 ---------
 
-``on_batch_drained(topic, queue_time_seconds, batch_size_bytes, record_count)``
+``on_batch_drained(*, topic, partition, queue_time_seconds, batch_size_bytes, record_count)``
     Called when a batch leaves the producer accumulator and is handed to the
     sender. ``queue_time_seconds`` measures time from batch creation to drain.
 
-``on_batch_done(topic, request_latency_seconds, record_count)``
+``on_batch_done(*, topic, partition, request_latency_seconds, record_count)``
     Called when the broker acknowledges a batch. ``request_latency_seconds``
     measures time from drain to acknowledgment.
 
-``on_batch_failure(topic, exception, record_count)``
+``on_batch_failure(*, topic, partition, exception, record_count)``
     Called when a batch ultimately fails.
 
-``on_buffer_wait(topic, wait_seconds)``
+``on_buffer_wait(*, topic, partition, wait_seconds)``
     Called when ``send()`` had to wait for accumulator space before appending a
     record.
 
-All durations are reported in seconds. ``topic`` is always passed; collector
-implementations decide whether to use it as a label.
+All durations are reported in seconds. ``topic`` and ``partition`` are always
+passed; collector implementations decide whether to use them as labels.
 
 Prometheus example
 ------------------
 
 .. code:: python
 
+    from aiokafka import ProducerMetricsCollector
     from prometheus_client import Counter, Histogram
 
 
     queue_time = Histogram(
         "aiokafka_producer_record_queue_time_seconds",
         "Time records spent queued in the producer accumulator.",
-        ["topic"],
+        ["topic", "partition"],
     )
     request_latency = Histogram(
         "aiokafka_producer_request_latency_seconds",
         "Time between sending a produce request and receiving acknowledgment.",
-        ["topic"],
+        ["topic", "partition"],
     )
     batch_size = Histogram(
         "aiokafka_producer_batch_size_bytes",
         "Producer batch size in bytes.",
-        ["topic"],
+        ["topic", "partition"],
     )
     records_sent = Counter(
         "aiokafka_producer_records_sent_total",
         "Records acknowledged by the broker.",
-        ["topic"],
+        ["topic", "partition"],
     )
     batch_failures = Counter(
         "aiokafka_producer_batch_failures_total",
         "Producer batches that ultimately failed.",
-        ["topic", "exception"],
+        ["topic", "partition", "exception"],
     )
     buffer_wait = Counter(
         "aiokafka_producer_buffer_wait_seconds_total",
         "Total time spent waiting for producer accumulator space.",
-        ["topic"],
+        ["topic", "partition"],
     )
 
 
-    class PrometheusProducerMetrics:
+    class PrometheusProducerMetrics(ProducerMetricsCollector):
         def on_batch_drained(
-            self, topic, queue_time_seconds, batch_size_bytes, record_count
+            self, *, topic, partition, queue_time_seconds, batch_size_bytes, record_count
         ):
-            queue_time.labels(topic).observe(queue_time_seconds)
-            batch_size.labels(topic).observe(batch_size_bytes)
+            queue_time.labels(topic, partition).observe(queue_time_seconds)
+            batch_size.labels(topic, partition).observe(batch_size_bytes)
 
-        def on_batch_done(self, topic, request_latency_seconds, record_count):
-            request_latency.labels(topic).observe(request_latency_seconds)
-            records_sent.labels(topic).inc(record_count)
+        def on_batch_done(
+            self, *, topic, partition, request_latency_seconds, record_count
+        ):
+            request_latency.labels(topic, partition).observe(request_latency_seconds)
+            records_sent.labels(topic, partition).inc(record_count)
 
-        def on_batch_failure(self, topic, exception, record_count):
-            batch_failures.labels(topic, type(exception).__name__).inc()
+        def on_batch_failure(self, *, topic, partition, exception, record_count):
+            batch_failures.labels(
+                topic, partition, type(exception).__name__
+            ).inc()
 
-        def on_buffer_wait(self, topic, wait_seconds):
-            buffer_wait.labels(topic).inc(wait_seconds)
+        def on_buffer_wait(self, *, topic, partition, wait_seconds):
+            buffer_wait.labels(topic, partition).inc(wait_seconds)
 
 
 API reference

--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -1,0 +1,129 @@
+.. _metrics:
+
+Producer metrics
+================
+
+``AIOKafkaProducer`` can emit lightweight producer batch lifecycle metrics via
+the ``metrics_collector`` constructor argument. The collector is a synchronous
+callback object; aiokafka does not aggregate, sample, export, or depend on a
+metrics backend.
+
+Implementations should keep callbacks fast and non-blocking. If you need to do
+asynchronous work, push the event into an internal queue and process it from a
+separate task. Exceptions raised by collectors are logged and ignored.
+
+.. code:: python
+
+    from aiokafka import AIOKafkaProducer
+
+
+    class MetricsCollector:
+        def on_batch_drained(
+            self, topic, queue_time_seconds, batch_size_bytes, record_count
+        ):
+            ...
+
+        def on_batch_done(self, topic, request_latency_seconds, record_count):
+            ...
+
+        def on_batch_failure(self, topic, exception, record_count):
+            ...
+
+        def on_buffer_wait(self, topic, wait_seconds):
+            ...
+
+
+    producer = AIOKafkaProducer(
+        bootstrap_servers="localhost:9092",
+        metrics_collector=MetricsCollector(),
+    )
+
+Callbacks
+---------
+
+``on_batch_drained(topic, queue_time_seconds, batch_size_bytes, record_count)``
+    Called when a batch leaves the producer accumulator and is handed to the
+    sender. ``queue_time_seconds`` measures time from batch creation to drain.
+
+``on_batch_done(topic, request_latency_seconds, record_count)``
+    Called when the broker acknowledges a batch. ``request_latency_seconds``
+    measures time from drain to acknowledgment.
+
+``on_batch_failure(topic, exception, record_count)``
+    Called when a batch ultimately fails.
+
+``on_buffer_wait(topic, wait_seconds)``
+    Called when ``send()`` had to wait for accumulator space before appending a
+    record.
+
+All durations are reported in seconds. ``topic`` is always passed; collector
+implementations decide whether to use it as a label.
+
+Prometheus example
+------------------
+
+.. code:: python
+
+    from prometheus_client import Counter, Histogram
+
+
+    queue_time = Histogram(
+        "aiokafka_producer_record_queue_time_seconds",
+        "Time records spent queued in the producer accumulator.",
+        ["topic"],
+    )
+    request_latency = Histogram(
+        "aiokafka_producer_request_latency_seconds",
+        "Time between sending a produce request and receiving acknowledgment.",
+        ["topic"],
+    )
+    batch_size = Histogram(
+        "aiokafka_producer_batch_size_bytes",
+        "Producer batch size in bytes.",
+        ["topic"],
+    )
+    records_sent = Counter(
+        "aiokafka_producer_records_sent_total",
+        "Records acknowledged by the broker.",
+        ["topic"],
+    )
+    batch_failures = Counter(
+        "aiokafka_producer_batch_failures_total",
+        "Producer batches that ultimately failed.",
+        ["topic", "exception"],
+    )
+    buffer_wait = Counter(
+        "aiokafka_producer_buffer_wait_seconds_total",
+        "Total time spent waiting for producer accumulator space.",
+        ["topic"],
+    )
+
+
+    class PrometheusProducerMetrics:
+        def on_batch_drained(
+            self, topic, queue_time_seconds, batch_size_bytes, record_count
+        ):
+            queue_time.labels(topic).observe(queue_time_seconds)
+            batch_size.labels(topic).observe(batch_size_bytes)
+
+        def on_batch_done(self, topic, request_latency_seconds, record_count):
+            request_latency.labels(topic).observe(request_latency_seconds)
+            records_sent.labels(topic).inc(record_count)
+
+        def on_batch_failure(self, topic, exception, record_count):
+            batch_failures.labels(topic, type(exception).__name__).inc()
+
+        def on_buffer_wait(self, topic, wait_seconds):
+            buffer_wait.labels(topic).inc(wait_seconds)
+
+
+API reference
+-------------
+
+.. autoclass:: aiokafka.metrics.ProducerMetricsCollector
+    :members:
+    :no-index:
+
+.. autoclass:: aiokafka.metrics.NullMetricsCollector
+    :members:
+    :no-index:

--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -124,6 +124,6 @@ API reference
     :members:
     :no-index:
 
-.. autoclass:: aiokafka.metrics.NullMetricsCollector
+.. autoclass:: aiokafka.metrics.NullProducerMetricsCollector
     :members:
     :no-index:

--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -17,7 +17,8 @@ Implementations should keep callbacks fast and non-blocking. If you need to do
 asynchronous work, push the event into an internal queue and process it from a
 separate task. Exceptions raised by collectors are logged and ignored.
 Every callback has a no-op default, so implementations only need to override
-the callbacks they use.
+the callbacks they use. Defining an unknown method whose name starts with
+``on_`` emits a warning to help catch callback name typos.
 
 .. code:: python
 

--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -3,10 +3,15 @@
 Producer metrics
 ================
 
+.. warning::
+
+    The producer metrics API is experimental and may change without a
+    deprecation period.
+
 ``AIOKafkaProducer`` can emit lightweight producer batch lifecycle metrics via
 the ``metrics_collector`` constructor argument. The collector is a synchronous
-callback object; aiokafka does not aggregate, sample, export, or depend on a
-metrics backend.
+callback object derived from ``ProducerMetricsCollector``; aiokafka does not
+aggregate, sample, export, or depend on a metrics backend.
 
 Implementations should keep callbacks fast and non-blocking. If you need to do
 asynchronous work, push the event into an internal queue and process it from a
@@ -14,49 +19,83 @@ separate task. Exceptions raised by collectors are logged and ignored.
 
 .. code:: python
 
-    from aiokafka import AIOKafkaProducer, ProducerMetricsCollector
+    from aiokafka import AIOKafkaProducer, NullProducerMetricsCollector
 
 
-    class MetricsCollector(ProducerMetricsCollector):
-        def on_batch_drained(
-            self, *, topic, partition, queue_time_seconds, batch_size_bytes, record_count
+    class CompletionMetrics(NullProducerMetricsCollector):
+        def on_batch_completed(
+            self,
+            *,
+            topic,
+            partition,
+            send_to_completion_seconds,
+            record_count,
+            acknowledged,
+            batch_age_seconds,
         ):
-            ...
-
-        def on_batch_done(
-            self, *, topic, partition, request_latency_seconds, record_count
-        ):
-            ...
-
-        def on_batch_failure(self, *, topic, partition, exception, record_count):
-            ...
-
-        def on_buffer_wait(self, *, topic, partition, wait_seconds):
-            ...
+            print(
+                topic,
+                partition,
+                record_count,
+                acknowledged,
+                batch_age_seconds,
+            )
 
 
     producer = AIOKafkaProducer(
         bootstrap_servers="localhost:9092",
-        metrics_collector=MetricsCollector(),
+        metrics_collector=CompletionMetrics(),
     )
 
 Callbacks
 ---------
 
-``on_batch_drained(*, topic, partition, queue_time_seconds, batch_size_bytes, record_count)``
-    Called when a batch leaves the producer accumulator and is handed to the
-    sender. ``queue_time_seconds`` measures time from batch creation to drain.
+``on_batch_dispatched(*, topic, partition, queue_time_seconds, batch_size_bytes, record_count, attempt)``
+    Called every time a batch leaves the accumulator and is handed to the
+    sender. The first attempt is ``1``. Retried batches emit this callback
+    again with an incremented attempt.
 
-``on_batch_done(*, topic, partition, request_latency_seconds, record_count)``
-    Called when the broker acknowledges a batch. ``request_latency_seconds``
-    measures time from drain to acknowledgment.
+    ``queue_time_seconds`` covers only the time spent in the accumulator for
+    this attempt. Retry backoff and earlier attempts are excluded.
+    ``batch_size_bytes`` and ``record_count`` are therefore observed per
+    attempt. Count successfully completed records in a terminal callback
+    instead of this callback if retries must not be double-counted.
 
-``on_batch_failure(*, topic, partition, exception, record_count)``
-    Called when a batch ultimately fails.
+``on_batch_completed(*, topic, partition, send_to_completion_seconds, record_count, acknowledged, batch_age_seconds)``
+    Called once when the producer successfully completes a batch.
+    ``send_to_completion_seconds`` measures time from the final dispatch until
+    producer-side completion.
+
+    ``acknowledged`` is ``True`` when a broker acknowledgment was received.
+    With ``acks=0`` it is ``False`` and completion means that the producer
+    finished sending the request without waiting for a broker response.
+
+    ``batch_age_seconds`` measures time from batch creation to completion and
+    includes retries.
+
+``on_batch_failed(*, topic, partition, exception, record_count, batch_age_seconds)``
+    Called once when a batch ultimately fails. ``batch_age_seconds`` measures
+    time from batch creation to failure and includes retries.
 
 ``on_buffer_wait(*, topic, partition, wait_seconds)``
-    Called when ``send()`` had to wait for accumulator space before appending a
-    record.
+    Called once after a ``send()`` or ``send_batch()`` operation that waited
+    for accumulator space. ``wait_seconds`` is accumulated across all wait
+    loops in that operation. It is also reported when the operation ultimately
+    times out or otherwise fails after waiting.
+
+Granularity
+-----------
+
+The dispatch, completion, and failure callbacks are batch-level events.
+``on_buffer_wait`` is an operation-level event for a single ``send()`` or
+``send_batch()`` call.
+
+``batch_age_seconds`` is an upper bound for per-message latency because records
+can be appended after their batch was created. The API does not track append
+timestamps for individual records and therefore cannot provide exact
+per-message end-to-end latency.
+
+Empty batches emit no lifecycle metrics.
 
 All durations are reported in seconds. ``topic`` and ``partition`` are always
 passed; collector implementations decide whether to use them as labels.
@@ -71,24 +110,34 @@ Prometheus example
 
 
     queue_time = Histogram(
-        "aiokafka_producer_record_queue_time_seconds",
-        "Time records spent queued in the producer accumulator.",
+        "aiokafka_producer_batch_queue_time_seconds",
+        "Time batches spent queued per dispatch attempt.",
         ["topic", "partition"],
     )
-    request_latency = Histogram(
-        "aiokafka_producer_request_latency_seconds",
-        "Time between sending a produce request and receiving acknowledgment.",
-        ["topic", "partition"],
+    send_to_completion = Histogram(
+        "aiokafka_producer_send_to_completion_seconds",
+        "Time from final batch dispatch to producer-side completion.",
+        ["topic", "partition", "acknowledged"],
+    )
+    batch_age = Histogram(
+        "aiokafka_producer_batch_age_seconds",
+        "Time from batch creation to terminal outcome.",
+        ["topic", "partition", "outcome"],
     )
     batch_size = Histogram(
         "aiokafka_producer_batch_size_bytes",
-        "Producer batch size in bytes.",
+        "Producer batch size in bytes per dispatch attempt.",
         ["topic", "partition"],
     )
-    records_sent = Counter(
-        "aiokafka_producer_records_sent_total",
-        "Records acknowledged by the broker.",
+    batch_retries = Counter(
+        "aiokafka_producer_batch_retries_total",
+        "Producer batch retry attempts.",
         ["topic", "partition"],
+    )
+    records_completed = Counter(
+        "aiokafka_producer_records_completed_total",
+        "Records successfully completed by the producer.",
+        ["topic", "partition", "acknowledged"],
     )
     batch_failures = Counter(
         "aiokafka_producer_batch_failures_total",
@@ -103,22 +152,54 @@ Prometheus example
 
 
     class PrometheusProducerMetrics(ProducerMetricsCollector):
-        def on_batch_drained(
-            self, *, topic, partition, queue_time_seconds, batch_size_bytes, record_count
+        def on_batch_dispatched(
+            self,
+            *,
+            topic,
+            partition,
+            queue_time_seconds,
+            batch_size_bytes,
+            record_count,
+            attempt,
         ):
             queue_time.labels(topic, partition).observe(queue_time_seconds)
             batch_size.labels(topic, partition).observe(batch_size_bytes)
+            if attempt > 1:
+                batch_retries.labels(topic, partition).inc()
 
-        def on_batch_done(
-            self, *, topic, partition, request_latency_seconds, record_count
+        def on_batch_completed(
+            self,
+            *,
+            topic,
+            partition,
+            send_to_completion_seconds,
+            record_count,
+            acknowledged,
+            batch_age_seconds,
         ):
-            request_latency.labels(topic, partition).observe(request_latency_seconds)
-            records_sent.labels(topic, partition).inc(record_count)
+            acknowledged_label = str(acknowledged).lower()
+            outcome = "acknowledged" if acknowledged else "unacknowledged"
+            send_to_completion.labels(
+                topic, partition, acknowledged_label
+            ).observe(send_to_completion_seconds)
+            records_completed.labels(
+                topic, partition, acknowledged_label
+            ).inc(record_count)
+            batch_age.labels(topic, partition, outcome).observe(batch_age_seconds)
 
-        def on_batch_failure(self, *, topic, partition, exception, record_count):
+        def on_batch_failed(
+            self,
+            *,
+            topic,
+            partition,
+            exception,
+            record_count,
+            batch_age_seconds,
+        ):
             batch_failures.labels(
                 topic, partition, type(exception).__name__
             ).inc()
+            batch_age.labels(topic, partition, "failed").observe(batch_age_seconds)
 
         def on_buffer_wait(self, *, topic, partition, wait_seconds):
             buffer_wait.labels(topic, partition).inc(wait_seconds)

--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -16,13 +16,15 @@ aggregate, sample, export, or depend on a metrics backend.
 Implementations should keep callbacks fast and non-blocking. If you need to do
 asynchronous work, push the event into an internal queue and process it from a
 separate task. Exceptions raised by collectors are logged and ignored.
+Every callback has a no-op default, so implementations only need to override
+the callbacks they use.
 
 .. code:: python
 
-    from aiokafka import AIOKafkaProducer, NullProducerMetricsCollector
+    from aiokafka import AIOKafkaProducer, ProducerMetricsCollector
 
 
-    class CompletionMetrics(NullProducerMetricsCollector):
+    class CompletionMetrics(ProducerMetricsCollector):
         def on_batch_completed(
             self,
             *,
@@ -209,9 +211,5 @@ API reference
 -------------
 
 .. autoclass:: aiokafka.metrics.ProducerMetricsCollector
-    :members:
-    :no-index:
-
-.. autoclass:: aiokafka.metrics.NullProducerMetricsCollector
     :members:
     :no-index:

--- a/examples/prometheus_metrics.py
+++ b/examples/prometheus_metrics.py
@@ -5,24 +5,34 @@ from prometheus_client import Counter, Histogram, start_http_server
 from aiokafka import AIOKafkaProducer, ProducerMetricsCollector
 
 queue_time = Histogram(
-    "aiokafka_producer_record_queue_time_seconds",
-    "Time records spent queued in the producer accumulator.",
+    "aiokafka_producer_batch_queue_time_seconds",
+    "Time batches spent queued per dispatch attempt.",
     ["topic", "partition"],
 )
-request_latency = Histogram(
-    "aiokafka_producer_request_latency_seconds",
-    "Time between sending a produce request and receiving acknowledgment.",
-    ["topic", "partition"],
+send_to_completion = Histogram(
+    "aiokafka_producer_send_to_completion_seconds",
+    "Time from final batch dispatch to producer-side completion.",
+    ["topic", "partition", "acknowledged"],
+)
+batch_age = Histogram(
+    "aiokafka_producer_batch_age_seconds",
+    "Time from batch creation to terminal outcome.",
+    ["topic", "partition", "outcome"],
 )
 batch_size = Histogram(
     "aiokafka_producer_batch_size_bytes",
-    "Producer batch size in bytes.",
+    "Producer batch size in bytes per dispatch attempt.",
     ["topic", "partition"],
 )
-records_sent = Counter(
-    "aiokafka_producer_records_sent_total",
-    "Records acknowledged by the broker.",
+batch_retries = Counter(
+    "aiokafka_producer_batch_retries_total",
+    "Producer batch retry attempts.",
     ["topic", "partition"],
+)
+records_completed = Counter(
+    "aiokafka_producer_records_completed_total",
+    "Records successfully completed by the producer.",
+    ["topic", "partition", "acknowledged"],
 )
 batch_failures = Counter(
     "aiokafka_producer_batch_failures_total",
@@ -37,18 +47,50 @@ buffer_wait = Counter(
 
 
 class PrometheusProducerMetrics(ProducerMetricsCollector):
-    def on_batch_drained(
-        self, *, topic, partition, queue_time_seconds, batch_size_bytes, record_count
+    def on_batch_dispatched(
+        self,
+        *,
+        topic,
+        partition,
+        queue_time_seconds,
+        batch_size_bytes,
+        record_count,
+        attempt,
     ):
         queue_time.labels(topic, partition).observe(queue_time_seconds)
         batch_size.labels(topic, partition).observe(batch_size_bytes)
+        if attempt > 1:
+            batch_retries.labels(topic, partition).inc()
 
-    def on_batch_done(self, *, topic, partition, request_latency_seconds, record_count):
-        request_latency.labels(topic, partition).observe(request_latency_seconds)
-        records_sent.labels(topic, partition).inc(record_count)
+    def on_batch_completed(
+        self,
+        *,
+        topic,
+        partition,
+        send_to_completion_seconds,
+        record_count,
+        acknowledged,
+        batch_age_seconds,
+    ):
+        acknowledged_label = str(acknowledged).lower()
+        outcome = "acknowledged" if acknowledged else "unacknowledged"
+        send_to_completion.labels(topic, partition, acknowledged_label).observe(
+            send_to_completion_seconds
+        )
+        records_completed.labels(topic, partition, acknowledged_label).inc(record_count)
+        batch_age.labels(topic, partition, outcome).observe(batch_age_seconds)
 
-    def on_batch_failure(self, *, topic, partition, exception, record_count):
+    def on_batch_failed(
+        self,
+        *,
+        topic,
+        partition,
+        exception,
+        record_count,
+        batch_age_seconds,
+    ):
         batch_failures.labels(topic, partition, type(exception).__name__).inc()
+        batch_age.labels(topic, partition, "failed").observe(batch_age_seconds)
 
     def on_buffer_wait(self, *, topic, partition, wait_seconds):
         buffer_wait.labels(topic, partition).inc(wait_seconds)

--- a/examples/prometheus_metrics.py
+++ b/examples/prometheus_metrics.py
@@ -1,0 +1,72 @@
+import asyncio
+
+from prometheus_client import Counter, Histogram, start_http_server
+
+from aiokafka import AIOKafkaProducer
+
+queue_time = Histogram(
+    "aiokafka_producer_record_queue_time_seconds",
+    "Time records spent queued in the producer accumulator.",
+    ["topic"],
+)
+request_latency = Histogram(
+    "aiokafka_producer_request_latency_seconds",
+    "Time between sending a produce request and receiving acknowledgment.",
+    ["topic"],
+)
+batch_size = Histogram(
+    "aiokafka_producer_batch_size_bytes",
+    "Producer batch size in bytes.",
+    ["topic"],
+)
+records_sent = Counter(
+    "aiokafka_producer_records_sent_total",
+    "Records acknowledged by the broker.",
+    ["topic"],
+)
+batch_failures = Counter(
+    "aiokafka_producer_batch_failures_total",
+    "Producer batches that ultimately failed.",
+    ["topic", "exception"],
+)
+buffer_wait = Counter(
+    "aiokafka_producer_buffer_wait_seconds_total",
+    "Total time spent waiting for producer accumulator space.",
+    ["topic"],
+)
+
+
+class PrometheusProducerMetrics:
+    def on_batch_drained(
+        self, topic, queue_time_seconds, batch_size_bytes, record_count
+    ):
+        queue_time.labels(topic).observe(queue_time_seconds)
+        batch_size.labels(topic).observe(batch_size_bytes)
+
+    def on_batch_done(self, topic, request_latency_seconds, record_count):
+        request_latency.labels(topic).observe(request_latency_seconds)
+        records_sent.labels(topic).inc(record_count)
+
+    def on_batch_failure(self, topic, exception, record_count):
+        batch_failures.labels(topic, type(exception).__name__).inc()
+
+    def on_buffer_wait(self, topic, wait_seconds):
+        buffer_wait.labels(topic).inc(wait_seconds)
+
+
+async def produce():
+    start_http_server(8000)
+    producer = AIOKafkaProducer(
+        bootstrap_servers="localhost:9092",
+        metrics_collector=PrometheusProducerMetrics(),
+    )
+    await producer.start()
+    try:
+        while True:
+            await producer.send_and_wait("test-topic", b"Super message")
+            await asyncio.sleep(1)
+    finally:
+        await producer.stop()
+
+
+asyncio.run(produce())

--- a/examples/prometheus_metrics.py
+++ b/examples/prometheus_metrics.py
@@ -2,56 +2,56 @@ import asyncio
 
 from prometheus_client import Counter, Histogram, start_http_server
 
-from aiokafka import AIOKafkaProducer
+from aiokafka import AIOKafkaProducer, ProducerMetricsCollector
 
 queue_time = Histogram(
     "aiokafka_producer_record_queue_time_seconds",
     "Time records spent queued in the producer accumulator.",
-    ["topic"],
+    ["topic", "partition"],
 )
 request_latency = Histogram(
     "aiokafka_producer_request_latency_seconds",
     "Time between sending a produce request and receiving acknowledgment.",
-    ["topic"],
+    ["topic", "partition"],
 )
 batch_size = Histogram(
     "aiokafka_producer_batch_size_bytes",
     "Producer batch size in bytes.",
-    ["topic"],
+    ["topic", "partition"],
 )
 records_sent = Counter(
     "aiokafka_producer_records_sent_total",
     "Records acknowledged by the broker.",
-    ["topic"],
+    ["topic", "partition"],
 )
 batch_failures = Counter(
     "aiokafka_producer_batch_failures_total",
     "Producer batches that ultimately failed.",
-    ["topic", "exception"],
+    ["topic", "partition", "exception"],
 )
 buffer_wait = Counter(
     "aiokafka_producer_buffer_wait_seconds_total",
     "Total time spent waiting for producer accumulator space.",
-    ["topic"],
+    ["topic", "partition"],
 )
 
 
-class PrometheusProducerMetrics:
+class PrometheusProducerMetrics(ProducerMetricsCollector):
     def on_batch_drained(
-        self, topic, queue_time_seconds, batch_size_bytes, record_count
+        self, *, topic, partition, queue_time_seconds, batch_size_bytes, record_count
     ):
-        queue_time.labels(topic).observe(queue_time_seconds)
-        batch_size.labels(topic).observe(batch_size_bytes)
+        queue_time.labels(topic, partition).observe(queue_time_seconds)
+        batch_size.labels(topic, partition).observe(batch_size_bytes)
 
-    def on_batch_done(self, topic, request_latency_seconds, record_count):
-        request_latency.labels(topic).observe(request_latency_seconds)
-        records_sent.labels(topic).inc(record_count)
+    def on_batch_done(self, *, topic, partition, request_latency_seconds, record_count):
+        request_latency.labels(topic, partition).observe(request_latency_seconds)
+        records_sent.labels(topic, partition).inc(record_count)
 
-    def on_batch_failure(self, topic, exception, record_count):
-        batch_failures.labels(topic, type(exception).__name__).inc()
+    def on_batch_failure(self, *, topic, partition, exception, record_count):
+        batch_failures.labels(topic, partition, type(exception).__name__).inc()
 
-    def on_buffer_wait(self, topic, wait_seconds):
-        buffer_wait.labels(topic).inc(wait_seconds)
+    def on_buffer_wait(self, *, topic, partition, wait_seconds):
+        buffer_wait.labels(topic, partition).inc(wait_seconds)
 
 
 async def produce():

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -229,9 +229,9 @@ async def test_metrics_collector_records_buffer_wait_on_timeout():
     buffer_wait_events = [
         event for event in collector.events if event[0] == "buffer_wait"
     ]
-    assert len(buffer_wait_events) == 1
-    assert buffer_wait_events[0][1] == "test-topic"
-    assert buffer_wait_events[0][2] >= 0
+    assert buffer_wait_events
+    assert all(event[1] == "test-topic" for event in buffer_wait_events)
+    assert all(event[2] >= 0 for event in buffer_wait_events)
 
 
 @pytest.mark.asyncio

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -6,7 +6,7 @@ import pytest
 
 from aiokafka import AIOKafkaProducer, NullMetricsCollector, ProducerMetricsCollector
 from aiokafka.cluster import ClusterMetadata
-from aiokafka.errors import KafkaTimeoutError
+from aiokafka.errors import KafkaTimeoutError, NotLeaderForPartitionError
 from aiokafka.producer.message_accumulator import MessageAccumulator
 from aiokafka.structs import TopicPartition
 
@@ -48,6 +48,12 @@ class RaisingMetricsCollector(RecordingMetricsCollector):
 def make_cluster():
     cluster = ClusterMetadata(metadata_max_age_ms=10000)
     cluster.leader_for_partition = mock.Mock(return_value=0)
+    return cluster
+
+
+def make_cluster_without_leader():
+    cluster = ClusterMetadata(metadata_max_age_ms=10000)
+    cluster.leader_for_partition = mock.Mock(return_value=None)
     return cluster
 
 
@@ -181,10 +187,51 @@ async def test_metrics_not_reported_after_batch_already_completed():
     batch.failure(RuntimeError("late failure"))
 
     assert await future is None
-    assert [event[0] for event in collector.events] == [
-        "batch_drained",
-        "batch_drained",
-    ]
+    assert [event[0] for event in collector.events] == ["batch_drained"]
+
+
+@pytest.mark.asyncio
+async def test_metrics_not_drained_for_expired_batch_without_leader():
+    tp = TopicPartition("test-topic", 0)
+    collector = RecordingMetricsCollector()
+    accumulator = MessageAccumulator(
+        make_cluster_without_leader(),
+        batch_size=1000,
+        compression_type=0,
+        batch_ttl=-1,
+        metrics_collector=collector,
+    )
+
+    future = await accumulator.add_message(tp, None, b"value", timeout=2)
+    batches, unknown_leaders_exist = accumulator.drain_by_nodes(ignore_nodes=[])
+
+    assert batches == {}
+    assert unknown_leaders_exist
+    assert future.done()
+    future_exception = future.exception()
+    assert isinstance(future_exception, NotLeaderForPartitionError)
+    assert [event[0] for event in collector.events] == ["batch_failure"]
+
+
+@pytest.mark.asyncio
+async def test_metrics_not_drained_for_empty_batch():
+    tp = TopicPartition("test-topic", 0)
+    collector = RecordingMetricsCollector()
+    accumulator = MessageAccumulator(
+        make_cluster(),
+        batch_size=1000,
+        compression_type=0,
+        batch_ttl=30,
+        metrics_collector=collector,
+    )
+
+    future = await accumulator.add_batch(accumulator.create_builder(), tp, timeout=2)
+    batches, unknown_leaders_exist = accumulator.drain_by_nodes(ignore_nodes=[])
+
+    assert batches == {}
+    assert not unknown_leaders_exist
+    assert await future is None
+    assert collector.events == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -4,7 +4,11 @@ from unittest import mock
 
 import pytest
 
-from aiokafka import AIOKafkaProducer, NullMetricsCollector, ProducerMetricsCollector
+from aiokafka import (
+    AIOKafkaProducer,
+    NullProducerMetricsCollector,
+    ProducerMetricsCollector,
+)
 from aiokafka.cluster import ClusterMetadata
 from aiokafka.errors import KafkaTimeoutError, NotLeaderForPartitionError
 from aiokafka.producer.message_accumulator import MessageAccumulator
@@ -135,7 +139,7 @@ async def test_message_accumulator_uses_null_metrics_collector_by_default():
         batch_ttl=30,
     )
 
-    assert isinstance(accumulator._metrics_collector, NullMetricsCollector)
+    assert isinstance(accumulator._metrics_collector, NullProducerMetricsCollector)
 
 
 @pytest.mark.asyncio
@@ -318,7 +322,7 @@ async def test_producer_passes_metrics_collector_to_accumulator():
 
 
 def test_null_metrics_collector_is_protocol_implementation():
-    collector = NullMetricsCollector()
+    collector = NullProducerMetricsCollector()
 
     assert isinstance(collector, ProducerMetricsCollector)
     collector.on_batch_drained("topic", 0.1, 1, 1)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from unittest import mock
 
 import pytest
@@ -35,6 +36,13 @@ class RecordingMetricsCollector:
 
     def on_buffer_wait(self, topic, wait_seconds):
         self.events.append(("buffer_wait", topic, wait_seconds))
+
+
+class RaisingMetricsCollector(RecordingMetricsCollector):
+    def on_batch_drained(
+        self, topic, queue_time_seconds, batch_size_bytes, record_count
+    ):
+        raise RuntimeError("collector failed")
 
 
 def make_cluster():
@@ -110,6 +118,94 @@ async def test_metrics_collector_records_buffer_wait():
     assert len(buffer_wait_events) == 1
     assert buffer_wait_events[0][1] == "test-topic"
     assert buffer_wait_events[0][2] >= 0
+
+
+@pytest.mark.asyncio
+async def test_message_accumulator_uses_null_metrics_collector_by_default():
+    accumulator = MessageAccumulator(
+        make_cluster(),
+        batch_size=1000,
+        compression_type=0,
+        batch_ttl=30,
+    )
+
+    assert isinstance(accumulator._metrics_collector, NullMetricsCollector)
+
+
+@pytest.mark.asyncio
+async def test_metrics_collector_exceptions_are_logged_and_ignored(caplog):
+    tp = TopicPartition("test-topic", 0)
+    collector = RaisingMetricsCollector()
+    accumulator = MessageAccumulator(
+        make_cluster(),
+        batch_size=1000,
+        compression_type=0,
+        batch_ttl=30,
+        metrics_collector=collector,
+    )
+    caplog.set_level(logging.ERROR, logger="aiokafka.producer.message_accumulator")
+
+    future = await accumulator.add_message(tp, None, b"value", timeout=2)
+    batches, unknown_leaders_exist = accumulator.drain_by_nodes(ignore_nodes=[])
+    batch = batches[0][tp]
+
+    assert not unknown_leaders_exist
+    assert not future.done()
+    assert "Producer metrics collector callback failed" in caplog.text
+
+    batch.done(base_offset=10)
+    metadata = await future
+    assert metadata.topic == "test-topic"
+
+
+@pytest.mark.asyncio
+async def test_metrics_not_reported_after_batch_already_completed():
+    tp = TopicPartition("test-topic", 0)
+    collector = RecordingMetricsCollector()
+    accumulator = MessageAccumulator(
+        make_cluster(),
+        batch_size=1000,
+        compression_type=0,
+        batch_ttl=30,
+        metrics_collector=collector,
+    )
+
+    future = await accumulator.add_message(tp, None, b"value", timeout=2)
+    batches, _ = accumulator.drain_by_nodes(ignore_nodes=[])
+    batch = batches[0][tp]
+
+    batch.drain_ready()
+    batch.done_noack()
+    batch.done_noack()
+    batch.done(base_offset=10)
+    batch.failure(RuntimeError("late failure"))
+
+    assert await future is None
+    assert [event[0] for event in collector.events] == [
+        "batch_drained",
+        "batch_drained",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_metrics_collector_records_batch_failure_before_drain():
+    tp = TopicPartition("test-topic", 0)
+    collector = RecordingMetricsCollector()
+    accumulator = MessageAccumulator(
+        make_cluster(),
+        batch_size=1000,
+        compression_type=0,
+        batch_ttl=30,
+        metrics_collector=collector,
+    )
+
+    future = await accumulator.add_message(tp, None, b"value", timeout=2)
+    exc = RuntimeError("sender failed")
+    accumulator.fail_all(exc)
+
+    with pytest.raises(RuntimeError, match="sender failed"):
+        await future
+    assert ("batch_failure", "test-topic", exc, 1) in collector.events
 
 
 @pytest.mark.asyncio

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -15,36 +15,39 @@ from aiokafka.producer.message_accumulator import MessageAccumulator
 from aiokafka.structs import TopicPartition
 
 
-class RecordingMetricsCollector:
+class RecordingMetricsCollector(ProducerMetricsCollector):
     def __init__(self):
         self.events = []
 
     def on_batch_drained(
-        self, topic, queue_time_seconds, batch_size_bytes, record_count
+        self, *, topic, partition, queue_time_seconds, batch_size_bytes, record_count
     ):
         self.events.append(
             (
                 "batch_drained",
                 topic,
+                partition,
                 queue_time_seconds,
                 batch_size_bytes,
                 record_count,
             )
         )
 
-    def on_batch_done(self, topic, request_latency_seconds, record_count):
-        self.events.append(("batch_done", topic, request_latency_seconds, record_count))
+    def on_batch_done(self, *, topic, partition, request_latency_seconds, record_count):
+        self.events.append(
+            ("batch_done", topic, partition, request_latency_seconds, record_count)
+        )
 
-    def on_batch_failure(self, topic, exception, record_count):
-        self.events.append(("batch_failure", topic, exception, record_count))
+    def on_batch_failure(self, *, topic, partition, exception, record_count):
+        self.events.append(("batch_failure", topic, partition, exception, record_count))
 
-    def on_buffer_wait(self, topic, wait_seconds):
-        self.events.append(("buffer_wait", topic, wait_seconds))
+    def on_buffer_wait(self, *, topic, partition, wait_seconds):
+        self.events.append(("buffer_wait", topic, partition, wait_seconds))
 
 
 class RaisingMetricsCollector(RecordingMetricsCollector):
     def on_batch_drained(
-        self, topic, queue_time_seconds, batch_size_bytes, record_count
+        self, *, topic, partition, queue_time_seconds, batch_size_bytes, record_count
     ):
         raise RuntimeError("collector failed")
 
@@ -92,10 +95,10 @@ async def test_metrics_collector_records_batch_lifecycle():
 
     metadata = await future
     assert metadata.topic == "test-topic"
-    assert collector.events[0][:3] == ("batch_drained", "test-topic", 0.75)
-    assert collector.events[0][3] > 0
-    assert collector.events[0][4] == 1
-    assert collector.events[1] == ("batch_done", "test-topic", 0.25, 1)
+    assert collector.events[0][:4] == ("batch_drained", "test-topic", 0, 0.75)
+    assert collector.events[0][4] > 0
+    assert collector.events[0][5] == 1
+    assert collector.events[1] == ("batch_done", "test-topic", 0, 0.25, 1)
 
 
 @pytest.mark.asyncio
@@ -127,7 +130,8 @@ async def test_metrics_collector_records_buffer_wait():
     ]
     assert len(buffer_wait_events) == 1
     assert buffer_wait_events[0][1] == "test-topic"
-    assert buffer_wait_events[0][2] >= 0
+    assert buffer_wait_events[0][2] == 0
+    assert buffer_wait_events[0][3] >= 0
 
 
 @pytest.mark.asyncio
@@ -256,7 +260,7 @@ async def test_metrics_collector_records_batch_failure_before_drain():
 
     with pytest.raises(RuntimeError, match="sender failed"):
         await future
-    assert ("batch_failure", "test-topic", exc, 1) in collector.events
+    assert ("batch_failure", "test-topic", 0, exc, 1) in collector.events
 
 
 @pytest.mark.asyncio
@@ -282,7 +286,8 @@ async def test_metrics_collector_records_buffer_wait_on_timeout():
     ]
     assert buffer_wait_events
     assert all(event[1] == "test-topic" for event in buffer_wait_events)
-    assert all(event[2] >= 0 for event in buffer_wait_events)
+    assert all(event[2] == 0 for event in buffer_wait_events)
+    assert all(event[3] >= 0 for event in buffer_wait_events)
 
 
 @pytest.mark.asyncio
@@ -307,7 +312,7 @@ async def test_metrics_collector_records_batch_failure():
     future_exception = future.exception()
     assert isinstance(future_exception, RuntimeError)
     assert str(future_exception) == "delivery failed"
-    assert ("batch_failure", "test-topic", exc, 1) in collector.events
+    assert ("batch_failure", "test-topic", 0, exc, 1) in collector.events
 
 
 @pytest.mark.asyncio
@@ -321,11 +326,32 @@ async def test_producer_passes_metrics_collector_to_accumulator():
         await producer.stop()
 
 
-def test_null_metrics_collector_is_protocol_implementation():
+def test_null_metrics_collector_is_abc_implementation():
     collector = NullProducerMetricsCollector()
 
     assert isinstance(collector, ProducerMetricsCollector)
-    collector.on_batch_drained("topic", 0.1, 1, 1)
-    collector.on_batch_done("topic", 0.2, 1)
-    collector.on_batch_failure("topic", RuntimeError("boom"), 1)
-    collector.on_buffer_wait("topic", 0.3)
+    collector.on_batch_drained(
+        topic="topic",
+        partition=0,
+        queue_time_seconds=0.1,
+        batch_size_bytes=1,
+        record_count=1,
+    )
+    collector.on_batch_done(
+        topic="topic",
+        partition=0,
+        request_latency_seconds=0.2,
+        record_count=1,
+    )
+    collector.on_batch_failure(
+        topic="topic",
+        partition=0,
+        exception=RuntimeError("boom"),
+        record_count=1,
+    )
+    collector.on_buffer_wait(topic="topic", partition=0, wait_seconds=0.3)
+
+
+def test_producer_metrics_collector_is_abstract():
+    with pytest.raises(TypeError, match="abstract class"):
+        ProducerMetricsCollector()

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -12,6 +12,7 @@ from aiokafka import (
 from aiokafka.cluster import ClusterMetadata
 from aiokafka.errors import KafkaTimeoutError, NotLeaderForPartitionError
 from aiokafka.producer.message_accumulator import MessageAccumulator
+from aiokafka.producer.sender import SendProduceReqHandler
 from aiokafka.structs import TopicPartition
 
 
@@ -19,35 +20,78 @@ class RecordingMetricsCollector(ProducerMetricsCollector):
     def __init__(self):
         self.events = []
 
-    def on_batch_drained(
-        self, *, topic, partition, queue_time_seconds, batch_size_bytes, record_count
+    def on_batch_dispatched(
+        self,
+        *,
+        topic,
+        partition,
+        queue_time_seconds,
+        batch_size_bytes,
+        record_count,
+        attempt,
     ):
         self.events.append(
             (
-                "batch_drained",
+                "batch_dispatched",
                 topic,
                 partition,
                 queue_time_seconds,
                 batch_size_bytes,
                 record_count,
+                attempt,
             )
         )
 
-    def on_batch_done(self, *, topic, partition, request_latency_seconds, record_count):
+    def on_batch_completed(
+        self,
+        *,
+        topic,
+        partition,
+        send_to_completion_seconds,
+        record_count,
+        acknowledged,
+        batch_age_seconds,
+    ):
         self.events.append(
-            ("batch_done", topic, partition, request_latency_seconds, record_count)
+            (
+                "batch_completed",
+                topic,
+                partition,
+                send_to_completion_seconds,
+                record_count,
+                acknowledged,
+                batch_age_seconds,
+            )
         )
 
-    def on_batch_failure(self, *, topic, partition, exception, record_count):
-        self.events.append(("batch_failure", topic, partition, exception, record_count))
+    def on_batch_failed(
+        self, *, topic, partition, exception, record_count, batch_age_seconds
+    ):
+        self.events.append(
+            (
+                "batch_failed",
+                topic,
+                partition,
+                exception,
+                record_count,
+                batch_age_seconds,
+            )
+        )
 
     def on_buffer_wait(self, *, topic, partition, wait_seconds):
         self.events.append(("buffer_wait", topic, partition, wait_seconds))
 
 
 class RaisingMetricsCollector(RecordingMetricsCollector):
-    def on_batch_drained(
-        self, *, topic, partition, queue_time_seconds, batch_size_bytes, record_count
+    def on_batch_dispatched(
+        self,
+        *,
+        topic,
+        partition,
+        queue_time_seconds,
+        batch_size_bytes,
+        record_count,
+        attempt,
     ):
         raise RuntimeError("collector failed")
 
@@ -95,10 +139,136 @@ async def test_metrics_collector_records_batch_lifecycle():
 
     metadata = await future
     assert metadata.topic == "test-topic"
-    assert collector.events[0][:4] == ("batch_drained", "test-topic", 0, 0.75)
+    assert collector.events[0][:4] == ("batch_dispatched", "test-topic", 0, 0.75)
     assert collector.events[0][4] > 0
     assert collector.events[0][5] == 1
-    assert collector.events[1] == ("batch_done", "test-topic", 0, 0.25, 1)
+    assert collector.events[0][6] == 1
+    assert collector.events[1] == (
+        "batch_completed",
+        "test-topic",
+        0,
+        0.25,
+        1,
+        True,
+        1.0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_metrics_collector_records_each_dispatch_attempt():
+    tp = TopicPartition("test-topic", 0)
+    collector = RecordingMetricsCollector()
+    clock = [10.0]
+
+    with mock.patch(
+        "aiokafka.producer.message_accumulator.time.monotonic",
+        side_effect=lambda: clock[0],
+    ):
+        accumulator = MessageAccumulator(
+            make_cluster(),
+            batch_size=1000,
+            compression_type=0,
+            batch_ttl=30,
+            metrics_collector=collector,
+        )
+
+        future = await accumulator.add_message(tp, None, b"value", timeout=2)
+
+        clock[0] = 10.5
+        batches, _ = accumulator.drain_by_nodes(ignore_nodes=[])
+        batch = batches[0][tp]
+
+        clock[0] = 11.0
+        accumulator.reenqueue(batch)
+
+        clock[0] = 11.25
+        batches, _ = accumulator.drain_by_nodes(ignore_nodes=[])
+        assert batches[0][tp] is batch
+
+        clock[0] = 12.0
+        batch.done(base_offset=10)
+
+    await future
+    dispatched_events = [
+        event for event in collector.events if event[0] == "batch_dispatched"
+    ]
+    assert len(dispatched_events) == 2
+    assert dispatched_events[0][3] == 0.5
+    assert dispatched_events[0][6] == 1
+    assert dispatched_events[1][3] == 0.25
+    assert dispatched_events[1][6] == 2
+    assert collector.events[-1] == (
+        "batch_completed",
+        "test-topic",
+        0,
+        0.75,
+        1,
+        True,
+        2.0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_metrics_collector_records_unacknowledged_completion():
+    tp = TopicPartition("test-topic", 0)
+    collector = RecordingMetricsCollector()
+    clock = [20.0]
+
+    with mock.patch(
+        "aiokafka.producer.message_accumulator.time.monotonic",
+        side_effect=lambda: clock[0],
+    ):
+        accumulator = MessageAccumulator(
+            make_cluster(),
+            batch_size=1000,
+            compression_type=0,
+            batch_ttl=30,
+            metrics_collector=collector,
+        )
+
+        future = await accumulator.add_message(tp, None, b"value", timeout=2)
+        clock[0] = 20.5
+        batches, _ = accumulator.drain_by_nodes(ignore_nodes=[])
+        clock[0] = 20.75
+        batches[0][tp].done_noack()
+
+    assert await future is None
+    assert collector.events[-1] == (
+        "batch_completed",
+        "test-topic",
+        0,
+        0.25,
+        1,
+        False,
+        0.75,
+    )
+
+
+@pytest.mark.asyncio
+async def test_metrics_collector_records_acks_zero_completion():
+    tp = TopicPartition("test-topic", 0)
+    collector = RecordingMetricsCollector()
+    producer = AIOKafkaProducer(acks=0, metrics_collector=collector)
+    producer._metadata.leader_for_partition = mock.Mock(return_value=0)
+    producer.client.send = mock.AsyncMock(return_value=None)
+
+    try:
+        future = await producer._message_accumulator.add_message(
+            tp, None, b"value", timeout=2
+        )
+        batches, _ = producer._message_accumulator.drain_by_nodes(ignore_nodes=[])
+        handler = SendProduceReqHandler(producer._sender, batches[0])
+
+        await handler.do(0)
+
+        assert await future is None
+        completed_events = [
+            event for event in collector.events if event[0] == "batch_completed"
+        ]
+        assert len(completed_events) == 1
+        assert completed_events[0][5] is False
+    finally:
+        await producer.stop()
 
 
 @pytest.mark.asyncio
@@ -119,7 +289,7 @@ async def test_metrics_collector_records_buffer_wait():
     add_task = asyncio.create_task(
         accumulator.add_message(tp, None, b"hello", timeout=2)
     )
-    await asyncio.sleep(0)
+    await asyncio.sleep(0.02)
     assert not add_task.done()
 
     accumulator.drain_by_nodes(ignore_nodes=[])
@@ -131,7 +301,42 @@ async def test_metrics_collector_records_buffer_wait():
     assert len(buffer_wait_events) == 1
     assert buffer_wait_events[0][1] == "test-topic"
     assert buffer_wait_events[0][2] == 0
-    assert buffer_wait_events[0][3] >= 0
+    assert buffer_wait_events[0][3] > 0
+
+
+@pytest.mark.asyncio
+async def test_metrics_collector_records_add_batch_buffer_wait():
+    tp = TopicPartition("test-topic", 0)
+    collector = RecordingMetricsCollector()
+    accumulator = MessageAccumulator(
+        make_cluster(),
+        batch_size=1000,
+        compression_type=0,
+        batch_ttl=30,
+        metrics_collector=collector,
+    )
+
+    await accumulator.add_message(tp, None, b"value", timeout=2)
+    add_task = asyncio.create_task(
+        accumulator.add_batch(accumulator.create_builder(), tp, timeout=2)
+    )
+    await asyncio.sleep(0.02)
+    assert not add_task.done()
+
+    batches, _ = accumulator.drain_by_nodes(ignore_nodes=[])
+    batches[0][tp].done_noack()
+    batch_future = await add_task
+
+    batches, _ = accumulator.drain_by_nodes(ignore_nodes=[])
+    assert batches == {}
+    assert await batch_future is None
+
+    buffer_wait_events = [
+        event for event in collector.events if event[0] == "buffer_wait"
+    ]
+    assert len(buffer_wait_events) == 1
+    assert buffer_wait_events[0][1:3] == ("test-topic", 0)
+    assert buffer_wait_events[0][3] > 0
 
 
 @pytest.mark.asyncio
@@ -195,11 +400,15 @@ async def test_metrics_not_reported_after_batch_already_completed():
     batch.failure(RuntimeError("late failure"))
 
     assert await future is None
-    assert [event[0] for event in collector.events] == ["batch_drained"]
+    assert [event[0] for event in collector.events] == [
+        "batch_dispatched",
+        "batch_completed",
+    ]
+    assert collector.events[1][5] is False
 
 
 @pytest.mark.asyncio
-async def test_metrics_not_drained_for_expired_batch_without_leader():
+async def test_metrics_not_dispatched_for_expired_batch_without_leader():
     tp = TopicPartition("test-topic", 0)
     collector = RecordingMetricsCollector()
     accumulator = MessageAccumulator(
@@ -218,11 +427,12 @@ async def test_metrics_not_drained_for_expired_batch_without_leader():
     assert future.done()
     future_exception = future.exception()
     assert isinstance(future_exception, NotLeaderForPartitionError)
-    assert [event[0] for event in collector.events] == ["batch_failure"]
+    assert [event[0] for event in collector.events] == ["batch_failed"]
+    assert collector.events[0][5] >= 0
 
 
 @pytest.mark.asyncio
-async def test_metrics_not_drained_for_empty_batch():
+async def test_metrics_not_dispatched_for_empty_batch():
     tp = TopicPartition("test-topic", 0)
     collector = RecordingMetricsCollector()
     accumulator = MessageAccumulator(
@@ -260,7 +470,10 @@ async def test_metrics_collector_records_batch_failure_before_drain():
 
     with pytest.raises(RuntimeError, match="sender failed"):
         await future
-    assert ("batch_failure", "test-topic", 0, exc, 1) in collector.events
+    failure_events = [event for event in collector.events if event[0] == "batch_failed"]
+    assert len(failure_events) == 1
+    assert failure_events[0][:5] == ("batch_failed", "test-topic", 0, exc, 1)
+    assert failure_events[0][5] >= 0
 
 
 @pytest.mark.asyncio
@@ -284,10 +497,10 @@ async def test_metrics_collector_records_buffer_wait_on_timeout():
     buffer_wait_events = [
         event for event in collector.events if event[0] == "buffer_wait"
     ]
-    assert buffer_wait_events
-    assert all(event[1] == "test-topic" for event in buffer_wait_events)
-    assert all(event[2] == 0 for event in buffer_wait_events)
-    assert all(event[3] >= 0 for event in buffer_wait_events)
+    assert len(buffer_wait_events) == 1
+    assert buffer_wait_events[0][1] == "test-topic"
+    assert buffer_wait_events[0][2] == 0
+    assert buffer_wait_events[0][3] > 0
 
 
 @pytest.mark.asyncio
@@ -312,7 +525,10 @@ async def test_metrics_collector_records_batch_failure():
     future_exception = future.exception()
     assert isinstance(future_exception, RuntimeError)
     assert str(future_exception) == "delivery failed"
-    assert ("batch_failure", "test-topic", 0, exc, 1) in collector.events
+    failure_events = [event for event in collector.events if event[0] == "batch_failed"]
+    assert len(failure_events) == 1
+    assert failure_events[0][:5] == ("batch_failed", "test-topic", 0, exc, 1)
+    assert failure_events[0][5] >= 0
 
 
 @pytest.mark.asyncio
@@ -326,28 +542,41 @@ async def test_producer_passes_metrics_collector_to_accumulator():
         await producer.stop()
 
 
+@pytest.mark.asyncio
+async def test_producer_rejects_invalid_metrics_collector():
+    with pytest.raises(
+        TypeError,
+        match="metrics_collector must be an instance of ProducerMetricsCollector",
+    ):
+        AIOKafkaProducer(metrics_collector=object())
+
+
 def test_null_metrics_collector_is_abc_implementation():
     collector = NullProducerMetricsCollector()
 
     assert isinstance(collector, ProducerMetricsCollector)
-    collector.on_batch_drained(
+    collector.on_batch_dispatched(
         topic="topic",
         partition=0,
         queue_time_seconds=0.1,
         batch_size_bytes=1,
         record_count=1,
+        attempt=1,
     )
-    collector.on_batch_done(
+    collector.on_batch_completed(
         topic="topic",
         partition=0,
-        request_latency_seconds=0.2,
+        send_to_completion_seconds=0.2,
         record_count=1,
+        acknowledged=True,
+        batch_age_seconds=0.3,
     )
-    collector.on_batch_failure(
+    collector.on_batch_failed(
         topic="topic",
         partition=0,
         exception=RuntimeError("boom"),
         record_count=1,
+        batch_age_seconds=0.4,
     )
     collector.on_buffer_wait(topic="topic", partition=0, wait_seconds=0.3)
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -596,3 +596,14 @@ def test_producer_metrics_collector_allows_partial_implementation():
     )
 
     assert collector.completed["topic"] == "topic"
+
+
+def test_producer_metrics_collector_warns_about_unknown_callback():
+    with pytest.warns(
+        UserWarning,
+        match="Unknown producer metrics callbacks.*on_batch_complete",
+    ):
+
+        class TypoMetricsCollector(ProducerMetricsCollector):
+            def on_batch_complete(self, **kwargs):
+                self.completed = kwargs

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,182 @@
+import asyncio
+from unittest import mock
+
+import pytest
+
+from aiokafka import AIOKafkaProducer, NullMetricsCollector, ProducerMetricsCollector
+from aiokafka.cluster import ClusterMetadata
+from aiokafka.errors import KafkaTimeoutError
+from aiokafka.producer.message_accumulator import MessageAccumulator
+from aiokafka.structs import TopicPartition
+
+
+class RecordingMetricsCollector:
+    def __init__(self):
+        self.events = []
+
+    def on_batch_drained(
+        self, topic, queue_time_seconds, batch_size_bytes, record_count
+    ):
+        self.events.append(
+            (
+                "batch_drained",
+                topic,
+                queue_time_seconds,
+                batch_size_bytes,
+                record_count,
+            )
+        )
+
+    def on_batch_done(self, topic, request_latency_seconds, record_count):
+        self.events.append(("batch_done", topic, request_latency_seconds, record_count))
+
+    def on_batch_failure(self, topic, exception, record_count):
+        self.events.append(("batch_failure", topic, exception, record_count))
+
+    def on_buffer_wait(self, topic, wait_seconds):
+        self.events.append(("buffer_wait", topic, wait_seconds))
+
+
+def make_cluster():
+    cluster = ClusterMetadata(metadata_max_age_ms=10000)
+    cluster.leader_for_partition = mock.Mock(return_value=0)
+    return cluster
+
+
+@pytest.mark.asyncio
+async def test_metrics_collector_records_batch_lifecycle():
+    tp = TopicPartition("test-topic", 0)
+    collector = RecordingMetricsCollector()
+    clock = [10.0]
+
+    with mock.patch(
+        "aiokafka.producer.message_accumulator.time.monotonic",
+        side_effect=lambda: clock[0],
+    ):
+        accumulator = MessageAccumulator(
+            make_cluster(),
+            batch_size=1000,
+            compression_type=0,
+            batch_ttl=30,
+            metrics_collector=collector,
+        )
+
+        future = await accumulator.add_message(
+            tp, b"key", b"value", timeout=2, timestamp_ms=1
+        )
+        clock[0] = 10.75
+        batches, unknown_leaders_exist = accumulator.drain_by_nodes(ignore_nodes=[])
+        assert not unknown_leaders_exist
+
+        batch = batches[0][tp]
+        clock[0] = 11.0
+        batch.done(base_offset=10)
+
+    metadata = await future
+    assert metadata.topic == "test-topic"
+    assert collector.events[0][:3] == ("batch_drained", "test-topic", 0.75)
+    assert collector.events[0][3] > 0
+    assert collector.events[0][4] == 1
+    assert collector.events[1] == ("batch_done", "test-topic", 0.25, 1)
+
+
+@pytest.mark.asyncio
+async def test_metrics_collector_records_buffer_wait():
+    tp = TopicPartition("test-topic", 0)
+    collector = RecordingMetricsCollector()
+    accumulator = MessageAccumulator(
+        make_cluster(),
+        batch_size=90,
+        compression_type=0,
+        batch_ttl=30,
+        metrics_collector=collector,
+    )
+
+    await accumulator.add_message(tp, None, b"hello", timeout=2)
+    await accumulator.add_message(tp, None, b"hello", timeout=2)
+
+    add_task = asyncio.create_task(
+        accumulator.add_message(tp, None, b"hello", timeout=2)
+    )
+    await asyncio.sleep(0)
+    assert not add_task.done()
+
+    accumulator.drain_by_nodes(ignore_nodes=[])
+    await add_task
+
+    buffer_wait_events = [
+        event for event in collector.events if event[0] == "buffer_wait"
+    ]
+    assert len(buffer_wait_events) == 1
+    assert buffer_wait_events[0][1] == "test-topic"
+    assert buffer_wait_events[0][2] >= 0
+
+
+@pytest.mark.asyncio
+async def test_metrics_collector_records_buffer_wait_on_timeout():
+    tp = TopicPartition("test-topic", 0)
+    collector = RecordingMetricsCollector()
+    accumulator = MessageAccumulator(
+        make_cluster(),
+        batch_size=90,
+        compression_type=0,
+        batch_ttl=30,
+        metrics_collector=collector,
+    )
+
+    await accumulator.add_message(tp, None, b"hello", timeout=2)
+    await accumulator.add_message(tp, None, b"hello", timeout=2)
+
+    with pytest.raises(KafkaTimeoutError):
+        await accumulator.add_message(tp, None, b"hello", timeout=0.001)
+
+    buffer_wait_events = [
+        event for event in collector.events if event[0] == "buffer_wait"
+    ]
+    assert len(buffer_wait_events) == 1
+    assert buffer_wait_events[0][1] == "test-topic"
+    assert buffer_wait_events[0][2] >= 0
+
+
+@pytest.mark.asyncio
+async def test_metrics_collector_records_batch_failure():
+    tp = TopicPartition("test-topic", 0)
+    collector = RecordingMetricsCollector()
+    accumulator = MessageAccumulator(
+        make_cluster(),
+        batch_size=1000,
+        compression_type=0,
+        batch_ttl=30,
+        metrics_collector=collector,
+    )
+
+    future = await accumulator.add_message(tp, None, b"value", timeout=2)
+    batches, _ = accumulator.drain_by_nodes(ignore_nodes=[])
+
+    exc = RuntimeError("delivery failed")
+    batches[0][tp].failure(exc)
+
+    with pytest.raises(RuntimeError, match="delivery failed"):
+        await future
+    assert ("batch_failure", "test-topic", exc, 1) in collector.events
+
+
+@pytest.mark.asyncio
+async def test_producer_passes_metrics_collector_to_accumulator():
+    collector = RecordingMetricsCollector()
+    producer = AIOKafkaProducer(metrics_collector=collector)
+    try:
+        assert producer._metrics_collector is collector
+        assert producer._message_accumulator._metrics_collector is collector
+    finally:
+        await producer.stop()
+
+
+def test_null_metrics_collector_is_protocol_implementation():
+    collector = NullMetricsCollector()
+
+    assert isinstance(collector, ProducerMetricsCollector)
+    collector.on_batch_drained("topic", 0.1, 1, 1)
+    collector.on_batch_done("topic", 0.2, 1)
+    collector.on_batch_failure("topic", RuntimeError("boom"), 1)
+    collector.on_buffer_wait("topic", 0.3)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -252,8 +252,10 @@ async def test_metrics_collector_records_batch_failure():
     exc = RuntimeError("delivery failed")
     batches[0][tp].failure(exc)
 
-    with pytest.raises(RuntimeError, match="delivery failed"):
-        await future
+    assert future.done()
+    future_exception = future.exception()
+    assert isinstance(future_exception, RuntimeError)
+    assert str(future_exception) == "delivery failed"
     assert ("batch_failure", "test-topic", exc, 1) in collector.events
 
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -6,7 +6,6 @@ import pytest
 
 from aiokafka import (
     AIOKafkaProducer,
-    NullProducerMetricsCollector,
     ProducerMetricsCollector,
 )
 from aiokafka.cluster import ClusterMetadata
@@ -340,7 +339,7 @@ async def test_metrics_collector_records_add_batch_buffer_wait():
 
 
 @pytest.mark.asyncio
-async def test_message_accumulator_uses_null_metrics_collector_by_default():
+async def test_message_accumulator_uses_metrics_collector_by_default():
     accumulator = MessageAccumulator(
         make_cluster(),
         batch_size=1000,
@@ -348,7 +347,7 @@ async def test_message_accumulator_uses_null_metrics_collector_by_default():
         batch_ttl=30,
     )
 
-    assert isinstance(accumulator._metrics_collector, NullProducerMetricsCollector)
+    assert type(accumulator._metrics_collector) is ProducerMetricsCollector
 
 
 @pytest.mark.asyncio
@@ -551,10 +550,9 @@ async def test_producer_rejects_invalid_metrics_collector():
         AIOKafkaProducer(metrics_collector=object())
 
 
-def test_null_metrics_collector_is_abc_implementation():
-    collector = NullProducerMetricsCollector()
+def test_producer_metrics_collector_has_noop_defaults():
+    collector = ProducerMetricsCollector()
 
-    assert isinstance(collector, ProducerMetricsCollector)
     collector.on_batch_dispatched(
         topic="topic",
         partition=0,
@@ -581,6 +579,20 @@ def test_null_metrics_collector_is_abc_implementation():
     collector.on_buffer_wait(topic="topic", partition=0, wait_seconds=0.3)
 
 
-def test_producer_metrics_collector_is_abstract():
-    with pytest.raises(TypeError, match="abstract class"):
-        ProducerMetricsCollector()
+def test_producer_metrics_collector_allows_partial_implementation():
+    class CompletionMetricsCollector(ProducerMetricsCollector):
+        def on_batch_completed(self, **kwargs):
+            self.completed = kwargs
+
+    collector = CompletionMetricsCollector()
+    collector.on_buffer_wait(topic="topic", partition=0, wait_seconds=0.1)
+    collector.on_batch_completed(
+        topic="topic",
+        partition=0,
+        send_to_completion_seconds=0.2,
+        record_count=1,
+        acknowledged=True,
+        batch_age_seconds=0.3,
+    )
+
+    assert collector.completed["topic"] == "topic"


### PR DESCRIPTION
### Changes

Fixes #1166

Adds the callback-based producer metrics collector proposed in #1166.

Summary:
- adds `ProducerMetricsCollector` and `NullMetricsCollector`
- wires batch drain, acknowledgment, failure, and buffer wait callbacks
- documents `metrics_collector` with a Prometheus example

### Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add a changelog/news entry
  * Added under `0.15.0` in `CHANGES.rst`; this checkout does not currently have a `CHANGES/` fragment directory.

### Tests

- `python -m ruff format --check aiokafka tests setup.py`
- `python -m ruff check aiokafka tests setup.py`
- `python -m pytest tests/test_metrics.py tests/test_message_accumulator.py`
- `python -m sphinx -E -b html docs docs/_build/html`
