### PR TITLE
Add Windows ARM64 build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,6 +48,8 @@ jobs:
             arch: arm64
           - os: windows-latest
             arch: amd64
+          - os: windows-11-arm
+            arch: arm64
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -61,7 +63,8 @@ jobs:
         env:
           CIBW_ARCHS_LINUX: ${{matrix.arch}}
           CIBW_BUILD: cp310-* cp311-* cp312-* cp313-* cp314-*
-          CIBW_SKIP: '*-musllinux*'
+          # CPython 3.10 has no official Windows arm64 distribution
+          CIBW_SKIP: '*-musllinux* cp310-win_arm64'
           CIBW_BEFORE_BUILD_LINUX: pip install -r requirements-cython.txt && yum install -y zlib-devel
           # On windows and mac we should have z library preinstalled
           CIBW_BEFORE_BUILD: pip install -r requirements-cython.txt
@@ -102,6 +105,49 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: dist-windows-latest-amd64
+          path: dist/
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Install python dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools
+          python -m pip install -r requirements-win-test.txt
+          python -m pip install ${{ matrix.aiokafka_whl }}
+        shell: bash
+
+      - name: Run Unit Tests
+        run: |
+          # Remove source code to be sure we use wheel code
+          rm -rf aiokafka
+          make ci-test-unit
+        shell: bash
+
+  test-wheels-arm64-windows:
+    needs: [package-source, package-wheel]
+    runs-on: windows-11-arm
+
+    strategy:
+      matrix:
+        python: ["3.11", "3.12", "3.13", "3.14"]
+        include:
+          - python: "3.11"
+            aiokafka_whl: dist/aiokafka-*-cp311-cp311-win_arm64.whl
+          - python: "3.12"
+            aiokafka_whl: dist/aiokafka-*-cp312-cp312-win_arm64.whl
+          - python: "3.13"
+            aiokafka_whl: dist/aiokafka-*-cp313-cp313-win_arm64.whl
+          - python: "3.14"
+            aiokafka_whl: dist/aiokafka-*-cp314-cp314-win_arm64.whl
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: dist-windows-11-arm-arm64
           path: dist/
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -311,6 +357,7 @@ jobs:
       - test-wheels-mac
       - test-wheels-arm64-mac
       - test-wheels-windows
+      - test-wheels-arm64-windows
 
     permissions:
       id-token: write  # IMPORTANT: mandatory for trusted publishing


### PR DESCRIPTION
### Changes

As the title says -- I structured the changes to be like how the publish workflow is written currently. The builds work fine and `make ci-unit-test` passes.

A couple of notes:
- The Linux aarch64 builds are currently done in QEMU on an x86-64 Linux runner. We can instead use a native runner (like `ubuntu-24.04-arm` or `ubuntu-22.04-arm`) to speed that up significantly.
- The whole workflow can be restructured with matrices to reduce the almost-identical copies of jobs that we have for each platform and architecture. Additionally we can just use cibuildwheel to run the tests, it sets up the environment automatically with the required Python version and newly-built wheel installed, etc.

Let me know if you would like me to add those changes as well here.

### Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
