### PR TITLE
Update & pin github actions in CI

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,11 +27,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -45,7 +45,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -58,6 +58,6 @@ jobs:
     #   ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,13 +27,13 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       with:
         persist-credentials: false
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -47,7 +47,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v4
+      uses: github/codeql-action/autobuild@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -60,6 +60,6 @@ jobs:
     #   ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ 'master' ]
+  workflow_dispatch: {}
   schedule:
     - cron: '36 22 * * 0'
 
@@ -14,7 +15,6 @@ jobs:
     name: Analyze
     runs-on: ubuntu-latest
     permissions:
-      actions: read
       contents: read
       security-events: write
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -309,20 +309,18 @@ jobs:
   test-wheels-aarch64-linux:
     needs: [package-source, package-wheel]
     runs-on: ubuntu-24.04-arm
-    env:
-      py: /opt/python/${{ matrix.pyver }}/bin/python
-      img: quay.io/pypa/manylinux2014_aarch64
 
     strategy:
       matrix:
+        python: ["3.11", "3.12", "3.13", "3.14"]
         include:
-          - pyver: cp311-cp311
+          - python: "3.11"
             aiokafka_whl: dist/aiokafka-*-cp311-cp311-manylinux*_aarch64.whl
-          - pyver: cp312-cp312
+          - python: "3.12"
             aiokafka_whl: dist/aiokafka-*-cp312-cp312-manylinux*_aarch64.whl
-          - pyver: cp313-cp313
+          - python: "3.13"
             aiokafka_whl: dist/aiokafka-*-cp313-cp313-manylinux*_aarch64.whl
-          - pyver: cp314-cp314
+          - python: "3.14"
             aiokafka_whl: dist/aiokafka-*-cp314-cp314-manylinux*_aarch64.whl
 
     steps:
@@ -334,21 +332,26 @@ jobs:
         with:
           name: dist-ubuntu-24.04-arm-aarch64
           path: dist/
-      - name: Test Wheel
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Install system dependencies
         run: |
-              docker run --rm -v ${{ github.workspace }}:/ws:rw --workdir=/ws \
-              ${{ env.img }} \
-              bash -exc '${{ env.py }} -m venv .env && \
-              source .env/bin/activate && \
-              yum install -y epel-release && \
-              yum-config-manager --enable epel && \
-              yum install -y krb5-devel && \
-              pip install --upgrade pip setuptools && \
-              pip install -r requirements-ci.txt && \
-              pip install ${{ matrix.aiokafka_whl }} && \
-              rm -rf aiokafka && \
-              make ci-test-unit && \
-              deactivate'
+          sudo apt-get update
+          sudo apt-get install -y libkrb5-dev
+      - name: Install python dependencies
+        run: |
+          pip install --upgrade pip setuptools
+          pip install -r requirements-ci.txt
+          pip install ${{ matrix.aiokafka_whl }}
+
+      - name: Run Unit Tests
+        run: |
+          # Remove source code to be sure we use wheel code
+          rm -rf aiokafka
+          make ci-test-unit
 
   deploy:
     if: ${{ github.event_name == 'release' }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,9 @@ on:
     types: [created]
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 jobs:
   package-source:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,10 +15,10 @@ jobs:
   package-source:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           persist-credentials: false
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.11"
       - name: Prepare C files to include
@@ -30,7 +30,7 @@ jobs:
       - name: Build source package
         run: python -m build --sdist
       - name: Upload source package
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dist-source
           path: dist/
@@ -56,10 +56,10 @@ jobs:
           - os: windows-11-arm
             arch: arm64
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           persist-credentials: false
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           # cibuildwheel requires 3.11+
           python-version: "3.11"
@@ -78,7 +78,7 @@ jobs:
           cibuildwheel --output-dir dist
         shell: bash
       - name: Upload wheels
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dist-${{ matrix.os }}-${{ matrix.arch }}
           path: dist/
@@ -101,16 +101,16 @@ jobs:
             aiokafka_whl: dist/aiokafka-*-cp314-cp314-win_amd64.whl
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           persist-credentials: false
       - name: Download distributions
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dist-windows-latest-amd64
           path: dist/
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ matrix.python }}
 
@@ -146,16 +146,16 @@ jobs:
             aiokafka_whl: dist/aiokafka-*-cp314-cp314-win_arm64.whl
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           persist-credentials: false
       - name: Download distributions
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dist-windows-11-arm-arm64
           path: dist/
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ matrix.python }}
 
@@ -191,16 +191,16 @@ jobs:
             aiokafka_whl: dist/aiokafka-*-cp314-cp314-macosx_*_x86_64.whl
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           persist-credentials: false
       - name: Download distributions
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dist-macos-15-intel-x86_64
           path: dist/
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ matrix.python }}
 
@@ -234,16 +234,16 @@ jobs:
             aiokafka_whl: dist/aiokafka-*-cp314-cp314-macosx_*_arm64.whl
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           persist-credentials: false
       - name: Download distributions
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dist-macos-latest-arm64
           path: dist/
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ matrix.python }}
 
@@ -277,16 +277,16 @@ jobs:
             aiokafka_whl: dist/aiokafka-*-cp314-cp314-manylinux*_x86_64.whl
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           persist-credentials: false
       - name: Download distributions
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dist-ubuntu-latest-x86_64
           path: dist/
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ matrix.python }}
 
@@ -324,16 +324,16 @@ jobs:
             aiokafka_whl: dist/aiokafka-*-cp314-cp314-manylinux*_aarch64.whl
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           persist-credentials: false
       - name: Download distributions
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dist-ubuntu-24.04-arm-aarch64
           path: dist/
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ matrix.python }}
 
@@ -374,10 +374,10 @@ jobs:
 
     steps:
       - name: Download distributions
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: dist/
           pattern: dist-*
           merge-multiple: true
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
@@ -55,6 +57,8 @@ jobs:
             arch: arm64
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v6
         with:
           # cibuildwheel requires 3.11+
@@ -98,6 +102,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Download distributions
         uses: actions/download-artifact@v8
         with:
@@ -141,6 +147,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Download distributions
         uses: actions/download-artifact@v8
         with:
@@ -184,6 +192,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Download distributions
         uses: actions/download-artifact@v8
         with:
@@ -225,6 +235,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Download distributions
         uses: actions/download-artifact@v8
         with:
@@ -266,6 +278,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Download distributions
         uses: actions/download-artifact@v8
         with:
@@ -313,6 +327,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Download distributions
         uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -351,7 +351,6 @@ jobs:
         https://pypi.org/project/aiokafka/${{ github.ref_name }}
 
     steps:
-      - uses: actions/checkout@v6
       - name: Download distributions
         uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,8 +12,8 @@ jobs:
   package-source:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Prepare C files to include
@@ -25,7 +25,7 @@ jobs:
       - name: Build source package
         run: python -m build --sdist
       - name: Upload source package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist-source
           path: dist/
@@ -51,8 +51,8 @@ jobs:
           - os: windows-11-arm
             arch: arm64
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           # cibuildwheel requires 3.11+
           python-version: "3.11"
@@ -71,7 +71,7 @@ jobs:
           cibuildwheel --output-dir dist
         shell: bash
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist-${{ matrix.os }}-${{ matrix.arch }}
           path: dist/
@@ -94,14 +94,14 @@ jobs:
             aiokafka_whl: dist/aiokafka-*-cp314-cp314-win_amd64.whl
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist-windows-latest-amd64
           path: dist/
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
 
@@ -137,14 +137,14 @@ jobs:
             aiokafka_whl: dist/aiokafka-*-cp314-cp314-win_arm64.whl
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist-windows-11-arm-arm64
           path: dist/
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
 
@@ -180,14 +180,14 @@ jobs:
             aiokafka_whl: dist/aiokafka-*-cp314-cp314-macosx_*_x86_64.whl
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist-macos-15-intel-x86_64
           path: dist/
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
 
@@ -221,14 +221,14 @@ jobs:
             aiokafka_whl: dist/aiokafka-*-cp314-cp314-macosx_*_arm64.whl
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist-macos-latest-arm64
           path: dist/
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
 
@@ -262,14 +262,14 @@ jobs:
             aiokafka_whl: dist/aiokafka-*-cp314-cp314-manylinux*_x86_64.whl
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist-ubuntu-latest-x86_64
           path: dist/
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
 
@@ -309,9 +309,9 @@ jobs:
             aiokafka_whl: dist/aiokafka-*-cp314-cp314-manylinux*_aarch64.whl
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist-ubuntu-24.04-arm-aarch64
           path: dist/
@@ -351,9 +351,9 @@ jobs:
         https://pypi.org/project/aiokafka/${{ github.ref_name }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: dist/
           pattern: dist-*

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: "3.11"
-        cache: pip
+        cache: pip  # zizmor: ignore[cache-poisoning]
         cache-dependency-path: |
           requirements-ci.txt
           requirements-docs.txt
@@ -79,7 +79,7 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python }}
-        cache: pip
+        cache: pip  # zizmor: ignore[cache-poisoning]
         cache-dependency-path: |
           requirements-win-test.txt
           setup.py
@@ -137,7 +137,7 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python }}
-        cache: pip
+        cache: pip  # zizmor: ignore[cache-poisoning]
         cache-dependency-path: |
           requirements-ci.txt
           setup.py
@@ -232,7 +232,7 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python }}
-        cache: pip
+        cache: pip  # zizmor: ignore[cache-poisoning]
         cache-dependency-path: |
           requirements-ci.txt
           setup.py

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -122,7 +122,7 @@ jobs:
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v7
       with:
-        file: ./coverage-ext.xml
+        files: ./coverage-ext.xml
         flags: unit,cext
         name: test-windows-${{ matrix.python }}-ext
       if: ${{ always() }}
@@ -130,7 +130,7 @@ jobs:
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v7
       with:
-        file: ./coverage-py.xml
+        files: ./coverage-py.xml
         flags: unit,purepy
         name: test-windows-${{ matrix.python }}-py
       if: ${{ always() }}
@@ -190,7 +190,7 @@ jobs:
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v7
       with:
-        file: ./coverage-ext.xml
+        files: ./coverage-ext.xml
         flags: unit,cext
         name: test-mac-${{ matrix.python }}-ext
       if: ${{ always() }}
@@ -198,7 +198,7 @@ jobs:
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v7
       with:
-        file: ./coverage-py.xml
+        files: ./coverage-py.xml
         flags: unit,purepy
         name: test-mac-${{ matrix.python }}-py
       if: ${{ always() }}
@@ -303,7 +303,7 @@ jobs:
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v7
       with:
-        file: ./coverage-ext.xml
+        files: ./coverage-ext.xml
         flags: integration,cext
         name: test-linux-${{ matrix.python }}-${{ matrix.kafka }}-${{ matrix.scala }}-ext
       if: ${{ always() }}
@@ -311,7 +311,7 @@ jobs:
     - name: Upload coverage without cext to Codecov
       uses: codecov/codecov-action@v7
       with:
-        file: ./coverage-py.xml
+        files: ./coverage-py.xml
         flags: integration,purepy
         name: test-linux-${{ matrix.python }}-${{ matrix.kafka }}-${{ matrix.scala }}-py
       if: ${{ always() }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,11 +21,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       with:
         persist-credentials: false
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: "3.11"
         cache: pip  # zizmor: ignore[cache-poisoning]
@@ -71,12 +71,12 @@ jobs:
         python: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         persist-credentials: false
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: ${{ matrix.python }}
         cache: pip  # zizmor: ignore[cache-poisoning]
@@ -105,7 +105,7 @@ jobs:
         AIOKAFKA_NO_EXTENSIONS: "1"
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v7
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         files: ./coverage-ext.xml
         flags: unit,cext
@@ -113,7 +113,7 @@ jobs:
       if: ${{ always() }}
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v7
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         files: ./coverage-py.xml
         flags: unit,purepy
@@ -129,12 +129,12 @@ jobs:
         python: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         persist-credentials: false
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: ${{ matrix.python }}
         cache: pip  # zizmor: ignore[cache-poisoning]
@@ -163,7 +163,7 @@ jobs:
         AIOKAFKA_NO_EXTENSIONS: "1"
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v7
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         files: ./coverage-ext.xml
         flags: unit,cext
@@ -171,7 +171,7 @@ jobs:
       if: ${{ always() }}
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v7
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         files: ./coverage-py.xml
         flags: unit,purepy
@@ -224,12 +224,12 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         persist-credentials: false
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: ${{ matrix.python }}
         cache: pip  # zizmor: ignore[cache-poisoning]
@@ -266,7 +266,7 @@ jobs:
         KAFKA_VERSION: ${{ matrix.kafka }}
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v7
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         files: ./coverage-ext.xml
         flags: integration,cext
@@ -274,7 +274,7 @@ jobs:
       if: ${{ always() }}
 
     - name: Upload coverage without cext to Codecov
-      uses: codecov/codecov-action@v7
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         files: ./coverage-py.xml
         flags: integration,purepy

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,9 +18,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.11"
 
@@ -36,7 +36,7 @@ jobs:
         echo "::set-output name=dir::$(pip cache dir)"
 
     - name: Cache packages
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{ steps.pip-cache.outputs.dir }}
         key: ${{ runner.os }}-py-3.11-${{ hashFiles('requirements-ci.txt') }}-${{ hashFiles('setup.py') }}
@@ -76,11 +76,11 @@ jobs:
         python: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         ref: ${{ github.event.pull_request.head.sha }}
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python }}
 
@@ -91,7 +91,7 @@ jobs:
         echo "::set-output name=dir::$(pip cache dir)"
 
     - name: Cache packages
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{ steps.pip-cache.outputs.dir }}
         key: ${{ runner.os }}-py-${{ matrix.python }}-${{ hashFiles('requirements-win-test.txt') }}-${{ hashFiles('setup.py') }}
@@ -120,7 +120,7 @@ jobs:
         AIOKAFKA_NO_EXTENSIONS: "1"
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v7
       with:
         file: ./coverage-ext.xml
         flags: unit,cext
@@ -128,7 +128,7 @@ jobs:
       if: ${{ always() }}
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v7
       with:
         file: ./coverage-py.xml
         flags: unit,purepy
@@ -144,11 +144,11 @@ jobs:
         python: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         ref: ${{ github.event.pull_request.head.sha }}
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python }}
 
@@ -159,7 +159,7 @@ jobs:
         echo "::set-output name=dir::$(pip cache dir)"
 
     - name: Cache packages
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{ steps.pip-cache.outputs.dir }}
         key: ${{ runner.os }}-py-${{ matrix.python }}-${{ hashFiles('requirements-ci.txt') }}-${{ hashFiles('setup.py') }}
@@ -188,7 +188,7 @@ jobs:
         AIOKAFKA_NO_EXTENSIONS: "1"
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v7
       with:
         file: ./coverage-ext.xml
         flags: unit,cext
@@ -196,7 +196,7 @@ jobs:
       if: ${{ always() }}
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v7
       with:
         file: ./coverage-py.xml
         flags: unit,purepy
@@ -249,11 +249,11 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         ref: ${{ github.event.pull_request.head.sha }}
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python }}
 
@@ -269,7 +269,7 @@ jobs:
         echo "::set-output name=dir::$(pip cache dir)"
 
     - name: Cache packages
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{ steps.pip-cache.outputs.dir }}
         key: ${{ runner.os }}-py-${{ matrix.python }}-${{ hashFiles('requirements-ci.txt') }}-${{ hashFiles('setup.py') }}
@@ -301,7 +301,7 @@ jobs:
         KAFKA_VERSION: ${{ matrix.kafka }}
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v7
       with:
         file: ./coverage-ext.xml
         flags: integration,cext
@@ -309,7 +309,7 @@ jobs:
       if: ${{ always() }}
 
     - name: Upload coverage without cext to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v7
       with:
         file: ./coverage-py.xml
         flags: integration,purepy

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   test-sanity:
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
@@ -36,7 +38,7 @@ jobs:
       id: pip-cache
       run: |
         python -m pip install -U "pip>=20.1"
-        echo "::set-output name=dir::$(pip cache dir)"
+        echo "dir=$(pip cache dir)" >> "$GITHUB_OUTPUT"
 
     - name: Cache packages
       uses: actions/cache@v5
@@ -82,6 +84,7 @@ jobs:
     - uses: actions/checkout@v6
       with:
         ref: ${{ github.event.pull_request.head.sha }}
+        persist-credentials: false
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
@@ -91,7 +94,7 @@ jobs:
       id: pip-cache
       run: |
         python -m pip install -U "pip>=20.1"
-        echo "::set-output name=dir::$(pip cache dir)"
+        "dir=$(pip cache dir)" >> $env:GITHUB_OUTPUT
 
     - name: Cache packages
       uses: actions/cache@v5
@@ -150,6 +153,7 @@ jobs:
     - uses: actions/checkout@v6
       with:
         ref: ${{ github.event.pull_request.head.sha }}
+        persist-credentials: false
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
@@ -159,7 +163,7 @@ jobs:
       id: pip-cache
       run: |
         python -m pip install -U "pip>=20.1"
-        echo "::set-output name=dir::$(pip cache dir)"
+        echo "dir=$(pip cache dir)" >> "$GITHUB_OUTPUT"
 
     - name: Cache packages
       uses: actions/cache@v5
@@ -255,6 +259,7 @@ jobs:
     - uses: actions/checkout@v6
       with:
         ref: ${{ github.event.pull_request.head.sha }}
+        persist-credentials: false
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
@@ -269,7 +274,7 @@ jobs:
       id: pip-cache
       run: |
         python -m pip install -U "pip>=20.1"
-        echo "::set-output name=dir::$(pip cache dir)"
+        echo "dir=$(pip cache dir)" >> "$GITHUB_OUTPUT"
 
     - name: Cache packages
       uses: actions/cache@v5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,26 +28,16 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: "3.11"
+        cache: pip
+        cache-dependency-path: |
+          requirements-ci.txt
+          requirements-docs.txt
+          setup.py
 
     - name: Install system dependencies
       run: |
         sudo apt-get update
         sudo apt-get install -y libkrb5-dev
-
-    - name: Get pip cache dir
-      id: pip-cache
-      run: |
-        python -m pip install -U "pip>=20.1"
-        echo "dir=$(pip cache dir)" >> "$GITHUB_OUTPUT"
-
-    - name: Cache packages
-      uses: actions/cache@v5
-      with:
-        path: ${{ steps.pip-cache.outputs.dir }}
-        key: ${{ runner.os }}-py-3.11-${{ hashFiles('requirements-ci.txt') }}-${{ hashFiles('setup.py') }}
-        # If miss on key takes any other cache with different hashes, will download correct ones on next step anyway
-        restore-keys: |
-          ${{ runner.os }}-py-3.11-
 
     - name: Install python dependencies
       run: |
@@ -89,21 +79,10 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python }}
-
-    - name: Get pip cache dir
-      id: pip-cache
-      run: |
-        python -m pip install -U "pip>=20.1"
-        "dir=$(pip cache dir)" >> $env:GITHUB_OUTPUT
-
-    - name: Cache packages
-      uses: actions/cache@v5
-      with:
-        path: ${{ steps.pip-cache.outputs.dir }}
-        key: ${{ runner.os }}-py-${{ matrix.python }}-${{ hashFiles('requirements-win-test.txt') }}-${{ hashFiles('setup.py') }}
-        # If miss on key takes any other cache with different hashes, will download correct ones on next step anyway
-        restore-keys: |
-         ${{ runner.os }}-py-${{ matrix.python }}-
+        cache: pip
+        cache-dependency-path: |
+          requirements-win-test.txt
+          setup.py
 
     - name: Install python dependencies
       run: |
@@ -158,21 +137,10 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python }}
-
-    - name: Get pip cache dir
-      id: pip-cache
-      run: |
-        python -m pip install -U "pip>=20.1"
-        echo "dir=$(pip cache dir)" >> "$GITHUB_OUTPUT"
-
-    - name: Cache packages
-      uses: actions/cache@v5
-      with:
-        path: ${{ steps.pip-cache.outputs.dir }}
-        key: ${{ runner.os }}-py-${{ matrix.python }}-${{ hashFiles('requirements-ci.txt') }}-${{ hashFiles('setup.py') }}
-        # If miss on key takes any other cache with different hashes, will download correct ones on next step anyway
-        restore-keys: |
-         ${{ runner.os }}-py-${{ matrix.python }}-
+        cache: pip
+        cache-dependency-path: |
+          requirements-ci.txt
+          setup.py
 
     - name: Install python dependencies
       run: |
@@ -264,26 +232,15 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python }}
+        cache: pip
+        cache-dependency-path: |
+          requirements-ci.txt
+          setup.py
 
     - name: Install system dependencies
       run: |
         sudo apt-get update
         sudo apt-get install -y libkrb5-dev krb5-user
-
-    - name: Get pip cache dir
-      id: pip-cache
-      run: |
-        python -m pip install -U "pip>=20.1"
-        echo "dir=$(pip cache dir)" >> "$GITHUB_OUTPUT"
-
-    - name: Cache packages
-      uses: actions/cache@v5
-      with:
-        path: ${{ steps.pip-cache.outputs.dir }}
-        key: ${{ runner.os }}-py-${{ matrix.python }}-${{ hashFiles('requirements-ci.txt') }}-${{ hashFiles('setup.py') }}
-        # If miss on key takes any other cache with different hashes, will download correct ones on next step anyway
-        restore-keys: |
-         ${{ runner.os }}-py-${{ matrix.python }}-
 
     - name: Install python dependencies
       run: |

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ lint:
 	ruff format --check aiokafka tests setup.py
 	ruff check aiokafka tests setup.py
 	mypy --install-types --non-interactive $(FORMATTED_AREAS)
+	zizmor .github/workflows
 
 .PHONY: test
 test: lint

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ lint:
 	ruff format --check aiokafka tests setup.py
 	ruff check aiokafka tests setup.py
 	mypy --install-types --non-interactive $(FORMATTED_AREAS)
-	zizmor .github/workflows
+	zizmor --pedantic .github/workflows
 
 .PHONY: test
 test: lint

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,6 +1,7 @@
 -r requirements-cython.txt
 ruff==0.16.6
 mypy==1.19.0
+zizmor==0.10.0
 pytest==9.0.2
 pytest-cov==7.0.0
 pytest-asyncio==1.3.0


### PR DESCRIPTION
### Changes

- Update and pin action versions
- Minimal permissions
- `persist-credentials: false`
- Use native caching in setup-python
- Add zizmor to linting

